### PR TITLE
#1552 + #1553 Updates gradle versions to 8.1. Removes @react-native-community/blur and updates duplicate react-native-voice package

### DIFF
--- a/app/Domits/android/app/build.gradle
+++ b/app/Domits/android/app/build.gradle
@@ -39,7 +39,7 @@ android {
                     details.useTarget "project :react-native-camera", {
                         attributes {
                             attribute(Attribute.of("com.android.build.api.attributes.BuildTypeAttr", String.class), "debug")
-                            attribute(Attribute.of("com.android.build.api.attributes.AgpVersionAttr", String.class), "8.1.1")
+                            attribute(Attribute.of("com.android.build.api.attributes.AgpVersionAttr", String.class), "8.1")
                             attribute(Attribute.of("org.jetbrains.kotlin.platform.type", String.class), "androidJvm")
                         }
                     }

--- a/app/Domits/android/build.gradle
+++ b/app/Domits/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.2.1" // Use the appropriate version for your project
+        classpath "com.android.tools.build:gradle:8.1" // Use the appropriate version for your project
         classpath "com.facebook.react:react-native-gradle-plugin:+"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }

--- a/app/Domits/package.json
+++ b/app/Domits/package.json
@@ -20,12 +20,11 @@
     "@aws-amplify/ui-react-core": "^3.1.1",
     "@aws-amplify/ui-react-native": "^2.2.2",
     "@react-native-async-storage/async-storage": "^1.23.1",
-    "@react-native-community/blur": "^4.4.0",
     "@react-native-community/checkbox": "^0.5.17",
     "@react-native-community/masked-view": "^0.1.11",
     "@react-native-community/netinfo": "^11.3.2",
     "@react-native-picker/picker": "^2.7.0",
-    "@react-native-voice/voice": "^3.1.5",
+    "@react-native-voice/voice": "^3.2.4",
     "@react-navigation/bottom-tabs": "^6.5.16",
     "@react-navigation/native": "^6.1.14",
     "@react-navigation/native-stack": "^6.9.22",
@@ -59,7 +58,6 @@
     "react-native-snap-carousel": "^1.3.1",
     "react-native-sound": "^0.11.2",
     "react-native-vector-icons": "^10.0.3",
-    "react-native-voice": "^0.3.0",
     "rn-fetch-blob": "^0.12.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Your name
Name: @Sandervg03 

## Related Issue
Related Issue: #1552 + #1553 

## Proposed Changes
Description: Updating gradle version allows for original build to function properly at JDK 17. @react-native-community/blur causes errors on fetching resources. And duplicate react-native-voice package was removed.

## Branch management
- [x] Merging into acceptance (not main)

## Change size
- [ ] Big change (300+)
- [x] Small change (less than 300)

## Change type
- [x] Bug fix
- [ ] New feature
- [x] Optimalization
- [ ] Documentation update

## Npm packages 
- [ ] NPM Packages installed
- [x] NPM Packages removed
- [x] NPM Packages updated
- [x] Did you check for vulnerabilities using "npm audit"?

## Checklist
- [x] Check if you didn't use global styling
- [x] Console.logs are deleted
- [x] Comments are deleted
- [ ] Jest tests are included
- [ ] Jest tests have succeeded
- [x] Pull request is assigned to a reviewer
- [x] Pull request title is descriptive and includes the issue number
- [ ] Code has been tested in a local environment
- [x] No sensitive data (e.g., passwords, keys) are hardcoded

All boxes must be checked in order to move forward with your pull request.

## Reviewers
Reviewer(s): @chantbalci @Stephanie-Lahmann 

## Additional Information
Additional Info: N/A

## Keep or delete my branch
- [x] Delete my branch
- [ ] Keep my branch
