### PR TITLE
feat(website-kpis): organize dashboard content into dedicated tabs

### DIFF
--- a/frontend/web/src/features/hostdashboard/Pages2.js
+++ b/frontend/web/src/features/hostdashboard/Pages2.js
@@ -12,7 +12,6 @@ import HomeIcon from "@mui/icons-material/Home";
 import LanguageIcon from "@mui/icons-material/Language";
 import SettingsIcon from "@mui/icons-material/Settings";
 import IntegrationInstructionsIcon from "@mui/icons-material/IntegrationInstructions";
-import InsightsOutlinedIcon from "@mui/icons-material/InsightsOutlined";
 
 const NAV = [
   { key: "ListProperty", label: "List your property", icon: <AddIcon />, to: "/hostonboarding" },
@@ -30,8 +29,8 @@ const NAV = [
   { key: "Tasks", label: "Tasks", icon: <CleaningServicesIcon />, to: "tasks" },
   { key: "Finance", label: "Finance", icon: <CreditCardIcon />, to: "finance" },
   { key: "Listings", label: "Listings", icon: <HomeIcon />, to: "listings" },
-  // { key: "Website", label: "Website", icon: <LanguageIcon />, to: "website" },
-  { key: "WebsiteKpis", label: "Website KPIs", icon: <InsightsOutlinedIcon />, to: "website-kpis" },
+  { key: "Website", label: "Website", icon: <LanguageIcon />, to: "website" },
+  // { key: "WebsiteKpis", label: "Website KPIs", icon: <InsightsOutlinedIcon />, to: "website-kpis" },
   { key: "Settings", label: "Settings", icon: <SettingsIcon />, to: "settings" },
 ];
 

--- a/frontend/web/src/features/hostdashboard/mainDashboardHost.js
+++ b/frontend/web/src/features/hostdashboard/mainDashboardHost.js
@@ -113,8 +113,9 @@ function MainDashboardHost() {
           <Route path="finance" element={<HostFinanceTab />} />
           <Route path="listings" element={<HostListings />} />
           <Route path="website" element={<WebsiteBuilderPage />} />
+          <Route path="website/kpis" element={<WebsiteKpiDashboardPage />} />
           <Route path="website/:propertyId" element={<WebsiteEditorPage />} />
-          <Route path="website-kpis" element={<WebsiteKpiDashboardPage />} />
+          <Route path="website-kpis" element={<Navigate to="../website/kpis" replace />} />
           <Route path="property" element={<HostProperty />} />
           <Route path="settings" element={<HostSettings />} />
 

--- a/frontend/web/src/features/hostdashboard/website/WebsiteBuilderPage.js
+++ b/frontend/web/src/features/hostdashboard/website/WebsiteBuilderPage.js
@@ -38,6 +38,7 @@ import { fetchWebsitePropertyDetails } from "./services/websitePropertyService";
 import { buildWebsiteTemplateModel } from "./rendering/buildWebsiteTemplateModel";
 import { applyWebsiteDraftContentOverrides } from "./rendering/websiteDraftContentOverrides";
 import { placeholderImage, resolveAccommodationImageUrl } from "../../../utils/accommodationImage";
+import { WEBSITE_DRAFT_DELETE_REASONS } from "./websiteDeleteReasons";
 
 const EMPTY_SELECTION = "";
 const PHOTO_CARD_VARIANT_CLASSES = [styles.photoCard1, styles.photoCard2, styles.photoCard3];
@@ -54,14 +55,6 @@ const WORKSPACE_TAB_BUILDER = "builder";
 const WORKSPACE_TAB_WEBSITES = "websites";
 const DELETE_WEBSITE_DRAFT_STEP_REASON = "reason";
 const DELETE_WEBSITE_DRAFT_STEP_CONFIRM = "confirm";
-const WEBSITE_DRAFT_DELETE_REASONS = Object.freeze([
-  "I no longer need this website.",
-  "I built it for the wrong listing.",
-  "The imported content does not look right.",
-  "I want to try a different template.",
-  "I prefer to manage bookings without a standalone website.",
-  "Other",
-]);
 
 const getPropertyStatusLabel = (status) =>
   PROPERTY_STATUS_LABELS[String(status || "").toUpperCase()] || "Unknown";

--- a/frontend/web/src/features/hostdashboard/website/_websiteBuilder.layout.scss
+++ b/frontend/web/src/features/hostdashboard/website/_websiteBuilder.layout.scss
@@ -6,6 +6,10 @@
   gap: 24px;
 }
 
+.websitePageWide {
+  max-width: 1480px;
+}
+
 .heroCard {
   display: grid;
   gap: 12px;
@@ -100,6 +104,61 @@
   gap: 18px;
 }
 
+.kpiToolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.kpiToolbarPrimary {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  flex: 1 1 640px;
+}
+
+.kpiViewTabRow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px;
+  border-radius: 999px;
+  background: #eef3f8;
+  max-width: 100%;
+}
+
+.kpiViewTabButton {
+  border: none;
+  border-radius: 999px;
+  padding: 0.55rem 0.9rem;
+  background: transparent;
+  color: #46627f;
+  font-size: 0.84rem;
+  font-weight: 800;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+}
+
+.kpiViewTabButton:hover {
+  color: #153e64;
+}
+
+.kpiViewTabButtonActive {
+  background: #ffffff;
+  color: #153e64;
+  box-shadow: 0 8px 18px rgba(31, 78, 121, 0.12);
+}
+
+.kpiSyncMeta {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
 .kpiGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -117,6 +176,11 @@
     linear-gradient(180deg, rgba(248, 251, 255, 0.98), rgba(255, 255, 255, 1)),
     #ffffff;
   box-shadow: 0 12px 28px rgba(15, 23, 42, 0.05);
+}
+
+.kpiCardUpdated,
+.researchKpiCardUpdated {
+  animation: kpiCardHuePulse 1.9s ease;
 }
 
 .kpiCardTitle {
@@ -259,26 +323,49 @@
   line-height: 1.55;
 }
 
