### PR TITLE
feat: add attachments field to task model and update task service for…

### DIFF
--- a/backend/ORM/models/Property_Task.js
+++ b/backend/ORM/models/Property_Task.js
@@ -21,6 +21,7 @@ status: { type: "varchar", default: "Pending" },
         due_date: { type: "bigint", nullable: true, transformer: bigintTransformer },
         assignee_name: { type: "varchar", nullable: true },
         completed_date: { type: "bigint", nullable: true, transformer: bigintTransformer },
+        attachments: { type: "text", nullable: true },
         is_legacy: { type: "boolean", default: false },
         created_at: { type: "bigint", nullable: false, transformer: bigintTransformer },
         updated_at: { type: "bigint", nullable: false, transformer: bigintTransformer }

--- a/backend/functions/property-tasks/business/service/taskService.js
+++ b/backend/functions/property-tasks/business/service/taskService.js
@@ -29,6 +29,7 @@ export const createTask = async (hostId, taskData) => {
         priority: taskData.priority || 'Medium',
         due_date: taskData.due_date ? new Date(taskData.due_date).getTime() : null,
         assignee_name: taskData.assignee_name || null,
+        attachments: taskData.attachments?.length > 0 ? JSON.stringify(taskData.attachments) : null,
         created_at: Date.now(),
         updated_at: Date.now()
     };

--- a/frontend/web/src/features/hostdashboard/services/taskService.js
+++ b/frontend/web/src/features/hostdashboard/services/taskService.js
@@ -24,6 +24,7 @@ const normalizeTask = (task) => ({
     dueDate: toDateString(task.due_date),
     completedAt: toDateString(task.completed_date),
     isLegacy: task.is_legacy,
+    attachments: task.attachments ? JSON.parse(task.attachments) : [],
 });
 
 const toBackendPayload = (taskData) => {
@@ -40,6 +41,9 @@ const toBackendPayload = (taskData) => {
     if (taskData.dueDate !== undefined) payload.due_date = toUnixTimestamp(taskData.dueDate);
     if (taskData.assignee !== undefined || taskData.assignee_name !== undefined) {
         payload.assignee_name = taskData.assignee || taskData.assignee_name || null;
+    }
+    if (taskData.attachments !== undefined) {
+        payload.attachments = taskData.attachments;
     }
     return payload;
 };


### PR DESCRIPTION
… handling attachments

## Close or Relate the Issue
[//]: # (Only if this should close the issue)
- Closes #

[//]: # (in the issue a reference will be added to this pr)
- Related Issue: #

## Proposed Changes
[//]: # (Add a detailed description of the changes here)
Description: add attachments field to task model and update task service for handling attachments

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Optimization
- [ ] Documentation update

## Change Size
[//]: # (Indicate the size of this change.)
[//]: # (Clarify under Refactoring which parts are moved/unchanged code, so the reviewer doesn’t review old logic.)
- [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
- [ ] Big change (+-max 1000)
- [x] Small change (less than 300)

## Refactoring
Refactors following files, but didn't change the code. This is to avoid reviewing old logic.
- src/features/example.xx

## Evidence
- [ ] Screenshots or screen recording added for UI changes
- [ ] Before/after images added when relevant
- [ ] Images clearly show the implemented change
- [ ] Image quality is readable (no cropped or blurry evidence)

## Responsiveness
- [x] UI checked on mobile
- [x] UI checked on tablet
- [x] UI checked on desktop
- [x] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages
- [ ] NPM Packages installed
- [ ] NPM Packages removed
- [ ] NPM Packages updated
- [ ] Checked for vulnerabilities using "npm audit"

## Checklist
[//]: # (All boxes must be checked before merging.)
- [x] Pull request has at least 2 reviewers assigned
- [x] PR title is descriptive and includes issue number
- [x] Conventions
  - [x] No config files have been added (Amplify config, cache files)
  - [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  - [x] No global styling (see [#1691](https://github.com/domits1/Domits/issues/1691))
  - [x] No `console.log` left in code
  - [x] No commented-out code remains
- [x] Testing
  - [x] Code tested locally
  - [x] Jest tests are included
  - [x] Jest tests are passing

## Keep or delete my branch
- [ ] Delete my branch after merge
- [x] Keep my branch  
