### PR TITLE
Stripe account creation button takes user email from their account instead of a one-time save

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -44,8 +44,6 @@ import SettingsGuestDashboard from "./components/guestdashboard/SettingsGuestDas
 import FlowContext from './FlowContext'
 import ReviewsGuestDashboard from "./components/guestdashboard/ReviewsGuestDashboard";
 
-export const stripe = new Stripe(process.env.STRIPE_TEST_KEY);
-
 // Set the app element for react-modal
 Modal.setAppElement('#root'); // Assuming your root element has the id 'root'
 

--- a/web/src/components/hostdashboard/Pages.js
+++ b/web/src/components/hostdashboard/Pages.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import dashboard from "../../images/icons/dashboard-icon.png";
 import message from "../../images/icons/message-icon.png";
 import payment from "../../images/icons/payment-icon.png";
@@ -7,42 +7,63 @@ import calendar from "../../images/icons/calendar-icon.png";
 import settings from "../../images/icons/settings-icon.png";
 import stripe from "../../images/icons/stripe-icon.png";
 import { useNavigate } from 'react-router-dom';
-import { useAuth} from "../base/AuthContext"
+import { Auth } from "aws-amplify";
+import { useAuth } from "../base/AuthContext"
 import './HostHomepage.css';
 
 function Pages() {
+  const [userEmail, setUserEmail] = useState(null);
+
+  useEffect(() => {
+    const setUserEmailAsync = async () => {
+      try {
+        const userInfo = await Auth.currentUserInfo();
+        console.log(userInfo);
+
+        setUserEmail(userInfo.attributes.email);
+
+      } catch (error) {
+        console.error("Error setting user id:", error);
+      }
+    };
+
+    // Call the async function
+    setUserEmailAsync();
+  }, []);
+
+
 
   const navigate = useNavigate();
 
-  const userEmail = sessionStorage.getItem('userEmail');
+  // const userEmail = sessionStorage.getItem('userEmail');
 
   async function createStripeAccount() {
     if (!userEmail) {
       console.error('User email is not defined.');
       return;
-  }
+    }
 
-  const options = {
+    const options = {
       userEmail: userEmail
-  };
-  
+    };
+
     try {
-        const result = await fetch('https://zuak8serw5.execute-api.eu-north-1.amazonaws.com/dev/CreateStripeAccount', {
-            method: 'POST',
-            body: JSON.stringify(options),
-            headers: {
-                'Content-type': 'application/json; charset=UTF-8',
-            },
-        });
-  
-        if (!result.ok) {
-            throw new Error(`HTTP error! Status: ${result.status}`);
-        }
-  
-        const data = await result.json();
-        window.location.replace(data.url);
+      const result = await fetch('https://zuak8serw5.execute-api.eu-north-1.amazonaws.com/dev/CreateStripeAccount', {
+        method: 'POST',
+        body: JSON.stringify(options),
+        headers: {
+          'Content-type': 'application/json; charset=UTF-8',
+        },
+      });
+
+      if (!result.ok) {
+        throw new Error(`HTTP error! Status: ${result.status}`);
+      }
+
+      const data = await result.json();
+      window.location.replace(data.url);
     } catch (error) {
-        console.log(error);
+      console.log(error);
     }
   }
 
@@ -74,7 +95,7 @@ function Pages() {
       </div>
       <div className="wijzer-grn" onClick={() => createStripeAccount()}>
         <div className="stripe-icon-div">
-        <img src={stripe} className="stripe-icon" alt="Stripe"></img>
+          <img src={stripe} className="stripe-icon" alt="Stripe"></img>
         </div>
         <p className="stripe-btn">Create Stripe Account</p>
       </div>

--- a/web/src/components/hostdashboard/Pages.js
+++ b/web/src/components/hostdashboard/Pages.js
@@ -26,16 +26,10 @@ function Pages() {
         console.error("Error setting user id:", error);
       }
     };
-
-    // Call the async function
     setUserEmailAsync();
   }, []);
 
-
-
   const navigate = useNavigate();
-
-  // const userEmail = sessionStorage.getItem('userEmail');
 
   async function createStripeAccount() {
     if (!userEmail) {
@@ -59,7 +53,6 @@ function Pages() {
       if (!result.ok) {
         throw new Error(`HTTP error! Status: ${result.status}`);
       }
-
       const data = await result.json();
       window.location.replace(data.url);
     } catch (error) {
@@ -102,5 +95,4 @@ function Pages() {
     </div>
   );
 }
-
 export default Pages;


### PR DESCRIPTION
## Related Issue
Please link to the issue that this pull request is related to. If there is no related issue, please explain why this change is necessary.

Necessary because: The button was dependent on the user registering first and in the same session using it. This made it so that they couldn't use the button if they came back to it after closing their session and coming back later.

## Type of change
Please select the type of change.

- [ ] Big change (300+ changes)
- [x] Small change (Less than 300 changes)
- [ ] NPM Packages changed

## Proposed Changes
Please provide a detailed description of the changes you're proposing with this pull request. Include any specific changes to the code, new files, or changes to existing files.

Description: AWS Auth usage added to Pages.js in order for the userEmail attribute to be taken from the backend instead of it being saved in the frontend during registration. This way users can use the button later rather than only the first time they register and login.

## @Mentions
Mention the person or team responsible for reviewing the proposed changes. This notifies them that their review is needed.

`Reviewer(s): @[GitHub username]`

## Delete or keep branch
Please select if you want to keep the branch you worked on, or have it deleted.

- [ ] Delete my branch
- [x] Keep my branch

## Additional Information
Include any additional information or context that might be necessary for understanding the pull request.

`Additional Info: [Add any additional information here]`