-.deletionReasonList {
-  display: grid;
-  gap: 10px;
+.deletionReasonTableWrapper {
+  overflow-x: auto;
 }
 
-.deletionReasonRow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 12px 14px;
-  border-radius: 14px;
-  border: 1px solid rgba(31, 78, 121, 0.12);
+.deletionReasonTable {
+  width: 100%;
+  border-collapse: collapse;
   background: #ffffff;
+  border: 1px solid rgba(31, 78, 121, 0.12);
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.deletionReasonTable thead th {
+  padding: 12px 14px;
+  text-align: left;
+  background: #eef4fa;
+  color: #153e64;
+  font-size: 0.86rem;
+  font-weight: 800;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.deletionReasonTable tbody td {
+  padding: 12px 14px;
+  border-top: 1px solid rgba(31, 78, 121, 0.1);
   color: #0f172a;
   font-weight: 600;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
-.deletionReasonRow strong {
+.deletionReasonTable tbody td:last-child {
+  width: 96px;
+  text-align: right;
   color: #153e64;
+}
+
+.deletionReasonRowUpdated {
+  animation: kpiTableCellHuePulse 1.9s ease;
 }
 
 .researchKpiPanel {
@@ -326,6 +413,61 @@
   border: 1px solid rgba(31, 78, 121, 0.12);
   background: #ffffff;
   box-shadow: 0 10px 22px rgba(15, 23, 42, 0.04);
+}
+
+@keyframes kpiCardHuePulse {
+  0% {
+    border-color: rgba(31, 78, 121, 0.14);
+    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.05);
+    background:
+      linear-gradient(180deg, rgba(248, 251, 255, 0.98), rgba(255, 255, 255, 1)),
+      #ffffff;
+  }
+
+  20% {
+    border-color: rgba(14, 116, 144, 0.32);
+    box-shadow:
+      0 0 0 1px rgba(20, 184, 166, 0.12),
+      0 18px 32px rgba(14, 116, 144, 0.14);
+    background:
+      linear-gradient(180deg, rgba(240, 253, 250, 0.98), rgba(255, 255, 255, 1)),
+      #ffffff;
+  }
+
+  60% {
+    border-color: rgba(21, 94, 117, 0.24);
+    box-shadow:
+      0 0 0 1px rgba(20, 184, 166, 0.08),
+      0 14px 28px rgba(14, 116, 144, 0.09);
+  }
+
+  100% {
+    border-color: rgba(31, 78, 121, 0.14);
+    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.05);
+    background:
+      linear-gradient(180deg, rgba(248, 251, 255, 0.98), rgba(255, 255, 255, 1)),
+      #ffffff;
+  }
+}
+
+@keyframes kpiTableCellHuePulse {
+  0% {
+    background: #ffffff;
+    color: #0f172a;
+    box-shadow: inset 0 0 0 0 rgba(14, 116, 144, 0);
+  }
+
+  22% {
+    background: rgba(236, 253, 245, 0.96);
+    color: #0f172a;
+    box-shadow: inset 0 0 0 1px rgba(20, 184, 166, 0.18);
+  }
+
+  100% {
+    background: #ffffff;
+    color: #0f172a;
+    box-shadow: inset 0 0 0 0 rgba(14, 116, 144, 0);
+  }
 }
 
 .researchKpiCardHeader {

--- a/frontend/web/src/features/hostdashboard/website/_websiteBuilder.responsive.scss
+++ b/frontend/web/src/features/hostdashboard/website/_websiteBuilder.responsive.scss
@@ -64,6 +64,25 @@
     flex-direction: column;
   }
 
+  .kpiToolbar {
+    align-items: stretch;
+  }
+
+  .kpiToolbarPrimary {
+    flex-basis: auto;
+  }
+
+  .kpiViewTabRow {
+    width: 100%;
+    justify-content: space-between;
+    overflow-x: auto;
+  }
+
+  .kpiViewTabButton {
+    flex: 1 1 0;
+    text-align: center;
+  }
+
   .selectionPreview {
     justify-items: center;
   }

--- a/frontend/web/src/features/hostdashboard/website/kpis/WebsiteKpiCards.jsx
+++ b/frontend/web/src/features/hostdashboard/website/kpis/WebsiteKpiCards.jsx
@@ -9,9 +9,12 @@ export function WebsiteKpiMetricCard({
   meta,
   isLoading,
   loadingMeta = "Loading aggregated website activity...",
+  isHighlighted = false,
 }) {
+  const cardClassName = `${styles.kpiCard} ${isHighlighted ? styles.kpiCardUpdated : ""}`.trim();
+
   return (
-    <article className={styles.kpiCard}>
+    <article className={cardClassName}>
       <p className={styles.kpiCardTitle}>{title}</p>
       {isLoading ? (
         <div className={styles.kpiCardLoader}>
@@ -31,16 +34,20 @@ WebsiteKpiMetricCard.propTypes = {
   meta: PropTypes.string.isRequired,
   isLoading: PropTypes.bool.isRequired,
   loadingMeta: PropTypes.string,
+  isHighlighted: PropTypes.bool,
 };
 
-export function WebsiteKpiResearchCard({ researchKpiCard, isLoading }) {
+export function WebsiteKpiResearchCard({ researchKpiCard, isLoading, isHighlighted = false }) {
   const statusClassName =
     isLoading || !researchKpiCard.isInstrumented
       ? styles.researchKpiStatusBadgePending
       : styles.researchKpiStatusBadgeReady;
+  const cardClassName = `${styles.researchKpiCard} ${
+    isHighlighted ? styles.researchKpiCardUpdated : ""
+  }`.trim();
 
   return (
-    <article className={styles.researchKpiCard}>
+    <article className={cardClassName}>
       <div className={styles.researchKpiCardHeader}>
         <p className={styles.researchKpiCardTitle}>{researchKpiCard.id}</p>
         <span className={`${styles.researchKpiStatusBadge} ${statusClassName}`.trim()}>
@@ -83,4 +90,5 @@ WebsiteKpiResearchCard.propTypes = {
     note: PropTypes.string.isRequired,
   }).isRequired,
   isLoading: PropTypes.bool.isRequired,
+  isHighlighted: PropTypes.bool,
 };

--- a/frontend/web/src/features/hostdashboard/website/kpis/WebsiteKpiDashboardPage.js
+++ b/frontend/web/src/features/hostdashboard/website/kpis/WebsiteKpiDashboardPage.js
@@ -1,9 +1,10 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import InsightsOutlinedIcon from "@mui/icons-material/InsightsOutlined";
 import RefreshOutlinedIcon from "@mui/icons-material/RefreshOutlined";
 import PulseBarsLoader from "../../../../components/loaders/PulseBarsLoader";
 import { fetchWebsiteKpis } from "./services/websiteKpiService";
 import { WebsiteKpiMetricCard, WebsiteKpiResearchCard } from "./WebsiteKpiCards";
+import { WEBSITE_DRAFT_DELETE_REASONS } from "../websiteDeleteReasons";
 import {
   buildResearchKpiCards,
   buildSurfacePerformanceCards,
@@ -14,24 +15,179 @@ import {
 } from "./websiteKpiConfig";
 import styles from "../WebsiteBuilderPage.module.scss";
 
+const KPI_VIEW_TAB_OVERVIEW = "overview";
+const KPI_VIEW_TAB_PERFORMANCE = "performance";
+const KPI_VIEW_TAB_RESEARCH = "research";
+const KPI_VIEW_TAB_DELETIONS = "deletions";
+
+const KPI_VIEW_TAB_OPTIONS = Object.freeze([
+  { id: KPI_VIEW_TAB_OVERVIEW, label: "Overview" },
+  { id: KPI_VIEW_TAB_PERFORMANCE, label: "Performance" },
+  { id: KPI_VIEW_TAB_RESEARCH, label: "Research" },
+  { id: KPI_VIEW_TAB_DELETIONS, label: "Deletion reasons" },
+]);
+const WEBSITE_KPI_POLL_INTERVAL_MS = 60000;
+const WEBSITE_KPI_HIGHLIGHT_DURATION_MS = 2200;
+const formatWebsiteKpiSyncTime = (timestamp) =>
+  new Intl.DateTimeFormat("en-GB", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(new Date(timestamp));
+
+const createCardSignatureMap = (cards) =>
+  new Map(cards.map((card) => [card.id, JSON.stringify({ value: card.value, meta: card.meta })]));
+
+const collectChangedCardIds = (previousCards, nextCards) => {
+  const previousCardMap = createCardSignatureMap(previousCards);
+  return nextCards
+    .filter((nextCard) => previousCardMap.get(nextCard.id) !== JSON.stringify({ value: nextCard.value, meta: nextCard.meta }))
+    .map((nextCard) => nextCard.id);
+};
+
+const buildDeletionReasonRows = (deletionReasonBreakdown) => {
+  const reasonCountMap = new Map(
+    deletionReasonBreakdown.map((reasonEntry) => [reasonEntry.reason, reasonEntry.count])
+  );
+  const configuredRows = WEBSITE_DRAFT_DELETE_REASONS.map((reason) => ({
+    reason,
+    count: reasonCountMap.get(reason) || 0,
+  }));
+  const configuredReasons = new Set(WEBSITE_DRAFT_DELETE_REASONS);
+  const extraRows = deletionReasonBreakdown
+    .filter((reasonEntry) => !configuredReasons.has(reasonEntry.reason))
+    .map((reasonEntry) => ({
+      reason: reasonEntry.reason,
+      count: reasonEntry.count,
+    }));
+
+  return [...configuredRows, ...extraRows];
+};
+
+const collectChangedDeletionReasonIds = (previousBreakdown, nextBreakdown) => {
+  const previousReasonMap = new Map(
+    buildDeletionReasonRows(previousBreakdown).map((reasonEntry) => [reasonEntry.reason, reasonEntry.count])
+  );
+
+  return buildDeletionReasonRows(nextBreakdown)
+    .filter((reasonEntry) => previousReasonMap.get(reasonEntry.reason) !== reasonEntry.count)
+    .map((reasonEntry) => reasonEntry.reason);
+};
+
+const collectChangedKpiIds = (previousWebsiteKpis, nextWebsiteKpis) => {
+  const previousMetricCards = [
+    ...buildWebsiteMetricCards(previousWebsiteKpis),
+    ...Object.values(buildSurfacePerformanceCards(previousWebsiteKpis)).flatMap(
+      (surfaceCardGroup) => surfaceCardGroup.metrics
+    ),
+  ];
+  const nextMetricCards = [
+    ...buildWebsiteMetricCards(nextWebsiteKpis),
+    ...Object.values(buildSurfacePerformanceCards(nextWebsiteKpis)).flatMap(
+      (surfaceCardGroup) => surfaceCardGroup.metrics
+    ),
+  ];
+  const previousResearchCards = buildResearchKpiCards(previousWebsiteKpis).map((researchKpiCard) => ({
+    id: researchKpiCard.id,
+    value: researchKpiCard.value,
+    meta: researchKpiCard.statusLabel,
+  }));
+  const nextResearchCards = buildResearchKpiCards(nextWebsiteKpis).map((researchKpiCard) => ({
+    id: researchKpiCard.id,
+    value: researchKpiCard.value,
+    meta: researchKpiCard.statusLabel,
+  }));
+
+  return {
+    metricIds: collectChangedCardIds(previousMetricCards, nextMetricCards),
+    researchIds: collectChangedCardIds(previousResearchCards, nextResearchCards),
+    deletionReasonIds: collectChangedDeletionReasonIds(
+      previousWebsiteKpis.deletionReasonBreakdown,
+      nextWebsiteKpis.deletionReasonBreakdown
+    ),
+  };
+};
+
 function WebsiteKpiDashboardPage() {
   const [websiteKpis, setWebsiteKpis] = useState(EMPTY_WEBSITE_KPIS);
   const [isLoadingWebsiteKpis, setIsLoadingWebsiteKpis] = useState(true);
+  const [isRefreshingWebsiteKpis, setIsRefreshingWebsiteKpis] = useState(false);
   const [websiteKpisError, setWebsiteKpisError] = useState("");
+  const [websiteKpisRefreshError, setWebsiteKpisRefreshError] = useState("");
+  const [lastWebsiteKpiRefreshAt, setLastWebsiteKpiRefreshAt] = useState(0);
   const [surfaceKpiTab, setSurfaceKpiTab] = useState(SURFACE_KPI_TAB_PREVIEW);
+  const [kpiViewTab, setKpiViewTab] = useState(KPI_VIEW_TAB_OVERVIEW);
+  const [highlightedMetricIds, setHighlightedMetricIds] = useState([]);
+  const [highlightedResearchKpiIds, setHighlightedResearchKpiIds] = useState([]);
+  const [highlightedDeletionReasonIds, setHighlightedDeletionReasonIds] = useState([]);
+  const hasLoadedWebsiteKpisRef = useRef(false);
+  const websiteKpiRequestInFlightRef = useRef(false);
+  const latestWebsiteKpisRef = useRef(EMPTY_WEBSITE_KPIS);
+  const kpiHighlightTimeoutRef = useRef(null);
 
-  const loadWebsiteKpis = async () => {
-    setIsLoadingWebsiteKpis(true);
-    setWebsiteKpisError("");
+  const loadWebsiteKpis = async ({ background = false } = {}) => {
+    if (websiteKpiRequestInFlightRef.current) {
+      return;
+    }
+
+    websiteKpiRequestInFlightRef.current = true;
+
+    if (!hasLoadedWebsiteKpisRef.current) {
+      setIsLoadingWebsiteKpis(true);
+      setWebsiteKpisError("");
+    } else {
+      setIsRefreshingWebsiteKpis(true);
+      setWebsiteKpisRefreshError("");
+    }
 
     try {
       const nextWebsiteKpis = await fetchWebsiteKpis();
+      const previousWebsiteKpis = latestWebsiteKpisRef.current;
+      const shouldAnimateChanges = hasLoadedWebsiteKpisRef.current;
       setWebsiteKpis(nextWebsiteKpis);
+      latestWebsiteKpisRef.current = nextWebsiteKpis;
+      setLastWebsiteKpiRefreshAt(Date.now());
+      setWebsiteKpisError("");
+      setWebsiteKpisRefreshError("");
+      hasLoadedWebsiteKpisRef.current = true;
+
+      if (shouldAnimateChanges) {
+        const nextChangedKpiIds = collectChangedKpiIds(previousWebsiteKpis, nextWebsiteKpis);
+        const hasChangedKpis =
+          nextChangedKpiIds.metricIds.length > 0 ||
+          nextChangedKpiIds.researchIds.length > 0 ||
+          nextChangedKpiIds.deletionReasonIds.length > 0;
+
+        if (hasChangedKpis) {
+          setHighlightedMetricIds(nextChangedKpiIds.metricIds);
+          setHighlightedResearchKpiIds(nextChangedKpiIds.researchIds);
+          setHighlightedDeletionReasonIds(nextChangedKpiIds.deletionReasonIds);
+
+          if (kpiHighlightTimeoutRef.current) {
+            globalThis.clearTimeout(kpiHighlightTimeoutRef.current);
+          }
+
+          kpiHighlightTimeoutRef.current = globalThis.setTimeout(() => {
+            setHighlightedMetricIds([]);
+            setHighlightedResearchKpiIds([]);
+            setHighlightedDeletionReasonIds([]);
+            kpiHighlightTimeoutRef.current = null;
+          }, WEBSITE_KPI_HIGHLIGHT_DURATION_MS);
+        }
+      }
     } catch (error) {
-      setWebsiteKpis(EMPTY_WEBSITE_KPIS);
-      setWebsiteKpisError(error?.message || "We could not load the standalone website KPI overview.");
+      const nextErrorMessage =
+        error?.message || "We could not load the standalone website KPI overview.";
+      if (!hasLoadedWebsiteKpisRef.current) {
+        setWebsiteKpis(EMPTY_WEBSITE_KPIS);
+        setWebsiteKpisError(nextErrorMessage);
+      } else {
+        setWebsiteKpisRefreshError(nextErrorMessage);
+      }
     } finally {
       setIsLoadingWebsiteKpis(false);
+      setIsRefreshingWebsiteKpis(false);
+      websiteKpiRequestInFlightRef.current = false;
     }
   };
 
@@ -39,13 +195,36 @@ function WebsiteKpiDashboardPage() {
     void loadWebsiteKpis();
   }, []);
 
+  useEffect(() => () => {
+    if (kpiHighlightTimeoutRef.current) {
+      globalThis.clearTimeout(kpiHighlightTimeoutRef.current);
+    }
+  }, []);
+
+  useEffect(() => {
+    const intervalId = globalThis.setInterval(() => {
+      if (globalThis.document?.visibilityState === "hidden") {
+        return;
+      }
+
+      void loadWebsiteKpis({ background: true });
+    }, WEBSITE_KPI_POLL_INTERVAL_MS);
+
+    return () => {
+      globalThis.clearInterval(intervalId);
+    };
+  }, []);
+
   const metricCards = buildWebsiteMetricCards(websiteKpis);
   const surfacePerformanceCards = buildSurfacePerformanceCards(websiteKpis);
   const researchKpiCards = buildResearchKpiCards(websiteKpis);
-  const hasDeletionReasons = websiteKpis.deletionReasonBreakdown.length > 0;
+  const deletionReasonRows = useMemo(
+    () => buildDeletionReasonRows(websiteKpis.deletionReasonBreakdown),
+    [websiteKpis.deletionReasonBreakdown]
+  );
 
   const renderDeletionReasonContent = () => {
-    if (isLoadingWebsiteKpis) {
+    if (isLoadingWebsiteKpis && !hasLoadedWebsiteKpisRef.current) {
       return (
         <div className={styles.stateCard}>
           <PulseBarsLoader message="Loading website deletion reasons..." />
@@ -53,29 +232,171 @@ function WebsiteKpiDashboardPage() {
       );
     }
 
-    if (hasDeletionReasons) {
-      return (
-        <div className={styles.deletionReasonList}>
-          {websiteKpis.deletionReasonBreakdown.map((reasonEntry) => (
-            <div key={reasonEntry.reason} className={styles.deletionReasonRow}>
-              <span>{reasonEntry.reason}</span>
-              <strong>{reasonEntry.count}</strong>
-            </div>
-          ))}
-        </div>
-      );
-    }
-
     return (
-      <p className={styles.previewHelperText}>
-        No website deletions with selected reasons have been recorded yet.
-      </p>
+      <div className={styles.deletionReasonTableWrapper}>
+        <table className={styles.deletionReasonTable}>
+          <thead>
+            <tr>
+              <th scope="col">Reason</th>
+              <th scope="col">Count</th>
+            </tr>
+          </thead>
+          <tbody>
+            {deletionReasonRows.map((reasonEntry) => (
+            <tr key={reasonEntry.reason}>
+                <td
+                  className={
+                    highlightedDeletionReasonIds.includes(reasonEntry.reason)
+                      ? styles.deletionReasonRowUpdated
+                      : undefined
+                  }
+                >
+                  {reasonEntry.reason}
+                </td>
+                <td
+                  className={
+                    highlightedDeletionReasonIds.includes(reasonEntry.reason)
+                      ? styles.deletionReasonRowUpdated
+                      : undefined
+                  }
+                >
+                  {reasonEntry.count}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     );
   };
 
+  const renderOverviewTabContent = () => (
+    <div className={styles.kpiGrid}>
+      {metricCards.map((metricCard) => (
+        <WebsiteKpiMetricCard
+          key={metricCard.id}
+          title={metricCard.title}
+          value={metricCard.value}
+          meta={metricCard.meta}
+          isLoading={isLoadingWebsiteKpis && !hasLoadedWebsiteKpisRef.current}
+          isHighlighted={highlightedMetricIds.includes(metricCard.id)}
+        />
+      ))}
+    </div>
+  );
+
+  const renderPerformanceTabContent = () => (
+    <article className={styles.surfaceKpiPanel}>
+      <div className={styles.surfaceKpiHeader}>
+        <div>
+          <h3>{surfacePerformanceCards[surfaceKpiTab].title}</h3>
+          <p>Performance KPIs are separated by surface because preview and live do not share the same runtime path.</p>
+        </div>
+
+        <div className={styles.surfaceKpiTabRow} role="tablist" aria-label="Website surface KPI tabs">
+          {SURFACE_KPI_TAB_OPTIONS.map(({ id, label }) => {
+            const surfaceTab = id;
+            const isActiveTab = surfaceKpiTab === surfaceTab;
+            return (
+              <button
+                key={surfaceTab}
+                type="button"
+                role="tab"
+                aria-selected={isActiveTab}
+                className={`${styles.surfaceKpiTabButton} ${
+                  isActiveTab ? styles.surfaceKpiTabButtonActive : ""
+                }`.trim()}
+                onClick={() => setSurfaceKpiTab(surfaceTab)}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className={styles.surfaceKpiBody}>
+        <p className={styles.surfaceKpiDescription}>
+          {surfacePerformanceCards[surfaceKpiTab].description}
+        </p>
+        <div className={styles.surfaceKpiGrid}>
+          {surfacePerformanceCards[surfaceKpiTab].metrics.map((surfaceMetric) => (
+            <WebsiteKpiMetricCard
+              key={surfaceMetric.id}
+              title={surfaceMetric.title}
+              value={surfaceMetric.value}
+              meta={surfaceMetric.meta}
+              isLoading={isLoadingWebsiteKpis && !hasLoadedWebsiteKpisRef.current}
+              loadingMeta="Loading surface performance metrics..."
+              isHighlighted={highlightedMetricIds.includes(surfaceMetric.id)}
+            />
+          ))}
+        </div>
+      </div>
+    </article>
+  );
+
+  const renderResearchTabContent = () => (
+    <article className={styles.researchKpiPanel}>
+      <div className={styles.researchKpiHeader}>
+        <h3>Research KPI set</h3>
+        <p>
+          These KPI names come directly from the research. The dashboard shows them already, but
+          only metrics with real instrumentation should surface values.
+        </p>
+      </div>
+
+      <div className={styles.researchKpiGrid}>
+        {researchKpiCards.map((researchKpiCard) => (
+          <WebsiteKpiResearchCard
+            key={researchKpiCard.id}
+            researchKpiCard={researchKpiCard}
+            isLoading={isLoadingWebsiteKpis && !hasLoadedWebsiteKpisRef.current}
+            isHighlighted={highlightedResearchKpiIds.includes(researchKpiCard.id)}
+          />
+        ))}
+      </div>
+    </article>
+  );
+
+  const renderDeletionTabContent = () => (
+    <article className={styles.deletionReasonPanel}>
+      <div className={styles.deletionReasonHeader}>
+        <h3>Website deletion reasons</h3>
+        <p>Counts are aggregated from the reasons selected in the standalone website delete flow.</p>
+      </div>
+
+      {renderDeletionReasonContent()}
+    </article>
+  );
+
+  const renderSelectedKpiView = () => {
+    switch (kpiViewTab) {
+      case KPI_VIEW_TAB_PERFORMANCE:
+        return renderPerformanceTabContent();
+      case KPI_VIEW_TAB_RESEARCH:
+        return renderResearchTabContent();
+      case KPI_VIEW_TAB_DELETIONS:
+        return renderDeletionTabContent();
+      case KPI_VIEW_TAB_OVERVIEW:
+      default:
+        return renderOverviewTabContent();
+    }
+  };
+
+  const syncStatusText = websiteKpisRefreshError
+    ? websiteKpisRefreshError
+    : isRefreshingWebsiteKpis
+    ? "Syncing live KPI data..."
+    : lastWebsiteKpiRefreshAt > 0
+    ? `Live updates every 60 seconds. Last synced ${formatWebsiteKpiSyncTime(
+        lastWebsiteKpiRefreshAt
+      )}`
+    : "Live updates start after the first KPI response.";
+
   const renderKpiContent = () => {
     if (websiteKpisError) {
-        return (
+      return (
           <div className={`${styles.stateCard} ${styles.errorState}`}>
             <p>{websiteKpisError}</p>
             <div className={styles.buttonRow}>
@@ -88,103 +409,14 @@ function WebsiteKpiDashboardPage() {
     }
 
     return (
-      <>
-        <div className={styles.kpiGrid}>
-          {metricCards.map((metricCard) => (
-            <WebsiteKpiMetricCard
-              key={metricCard.id}
-              title={metricCard.title}
-              value={metricCard.value}
-              meta={metricCard.meta}
-              isLoading={isLoadingWebsiteKpis}
-            />
-          ))}
-        </div>
-
-        <article className={styles.surfaceKpiPanel}>
-          <div className={styles.surfaceKpiHeader}>
-            <div>
-              <h3>{surfacePerformanceCards[surfaceKpiTab].title}</h3>
-              <p>Performance KPIs are separated by surface because preview and live do not share the same runtime path.</p>
-            </div>
-
-            <div className={styles.surfaceKpiTabRow} role="tablist" aria-label="Website surface KPI tabs">
-              {SURFACE_KPI_TAB_OPTIONS.map(({ id, label }) => {
-                const surfaceTab = id;
-                const isActiveTab = surfaceKpiTab === surfaceTab;
-                return (
-                  <button
-                    key={surfaceTab}
-                    type="button"
-                    role="tab"
-                    aria-selected={isActiveTab}
-                    className={`${styles.surfaceKpiTabButton} ${
-                      isActiveTab ? styles.surfaceKpiTabButtonActive : ""
-                    }`.trim()}
-                    onClick={() => setSurfaceKpiTab(surfaceTab)}
-                  >
-                    {label}
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-
-          <div className={styles.surfaceKpiBody}>
-            <p className={styles.surfaceKpiDescription}>
-              {surfacePerformanceCards[surfaceKpiTab].description}
-            </p>
-            <div className={styles.surfaceKpiGrid}>
-              {surfacePerformanceCards[surfaceKpiTab].metrics.map((surfaceMetric) => (
-                <WebsiteKpiMetricCard
-                  key={surfaceMetric.id}
-                  title={surfaceMetric.title}
-                  value={surfaceMetric.value}
-                  meta={surfaceMetric.meta}
-                  isLoading={isLoadingWebsiteKpis}
-                  loadingMeta="Loading surface performance metrics..."
-                />
-              ))}
-            </div>
-          </div>
-        </article>
-
-        <article className={styles.researchKpiPanel}>
-          <div className={styles.researchKpiHeader}>
-            <h3>Research KPI set</h3>
-            <p>
-              These KPI names come directly from the research. The dashboard shows them already, but
-              only metrics with real instrumentation should surface values.
-            </p>
-          </div>
-
-          <div className={styles.researchKpiGrid}>
-            {researchKpiCards.map((researchKpiCard) => (
-              <WebsiteKpiResearchCard
-                key={researchKpiCard.id}
-                researchKpiCard={researchKpiCard}
-                isLoading={isLoadingWebsiteKpis}
-              />
-            ))}
-          </div>
-        </article>
-
-        <article className={styles.deletionReasonPanel}>
-          <div className={styles.deletionReasonHeader}>
-            <h3>Website deletion reasons</h3>
-            <p>Counts are aggregated from the reasons selected in the standalone website delete flow.</p>
-          </div>
-
-          {renderDeletionReasonContent()}
-        </article>
-      </>
+      renderSelectedKpiView()
     );
   };
 
   return (
     <main className="page-Host">
       <div className="page-Host-content">
-        <section className={styles.websitePage}>
+        <section className={`${styles.websitePage} ${styles.websitePageWide}`.trim()}>
           <div className={styles.heroCard}>
             <p className={styles.eyebrow}>Standalone website analytics</p>
             <h1 className={styles.heroTitle}>Direct Booking Website KPI dashboard</h1>
@@ -209,15 +441,43 @@ function WebsiteKpiDashboardPage() {
               </p>
             </div>
 
-            <div className={styles.buttonRow}>
+            <div className={styles.kpiToolbar}>
+              <div className={styles.kpiToolbarPrimary}>
+                <div className={styles.kpiViewTabRow} role="tablist" aria-label="Website KPI category tabs">
+                  {KPI_VIEW_TAB_OPTIONS.map(({ id, label }) => {
+                    const isActiveTab = kpiViewTab === id;
+                    return (
+                      <button
+                        key={id}
+                        type="button"
+                        role="tab"
+                        aria-selected={isActiveTab}
+                        className={`${styles.kpiViewTabButton} ${
+                          isActiveTab ? styles.kpiViewTabButtonActive : ""
+                        }`.trim()}
+                        onClick={() => setKpiViewTab(id)}
+                      >
+                        {label}
+                      </button>
+                    );
+                  })}
+                </div>
+
+                <p className={styles.kpiSyncMeta}>{syncStatusText}</p>
+              </div>
+
               <button
                 type="button"
                 className={styles.secondaryButton}
-                onClick={() => void loadWebsiteKpis()}
-                disabled={isLoadingWebsiteKpis}
+                onClick={() => void loadWebsiteKpis({ background: true })}
+                disabled={isLoadingWebsiteKpis || isRefreshingWebsiteKpis}
               >
                 <RefreshOutlinedIcon fontSize="small" />
-                {isLoadingWebsiteKpis ? "Loading..." : "Refresh data"}
+                {isLoadingWebsiteKpis
+                  ? "Loading..."
+                  : isRefreshingWebsiteKpis
+                  ? "Syncing..."
+                  : "Refresh data"}
               </button>
             </div>
 

--- a/frontend/web/src/features/hostdashboard/website/kpis/WebsiteKpiDashboardPage.js
+++ b/frontend/web/src/features/hostdashboard/website/kpis/WebsiteKpiDashboardPage.js
@@ -35,6 +35,40 @@ const formatWebsiteKpiSyncTime = (timestamp) =>
     second: "2-digit",
   }).format(new Date(timestamp));
 
+const getSyncStatusText = ({
+  websiteKpisRefreshError,
+  isRefreshingWebsiteKpis,
+  lastWebsiteKpiRefreshAt,
+}) => {
+  if (websiteKpisRefreshError) {
+    return websiteKpisRefreshError;
+  }
+
+  if (isRefreshingWebsiteKpis) {
+    return "Syncing live KPI data...";
+  }
+
+  if (lastWebsiteKpiRefreshAt > 0) {
+    return `Live updates every 60 seconds. Last synced ${formatWebsiteKpiSyncTime(
+      lastWebsiteKpiRefreshAt
+    )}`;
+  }
+
+  return "Live updates start after the first KPI response.";
+};
+
+const getRefreshButtonLabel = ({ isLoadingWebsiteKpis, isRefreshingWebsiteKpis }) => {
+  if (isLoadingWebsiteKpis) {
+    return "Loading...";
+  }
+
+  if (isRefreshingWebsiteKpis) {
+    return "Syncing...";
+  }
+
+  return "Refresh data";
+};
+
 const createCardSignatureMap = (cards) =>
   new Map(cards.map((card) => [card.id, JSON.stringify({ value: card.value, meta: card.meta })]));
 
@@ -131,8 +165,9 @@ function WebsiteKpiDashboardPage() {
     }
 
     websiteKpiRequestInFlightRef.current = true;
+    const isInitialLoad = hasLoadedWebsiteKpisRef.current === false;
 
-    if (!hasLoadedWebsiteKpisRef.current) {
+    if (isInitialLoad) {
       setIsLoadingWebsiteKpis(true);
       setWebsiteKpisError("");
     } else {
@@ -178,7 +213,9 @@ function WebsiteKpiDashboardPage() {
     } catch (error) {
       const nextErrorMessage =
         error?.message || "We could not load the standalone website KPI overview.";
-      if (!hasLoadedWebsiteKpisRef.current) {
+      const isInitialLoadError = hasLoadedWebsiteKpisRef.current === false;
+
+      if (isInitialLoadError) {
         setWebsiteKpis(EMPTY_WEBSITE_KPIS);
         setWebsiteKpisError(nextErrorMessage);
       } else {
@@ -222,9 +259,19 @@ function WebsiteKpiDashboardPage() {
     () => buildDeletionReasonRows(websiteKpis.deletionReasonBreakdown),
     [websiteKpis.deletionReasonBreakdown]
   );
+  const isInitialKpiLoad = isLoadingWebsiteKpis && hasLoadedWebsiteKpisRef.current === false;
+  const syncStatusText = getSyncStatusText({
+    websiteKpisRefreshError,
+    isRefreshingWebsiteKpis,
+    lastWebsiteKpiRefreshAt,
+  });
+  const refreshButtonLabel = getRefreshButtonLabel({
+    isLoadingWebsiteKpis,
+    isRefreshingWebsiteKpis,
+  });
 
   const renderDeletionReasonContent = () => {
-    if (isLoadingWebsiteKpis && !hasLoadedWebsiteKpisRef.current) {
+    if (isInitialKpiLoad) {
       return (
         <div className={styles.stateCard}>
           <PulseBarsLoader message="Loading website deletion reasons..." />
@@ -243,7 +290,7 @@ function WebsiteKpiDashboardPage() {
           </thead>
           <tbody>
             {deletionReasonRows.map((reasonEntry) => (
-            <tr key={reasonEntry.reason}>
+              <tr key={reasonEntry.reason}>
                 <td
                   className={
                     highlightedDeletionReasonIds.includes(reasonEntry.reason)
@@ -278,7 +325,7 @@ function WebsiteKpiDashboardPage() {
           title={metricCard.title}
           value={metricCard.value}
           meta={metricCard.meta}
-          isLoading={isLoadingWebsiteKpis && !hasLoadedWebsiteKpisRef.current}
+          isLoading={isInitialKpiLoad}
           isHighlighted={highlightedMetricIds.includes(metricCard.id)}
         />
       ))}
@@ -326,7 +373,7 @@ function WebsiteKpiDashboardPage() {
               title={surfaceMetric.title}
               value={surfaceMetric.value}
               meta={surfaceMetric.meta}
-              isLoading={isLoadingWebsiteKpis && !hasLoadedWebsiteKpisRef.current}
+              isLoading={isInitialKpiLoad}
               loadingMeta="Loading surface performance metrics..."
               isHighlighted={highlightedMetricIds.includes(surfaceMetric.id)}
             />
@@ -351,7 +398,7 @@ function WebsiteKpiDashboardPage() {
           <WebsiteKpiResearchCard
             key={researchKpiCard.id}
             researchKpiCard={researchKpiCard}
-            isLoading={isLoadingWebsiteKpis && !hasLoadedWebsiteKpisRef.current}
+            isLoading={isInitialKpiLoad}
             isHighlighted={highlightedResearchKpiIds.includes(researchKpiCard.id)}
           />
         ))}
@@ -384,33 +431,21 @@ function WebsiteKpiDashboardPage() {
     }
   };
 
-  const syncStatusText = websiteKpisRefreshError
-    ? websiteKpisRefreshError
-    : isRefreshingWebsiteKpis
-    ? "Syncing live KPI data..."
-    : lastWebsiteKpiRefreshAt > 0
-    ? `Live updates every 60 seconds. Last synced ${formatWebsiteKpiSyncTime(
-        lastWebsiteKpiRefreshAt
-      )}`
-    : "Live updates start after the first KPI response.";
-
   const renderKpiContent = () => {
     if (websiteKpisError) {
       return (
-          <div className={`${styles.stateCard} ${styles.errorState}`}>
-            <p>{websiteKpisError}</p>
-            <div className={styles.buttonRow}>
-              <button type="button" className={styles.primaryButton} onClick={() => void loadWebsiteKpis()}>
-                Try again
-              </button>
-            </div>
+        <div className={`${styles.stateCard} ${styles.errorState}`}>
+          <p>{websiteKpisError}</p>
+          <div className={styles.buttonRow}>
+            <button type="button" className={styles.primaryButton} onClick={() => void loadWebsiteKpis()}>
+              Try again
+            </button>
           </div>
-        );
+        </div>
+      );
     }
 
-    return (
-      renderSelectedKpiView()
-    );
+    return renderSelectedKpiView();
   };
 
   return (
@@ -473,11 +508,7 @@ function WebsiteKpiDashboardPage() {
                 disabled={isLoadingWebsiteKpis || isRefreshingWebsiteKpis}
               >
                 <RefreshOutlinedIcon fontSize="small" />
-                {isLoadingWebsiteKpis
-                  ? "Loading..."
-                  : isRefreshingWebsiteKpis
-                  ? "Syncing..."
-                  : "Refresh data"}
+                {refreshButtonLabel}
               </button>
             </div>
 

--- a/frontend/web/src/features/hostdashboard/website/websiteDeleteReasons.js
+++ b/frontend/web/src/features/hostdashboard/website/websiteDeleteReasons.js
@@ -1,0 +1,8 @@
+export const WEBSITE_DRAFT_DELETE_REASONS = Object.freeze([
+  "I no longer need this website.",
+  "I built it for the wrong listing.",
+  "The imported content does not look right.",
+  "I want to try a different template.",
+  "I prefer to manage bookings without a standalone website.",
+  "Other",
+]);


### PR DESCRIPTION
feat(website-kpis): kpis refresh automatically every 60 seconds, importing available data

KPIs refresh automatically every 60 seconds
adjustments to frontend. moved/split kpis in corresponding tabs