### PR TITLE
Changes regarding the co host functionality

### DIFF
--- a/backend/functions/property-tasks/auth/authManager.js
+++ b/backend/functions/property-tasks/auth/authManager.js
@@ -5,15 +5,24 @@ const cognitoClient = new CognitoIdentityProviderClient({ region: "eu-north-1" }
 
 export class AuthManager {
 
-    async getHostId(accessToken) {
+    async getUser(accessToken) {
         if (!accessToken) {
             throw new UnauthorizedException("No authorization token provided.");
         }
         try {
             const result = await cognitoClient.send(new GetUserCommand({ AccessToken: accessToken }));
-            return result.Username;
+            const attrs = Object.fromEntries(result.UserAttributes.map(a => [a.Name, a.Value]));
+            return {
+                username: result.Username,
+                role: attrs["custom:group"] || null,
+            };
         } catch {
             throw new UnauthorizedException("Invalid or expired authorization token.");
         }
+    }
+
+    async getHostId(accessToken) {
+        const { username } = await this.getUser(accessToken);
+        return username;
     }
 }

--- a/backend/functions/property-tasks/business/service/pomService.js
+++ b/backend/functions/property-tasks/business/service/pomService.js
@@ -1,0 +1,35 @@
+import Database from "database";
+import { Team_Member } from "database/models/Team_Member";
+import { UnauthorizedException } from "../../util/exception/unauthorizedException.js";
+
+const OWN_HOST_ROLES = ["Admin", "Host", "General Manager", "Reservation Manager",
+    "Guest Experience Manager", "Financial Manager", "Distribution Manager",
+    "Revenue Manager", "Sales Manager"];
+
+export const resolveEffectiveHostId = async (callerUsername, callerRole, asHostId) => {
+    const dataSource = await Database.getInstance();
+    const repo = dataSource.getRepository(Team_Member);
+
+    if (asHostId) {
+
+        const membership = await repo.findOne({
+            where: { member_user_id: callerUsername, host_id: asHostId, status: "active" },
+        });
+        if (!membership) {
+            throw new UnauthorizedException("You are not a co-host for this host.");
+        }
+        return { effectiveHostId: asHostId, isPOM: true };
+    }
+
+    if (OWN_HOST_ROLES.includes(callerRole)) {
+        return { effectiveHostId: callerUsername, isPOM: false };
+    }
+
+    const membership = await repo.findOne({
+        where: { member_user_id: callerUsername, status: "active" },
+    });
+    return {
+        effectiveHostId: membership ? membership.host_id : callerUsername,
+        isPOM: !!membership,
+    };
+};

--- a/backend/functions/property-tasks/business/service/pomService.js
+++ b/backend/functions/property-tasks/business/service/pomService.js
@@ -2,16 +2,15 @@ import Database from "database";
 import { Team_Member } from "database/models/Team_Member";
 import { UnauthorizedException } from "../../util/exception/unauthorizedException.js";
 
-const OWN_HOST_ROLES = ["Admin", "Host", "General Manager", "Reservation Manager",
+const OWN_HOST_ROLES = new Set(["Admin", "Host", "General Manager", "Reservation Manager",
     "Guest Experience Manager", "Financial Manager", "Distribution Manager",
-    "Revenue Manager", "Sales Manager"];
+    "Revenue Manager", "Sales Manager"]);
 
 export const resolveEffectiveHostId = async (callerUsername, callerRole, asHostId) => {
     const dataSource = await Database.getInstance();
     const repo = dataSource.getRepository(Team_Member);
 
     if (asHostId) {
-
         const membership = await repo.findOne({
             where: { member_user_id: callerUsername, host_id: asHostId, status: "active" },
         });
@@ -21,7 +20,7 @@ export const resolveEffectiveHostId = async (callerUsername, callerRole, asHostI
         return { effectiveHostId: asHostId, isPOM: true };
     }
 
-    if (OWN_HOST_ROLES.includes(callerRole)) {
+    if (OWN_HOST_ROLES.has(callerRole)) {
         return { effectiveHostId: callerUsername, isPOM: false };
     }
 

--- a/backend/functions/property-tasks/controller/controller.js
+++ b/backend/functions/property-tasks/controller/controller.js
@@ -18,7 +18,7 @@ export class Controller {
     async getTasks(event) {
         try {
             const { effectiveHostId } = await this.resolveHost(event);
-            const filters = { ...( event.queryStringParameters || {}) };
+            const filters = Object.assign({}, event.queryStringParameters);
             delete filters.asHostId;
             const tasks = await getTasks(effectiveHostId, filters);
             return { statusCode: 200, headers: responseHeaders, body: JSON.stringify(tasks) };

--- a/backend/functions/property-tasks/controller/controller.js
+++ b/backend/functions/property-tasks/controller/controller.js
@@ -1,5 +1,7 @@
 import { getTasks, createTask, updateTask, deleteTask, getUploadUrl, getViewUrl } from "../business/service/taskService.js";
+import { resolveEffectiveHostId } from "../business/service/pomService.js";
 import { AuthManager } from "../auth/authManager.js";
+import { UnauthorizedException } from "../util/exception/unauthorizedException.js";
 import responseHeaders from "../util/constant/responseHeader.json" with { type: "json" };
 
 export class Controller {
@@ -7,17 +9,19 @@ export class Controller {
         this.authManager = new AuthManager();
     }
 
+    async resolveHost(event) {
+        const { username, role } = await this.authManager.getUser(event.headers?.Authorization);
+        const asHostId = event.queryStringParameters?.asHostId || null;
+        return await resolveEffectiveHostId(username, role, asHostId);
+    }
+
     async getTasks(event) {
         try {
-            const hostId = await this.authManager.getHostId(event.headers?.Authorization);
-            const filters = event.queryStringParameters || {};
-
-            const tasks = await getTasks(hostId, filters);
-            return {
-                statusCode: 200,
-                headers: responseHeaders,
-                body: JSON.stringify(tasks)
-            };
+            const { effectiveHostId } = await this.resolveHost(event);
+            const filters = { ...( event.queryStringParameters || {}) };
+            delete filters.asHostId;
+            const tasks = await getTasks(effectiveHostId, filters);
+            return { statusCode: 200, headers: responseHeaders, body: JSON.stringify(tasks) };
         } catch (error) {
             return this.handleError(error);
         }
@@ -25,15 +29,10 @@ export class Controller {
 
     async createTask(event) {
         try {
-            const hostId = await this.authManager.getHostId(event.headers?.Authorization);
+            const { effectiveHostId } = await this.resolveHost(event);
             const taskData = JSON.parse(event.body);
-
-            const result = await createTask(hostId, taskData);
-            return {
-                statusCode: 201,
-                headers: responseHeaders,
-                body: JSON.stringify(result)
-            };
+            const result = await createTask(effectiveHostId, taskData);
+            return { statusCode: 201, headers: responseHeaders, body: JSON.stringify(result) };
         } catch (error) {
             return this.handleError(error);
         }
@@ -41,11 +40,10 @@ export class Controller {
 
     async updateTask(event) {
         try {
-            const hostId = await this.authManager.getHostId(event.headers?.Authorization);
+            const { effectiveHostId } = await this.resolveHost(event);
             const taskId = event.queryStringParameters?.id || event.pathParameters?.id;
             const updateData = JSON.parse(event.body);
-
-            const result = await updateTask(hostId, taskId, updateData);
+            const result = await updateTask(effectiveHostId, taskId, updateData);
             return { statusCode: 200, headers: responseHeaders, body: JSON.stringify(result) };
         } catch (error) {
             return this.handleError(error);
@@ -54,10 +52,10 @@ export class Controller {
 
     async deleteTask(event) {
         try {
-            const hostId = await this.authManager.getHostId(event.headers?.Authorization);
+            const { effectiveHostId, isPOM } = await this.resolveHost(event);
+            if (isPOM) throw new UnauthorizedException("Co-hosts cannot delete tasks.");
             const taskId = event.queryStringParameters?.id || event.pathParameters?.id;
-
-            const result = await deleteTask(hostId, taskId);
+            const result = await deleteTask(effectiveHostId, taskId);
             return { statusCode: 200, headers: responseHeaders, body: JSON.stringify(result) };
         } catch (error) {
             return this.handleError(error);
@@ -80,14 +78,12 @@ export class Controller {
 
     async getUploadUrl(event) {
         try {
-            const hostId = await this.authManager.getHostId(event.headers?.Authorization);
+            const { effectiveHostId } = await this.resolveHost(event);
             const { fileName, fileType } = event.queryStringParameters || {};
-
             if (!fileName || !fileType) {
                 return { statusCode: 400, headers: responseHeaders, body: JSON.stringify({ message: "fileName and fileType are required" }) };
             }
-
-            const result = await getUploadUrl(hostId, fileName, fileType);
+            const result = await getUploadUrl(effectiveHostId, fileName, fileType);
             return { statusCode: 200, headers: responseHeaders, body: JSON.stringify(result) };
         } catch (error) {
             return this.handleError(error);

--- a/backend/functions/property-tasks/controller/controller.js
+++ b/backend/functions/property-tasks/controller/controller.js
@@ -18,7 +18,7 @@ export class Controller {
     async getTasks(event) {
         try {
             const { effectiveHostId } = await this.resolveHost(event);
-            const filters = Object.assign({}, event.queryStringParameters);
+            const filters = { ...event.queryStringParameters };
             delete filters.asHostId;
             const tasks = await getTasks(effectiveHostId, filters);
             return { statusCode: 200, headers: responseHeaders, body: JSON.stringify(tasks) };

--- a/frontend/web/src/features/auth/UserContext.js
+++ b/frontend/web/src/features/auth/UserContext.js
@@ -10,6 +10,7 @@ export const UserProvider = ({ children }) => {
     const [user, setUser] = useState(null);
     const [role, setRole] = useState(null);
     const [isPOM, setIsPOM] = useState(false);
+    const [memberships, setMemberships] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
@@ -32,9 +33,11 @@ export const UserProvider = ({ children }) => {
         };
         const checkMemberships = async () => {
             try {
-                const memberships = await fetchMemberships();
-                setIsPOM(memberships.length > 0);
+                const result = await fetchMemberships();
+                setMemberships(Array.isArray(result) ? result : []);
+                setIsPOM(Array.isArray(result) && result.length > 0);
             } catch {
+                setMemberships([]);
                 setIsPOM(false);
             }
         };
@@ -45,8 +48,8 @@ export const UserProvider = ({ children }) => {
     const hasRole = (allowedRoles) => allowedRoles.includes(role);
 
     const contextValue = useMemo(
-        () => ({ user, role, isPOM, isLoading, hasRole }),
-        [user, role, isPOM, isLoading]
+        () => ({ user, role, isPOM, memberships, isLoading, hasRole }),
+        [user, role, isPOM, memberships, isLoading]
     );
 
     return (

--- a/frontend/web/src/features/auth/UserContext.js
+++ b/frontend/web/src/features/auth/UserContext.js
@@ -14,7 +14,7 @@ export const UserProvider = ({ children }) => {
     const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
-        const checkUser = async () => {
+        const initialize = async () => {
             try {
                 const userInfo = await Auth.currentAuthenticatedUser({ bypassCache: true });
                 if (userInfo && userInfo.attributes && 'custom:group' in userInfo.attributes) {
@@ -24,25 +24,24 @@ export const UserProvider = ({ children }) => {
                     setUser(userInfo);
                     setRole('Traveler');
                 }
+                try {
+                    const result = await fetchMemberships();
+                    setMemberships(Array.isArray(result) ? result : []);
+                    setIsPOM(Array.isArray(result) && result.length > 0);
+                } catch {
+                    setMemberships([]);
+                    setIsPOM(false);
+                }
             } catch {
                 setUser(null);
                 setRole(null);
+                setMemberships([]);
+                setIsPOM(false);
             } finally {
                 setIsLoading(false);
             }
         };
-        const checkMemberships = async () => {
-            try {
-                const result = await fetchMemberships();
-                setMemberships(Array.isArray(result) ? result : []);
-                setIsPOM(Array.isArray(result) && result.length > 0);
-            } catch {
-                setMemberships([]);
-                setIsPOM(false);
-            }
-        };
-        checkUser();
-        checkMemberships();
+        initialize();
     }, []);
 
     const hasRole = (allowedRoles) => allowedRoles.includes(role);

--- a/frontend/web/src/features/hostdashboard/AcceptInvite.js
+++ b/frontend/web/src/features/hostdashboard/AcceptInvite.js
@@ -40,13 +40,17 @@ const AcceptInvite = () => {
     }
 
     if (!user) {
+        const encodedRedirect = encodeURIComponent(`/team/accept?token=${token}`);
         return (
             <div className="accept-invite-page">
                 <div className="accept-invite-card">
                     <h2>You have been invited to a team on Domits</h2>
                     <p>Log in or create an account to accept this invitation.</p>
-                    <Link to={`/login?redirect=/team/accept?token=${token}`} className="accept-invite-btn">
+                    <Link to={`/login?redirect=${encodedRedirect}`} className="accept-invite-btn">
                         Log in to accept
+                    </Link>
+                    <Link to={`/register?redirect=${encodedRedirect}`} className="accept-invite-btn accept-invite-btn--secondary">
+                        Create account
                     </Link>
                 </div>
             </div>

--- a/frontend/web/src/features/hostdashboard/HostListings.js
+++ b/frontend/web/src/features/hostdashboard/HostListings.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Auth } from "aws-amplify";
 import PropTypes from "prop-types";
+import useEffectiveHostId from "../../hooks/useEffectiveHostId";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import styles from "./HostListings.module.scss";
@@ -108,25 +108,12 @@ HostListingCardActions.propTypes = {
 function HostListings() {
   const [accommodations, setAccommodations] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [userId, setUserId] = useState(null);
   const [activeFilter, setActiveFilter] = useState("ACTIVE");
   const [processingPropertyId, setProcessingPropertyId] = useState("");
   const navigate = useNavigate();
+  const { effectiveHostId: userId, ownId, managedHostId, isPurelyPOM } = useEffectiveHostId();
   const { liveEligibility, liveEligibilityError, liveEligibilityLoading, fetchVerificationStatus } =
-    useSetLiveEligibility({ userId });
-
-  useEffect(() => {
-    const setUserIdAsync = async () => {
-      try {
-        const userInfo = await Auth.currentUserInfo();
-        setUserId(userInfo?.attributes?.sub || null);
-      } catch {
-        setUserId(null);
-      }
-    };
-
-    setUserIdAsync();
-  }, []);
+    useSetLiveEligibility({ userId: ownId });
 
   useEffect(() => {
     if (userId) {
@@ -135,25 +122,46 @@ function HostListings() {
     }
   }, [fetchVerificationStatus, userId]);
 
+  const fetchFromByHostId = async (hostId) => {
+    const response = await fetch(
+      `https://wkmwpwurbc.execute-api.eu-north-1.amazonaws.com/default/bookingEngine/byHostId?hostId=${hostId}`,
+      { method: "GET", headers: { Authorization: getAccessToken() } }
+    );
+    if (!response.ok) return [];
+    const data = await response.json();
+    return Array.isArray(data) ? data : [];
+  };
+
   const fetchAccommodations = async () => {
     setIsLoading(true);
     try {
-      const response = await fetch(
-        "https://wkmwpwurbc.execute-api.eu-north-1.amazonaws.com/default/property/hostDashboard/all",
-        {
-          method: "GET",
-          headers: {
-            Authorization: getAccessToken(),
-          },
-        }
-      );
-      if (!response.ok) {
-        throw new Error("Failed to fetch host properties.");
+      let data = [];
+
+      if (isPurelyPOM) {
+        data = await fetchFromByHostId(userId);
+      } else if (managedHostId) {
+        const [ownResponse, managedResponse] = await Promise.all([
+          fetch(
+            "https://wkmwpwurbc.execute-api.eu-north-1.amazonaws.com/default/property/hostDashboard/all",
+            { method: "GET", headers: { Authorization: getAccessToken() } }
+          ),
+          fetchFromByHostId(managedHostId),
+        ]);
+        const ownData = ownResponse.ok ? await ownResponse.json() : [];
+        data = [...(Array.isArray(ownData) ? ownData : []), ...managedResponse];
+      } else {
+        const response = await fetch(
+          "https://wkmwpwurbc.execute-api.eu-north-1.amazonaws.com/default/property/hostDashboard/all",
+          { method: "GET", headers: { Authorization: getAccessToken() } }
+        );
+        if (!response.ok) throw new Error("Failed to fetch host properties.");
+        const raw = await response.json();
+        data = Array.isArray(raw) ? raw : [];
       }
-      const data = await response.json();
-      setAccommodations(Array.isArray(data) ? data : []);
+
+      setAccommodations(data);
     } catch (error) {
-      console.error("Unexpected error:", error);
+
       toast.error(error?.message || "Failed to load listings.");
     } finally {
       setIsLoading(false);
@@ -216,7 +224,6 @@ function HostListings() {
       toast.success(successMessage);
       await fetchAccommodations();
     } catch (error) {
-      console.error(error);
       toast.error(error?.message || "Failed to update listing status.");
     } finally {
       setProcessingPropertyId("");
@@ -268,7 +275,7 @@ function HostListings() {
           const propertyCity = accommodation?.location?.city || "Unknown city";
           const propertyImage = getListingImage(accommodation);
           const isBusy = processingPropertyId === propertyId;
-          const actions = LISTING_ACTIONS[propertyStatus] || [];
+          const actions = isPurelyPOM ? [] : (LISTING_ACTIONS[propertyStatus] || []);
           const handleListingActionClick = (action) => executeListingAction(action, propertyId);
 
           return (
@@ -325,9 +332,11 @@ function HostListings() {
             <div className={styles.hostListingContainer}>
               <div className={styles.listingBody}>
                 <div className={styles.buttonBox}>
-                  <button className={styles.greenBtn} onClick={() => navigate("/hostonboarding")}>
-                    Add new accommodation
-                  </button>
+                  {!isPurelyPOM && (
+                    <button className={styles.greenBtn} onClick={() => navigate("/hostonboarding")}>
+                      Add new accommodation
+                    </button>
+                  )}
                   <button className={styles.greenBtn} onClick={fetchAccommodations}>
                     Refresh
                   </button>

--- a/frontend/web/src/features/hostdashboard/HostTeam.js
+++ b/frontend/web/src/features/hostdashboard/HostTeam.js
@@ -13,6 +13,7 @@ const HostTeam = () => {
     const [inviteRole, setInviteRole] = useState("Property Operations Manager");
     const [inviteSent, setInviteSent] = useState(false);
     const [inviteError, setInviteError] = useState("");
+    const [loadError, setLoadError] = useState(false);
 
     useEffect(() => {
         const loadHost = async () => {
@@ -35,7 +36,7 @@ const HostTeam = () => {
     useEffect(() => {
         fetchTeamMembers()
             .then(setMembers)
-            .catch(() => {});
+            .catch(() => setLoadError(true));
     }, []);
 
     useEffect(() => {
@@ -135,7 +136,11 @@ const HostTeam = () => {
                     </button>
                 </div>
 
-                {members.length === 0 ? (
+                {loadError ? (
+                    <div className="team-empty-state">
+                        <p>Failed to load team members. Please refresh the page.</p>
+                    </div>
+                ) : members.length === 0 ? (
                     <div className="team-empty-state">
                         <p>No additional team members yet. Invite a co-host to get started.</p>
                     </div>

--- a/frontend/web/src/features/hostdashboard/HostTeam.js
+++ b/frontend/web/src/features/hostdashboard/HostTeam.js
@@ -74,6 +74,52 @@ const HostTeam = () => {
         }
     };
 
+    const renderMemberList = () => {
+        if (loadError) {
+            return (
+                <div className="team-empty-state">
+                    <p>Failed to load team members. Please refresh the page.</p>
+                </div>
+            );
+        }
+        if (members.length === 0) {
+            return (
+                <div className="team-empty-state">
+                    <p>No additional team members yet. Invite a co-host to get started.</p>
+                </div>
+            );
+        }
+        return (
+            <div className="team-card">
+                {members.map(member => (
+                    <div key={member.id} className="team-member-row team-member-row--bordered">
+                        <img
+                            src={standardAvatar}
+                            alt="Member avatar"
+                            className="team-member-avatar"
+                        />
+                        <div className="team-member-info">
+                            <div className="team-member-name">
+                                {member.member_email}
+                                <span className="team-role-badge">{member.role}</span>
+                                <span className={`team-status-badge team-status-badge--${member.status}`}>
+                                    {member.status}
+                                </span>
+                            </div>
+                        </div>
+                        <button
+                            className="team-remove-btn"
+                            onClick={() => handleRemove(member.id)}
+                            aria-label={`Remove ${member.member_email}`}
+                        >
+                            ✕
+                        </button>
+                    </div>
+                ))}
+            </div>
+        );
+    };
+
     return (
         <div className="page-body settings-page team-page">
             <nav className="settings-subnav">
@@ -136,43 +182,7 @@ const HostTeam = () => {
                     </button>
                 </div>
 
-                {loadError ? (
-                    <div className="team-empty-state">
-                        <p>Failed to load team members. Please refresh the page.</p>
-                    </div>
-                ) : members.length === 0 ? (
-                    <div className="team-empty-state">
-                        <p>No additional team members yet. Invite a co-host to get started.</p>
-                    </div>
-                ) : (
-                    <div className="team-card">
-                        {members.map(member => (
-                            <div key={member.id} className="team-member-row team-member-row--bordered">
-                                <img
-                                    src={standardAvatar}
-                                    alt="Member avatar"
-                                    className="team-member-avatar"
-                                />
-                                <div className="team-member-info">
-                                    <div className="team-member-name">
-                                        {member.member_email}
-                                        <span className="team-role-badge">{member.role}</span>
-                                        <span className={`team-status-badge team-status-badge--${member.status}`}>
-                                            {member.status}
-                                        </span>
-                                    </div>
-                                </div>
-                                <button
-                                    className="team-remove-btn"
-                                    onClick={() => handleRemove(member.id)}
-                                    aria-label={`Remove ${member.member_email}`}
-                                >
-                                    ✕
-                                </button>
-                            </div>
-                        ))}
-                    </div>
-                )}
+                {renderMemberList()}
             </section>
 
             {showInviteModal && (

--- a/frontend/web/src/features/hostdashboard/Housekeeping.css
+++ b/frontend/web/src/features/hostdashboard/Housekeeping.css
@@ -23,6 +23,38 @@
     margin: 0;
 }
 
+.top-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.task-context-toggle {
+    display: flex;
+    background: #f3f4f6;
+    border-radius: 8px;
+    padding: 3px;
+    gap: 2px;
+}
+
+.task-context-btn {
+    background: transparent;
+    border: none;
+    border-radius: 6px;
+    padding: 6px 14px;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: #6b7280;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+}
+
+.task-context-btn.active {
+    background: #fff;
+    color: #111827;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+
 
 .btn-create-green {
     background-color: #1e7e34; 

--- a/frontend/web/src/features/hostdashboard/Housekeeping.js
+++ b/frontend/web/src/features/hostdashboard/Housekeeping.js
@@ -167,7 +167,7 @@ const matchesTaskFilters = (
 };
 
 const HostPropertyCare = () => {
-    const { managedHostId, isPurelyPOM } = useEffectiveHostId();
+    const { effectiveHostId, managedHostId, isPurelyPOM } = useEffectiveHostId();
 
     const [taskContext, setTaskContext] = useState('own');
     const asHostId = taskContext === 'managed' ? managedHostId : null;
@@ -378,8 +378,9 @@ const HostPropertyCare = () => {
     }, [tasks, filters, timeView]);
 
     useEffect(() => {
-        fetchHostTaskPropertyOptions().then(setPropertyOptions);
-    }, []);
+        const hostIdForOptions = asHostId ?? effectiveHostId;
+        fetchHostTaskPropertyOptions(hostIdForOptions).then(setPropertyOptions);
+    }, [asHostId, effectiveHostId]);
     
     const handleToggleComplete = async (task) => {
         const now = new Date().toLocaleString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });

--- a/frontend/web/src/features/hostdashboard/Housekeeping.js
+++ b/frontend/web/src/features/hostdashboard/Housekeeping.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Auth } from 'aws-amplify';
+import useEffectiveHostId from '../../hooks/useEffectiveHostId';
 import {
     LuClipboardList, LuCircleAlert, LuRefreshCw, LuCircleCheck,
     LuSearch, LuChevronRight, LuTriangleAlert, LuX, LuCheck, LuPartyPopper
@@ -166,7 +167,12 @@ const matchesTaskFilters = (
 };
 
 const HostPropertyCare = () => {
-    const [activeTab, setActiveTab] = useState('Overview'); 
+    const { managedHostId, isPurelyPOM } = useEffectiveHostId();
+
+    const [taskContext, setTaskContext] = useState('own');
+    const asHostId = taskContext === 'managed' ? managedHostId : null;
+
+    const [activeTab, setActiveTab] = useState('Overview');
     const [tasks, setTasks] = useState([]);
     const [stats, setStats] = useState({ total: 0, overdue: 0, overdueIncrease: 0, inProgress: 0, completedToday: 0 });
     const [isModalOpen, setIsModalOpen] = useState(false);
@@ -403,7 +409,7 @@ const HostPropertyCare = () => {
 
     useEffect(() => {
         loadData();
-    }, []);
+    }, [asHostId]);
 
     useEffect(() => {
         setCurrentPage(1);
@@ -430,7 +436,7 @@ const HostPropertyCare = () => {
 
     const loadData = async () => {
         setIsLoading(true);
-        const data = await fetchTasks();
+        const data = await fetchTasks({}, asHostId);
         
         const todayStr = new Date().toISOString().split('T')[0];
         const processedTasks = data.map(task => {
@@ -1409,9 +1415,27 @@ const HostPropertyCare = () => {
         <main className="task-dashboard-v2">
             <div className="top-header">
                 <h2>Tasks</h2>
-                <button className="btn-create-green btn-create-desktop" onClick={() => setIsModalOpen(true)}>
-                    + Create Task
-                </button>
+                <div className="top-header-actions">
+                    {managedHostId && !isPurelyPOM && (
+                        <div className="task-context-toggle">
+                            <button
+                                className={`task-context-btn ${taskContext === 'own' ? 'active' : ''}`}
+                                onClick={() => setTaskContext('own')}
+                            >
+                                My tasks
+                            </button>
+                            <button
+                                className={`task-context-btn ${taskContext === 'managed' ? 'active' : ''}`}
+                                onClick={() => setTaskContext('managed')}
+                            >
+                                Co-host tasks
+                            </button>
+                        </div>
+                    )}
+                    <button className="btn-create-green btn-create-desktop" onClick={() => setIsModalOpen(true)}>
+                        + Create Task
+                    </button>
+                </div>
             </div>
 
             <button className="btn-create-fab" onClick={() => setIsModalOpen(true)} aria-label="Create Task">

--- a/frontend/web/src/features/hostdashboard/hooks/useHostDashboardData.js
+++ b/frontend/web/src/features/hostdashboard/hooks/useHostDashboardData.js
@@ -229,7 +229,7 @@ export default function useHostDashboardData() {
       }));
 
       const [listingsResult, revenueResult, bookedNightsResult, availableNightsResult] = await Promise.allSettled([
-        fetchHostPropertySelectOptions(),
+        fetchHostPropertySelectOptions(hostId),
         HostRevenueService.getRevenue(hostId),
         HostRevenueService.getBookedNights(hostId),
         HostRevenueService.getAvailableNights(hostId),

--- a/frontend/web/src/features/hostdashboard/services/hostTaskPropertyService.js
+++ b/frontend/web/src/features/hostdashboard/services/hostTaskPropertyService.js
@@ -105,19 +105,29 @@ const fetchListingsByHostId = async ({ hostId, token }) => {
     return Array.isArray(data) ? data : [];
 };
 
-const fetchHostOwnedListings = async () => {
+const fetchHostOwnedListings = async (effectiveHostId) => {
     const token = getAccessToken();
     if (!token) {
         throw new Error("You must be signed in to load your listings.");
     }
 
-    const hostId = getCognitoUserId();
+    const ownId = getCognitoUserId();
+    const isPOM = effectiveHostId && effectiveHostId !== ownId;
+
+    if (isPOM) {
+        const fallbackListings = await fetchListingsByHostId({ hostId: effectiveHostId, token });
+        if (fallbackListings !== null) {
+            return fallbackListings;
+        }
+        return [];
+    }
+
     const primaryResult = await fetchListingsFromHostDashboard(token);
     if (primaryResult.listings !== null) {
         return primaryResult.listings;
     }
 
-    const fallbackListings = await fetchListingsByHostId({ hostId, token });
+    const fallbackListings = await fetchListingsByHostId({ hostId: ownId, token });
     if (fallbackListings !== null) {
         return fallbackListings;
     }
@@ -125,14 +135,14 @@ const fetchHostOwnedListings = async () => {
     throw new Error("Failed to load your properties.");
 };
 
-export const fetchHostPropertySelectOptions = async () => {
-    const listings = await fetchHostOwnedListings();
+export const fetchHostPropertySelectOptions = async (effectiveHostId) => {
+    const listings = await fetchHostOwnedListings(effectiveHostId);
     return normalizePropertySelectOptions(listings);
 };
 
-export const fetchHostTaskPropertyOptions = async () => {
+export const fetchHostTaskPropertyOptions = async (effectiveHostId) => {
     try {
-        const propertyOptions = await fetchHostPropertySelectOptions();
+        const propertyOptions = await fetchHostPropertySelectOptions(effectiveHostId);
         return propertyOptions.map(({ value, label }) => ({ id: value, label }));
     } catch {
         return [];

--- a/frontend/web/src/features/hostdashboard/services/taskService.js
+++ b/frontend/web/src/features/hostdashboard/services/taskService.js
@@ -48,7 +48,7 @@ const toBackendPayload = (taskData) => {
     return payload;
 };
 
-export const fetchTasks = async (filters = {}) => {
+export const fetchTasks = async (filters = {}, asHostId = null) => {
     const params = new URLSearchParams();
     if (filters.propertyId) params.set("propertyId", filters.propertyId);
     if (filters.status && filters.status !== "All statuses") params.set("status", filters.status);
@@ -57,6 +57,7 @@ export const fetchTasks = async (filters = {}) => {
     if (filters.search) params.set("search", filters.search);
     if (filters.sortBy) params.set("sortBy", filters.sortBy);
     if (filters.sortDir) params.set("sortDir", filters.sortDir);
+    if (asHostId) params.set("asHostId", asHostId);
 
     const url = params.toString() ? `${TASKS_API_URL}?${params}` : TASKS_API_URL;
     const response = await fetch(url, { method: "GET", headers: getHeaders() });

--- a/frontend/web/src/hooks/useDashboardIdentity.js
+++ b/frontend/web/src/hooks/useDashboardIdentity.js
@@ -1,41 +1,31 @@
-import { useEffect, useState } from "react";
+import { useState, useEffect } from "react";
 import { Auth } from "aws-amplify";
 
 import { getDashboardDisplayName } from "../utils/dashboardShared";
+import useEffectiveHostId from "./useEffectiveHostId";
 
 export default function useDashboardIdentity(fallbackName) {
-  const [userId, setUserId] = useState(null);
+  const { effectiveHostId, loading: hostIdLoading } = useEffectiveHostId();
   const [displayName, setDisplayName] = useState(fallbackName);
-  const [loading, setLoading] = useState(true);
+  const [nameLoading, setNameLoading] = useState(true);
   const [error, setError] = useState(null);
 
   useEffect(() => {
     let isMounted = true;
 
-    const loadUser = async () => {
-      try {
-        const user = await Auth.currentAuthenticatedUser({ bypassCache: true });
-        if (!isMounted) {
-          return;
-        }
-
-        setUserId(user?.attributes?.sub || null);
+    Auth.currentAuthenticatedUser({ bypassCache: false })
+      .then((user) => {
+        if (!isMounted) return;
         setDisplayName(getDashboardDisplayName(user, fallbackName));
-        setLoading(false);
+        setNameLoading(false);
         setError(null);
-      } catch {
-        if (!isMounted) {
-          return;
-        }
-
-        setUserId(null);
+      })
+      .catch(() => {
+        if (!isMounted) return;
         setDisplayName(fallbackName);
-        setLoading(false);
+        setNameLoading(false);
         setError("Unable to load your dashboard.");
-      }
-    };
-
-    loadUser();
+      });
 
     return () => {
       isMounted = false;
@@ -43,9 +33,9 @@ export default function useDashboardIdentity(fallbackName) {
   }, [fallbackName]);
 
   return {
-    userId,
+    userId: effectiveHostId,
     displayName,
-    loading,
+    loading: hostIdLoading || nameLoading,
     error,
   };
 }

--- a/frontend/web/src/hooks/useEffectiveHostId.js
+++ b/frontend/web/src/hooks/useEffectiveHostId.js
@@ -1,0 +1,27 @@
+import { useState, useEffect } from "react";
+import { Auth } from "aws-amplify";
+import { useUser } from "../features/auth/UserContext";
+import { HOST_ROLES } from "../features/auth/roles";
+
+export default function useEffectiveHostId() {
+    const { role, isPOM, memberships, isLoading: userLoading } = useUser();
+    const [ownId, setOwnId] = useState(null);
+    const [idLoading, setIdLoading] = useState(true);
+
+    useEffect(() => {
+        Auth.currentAuthenticatedUser({ bypassCache: false })
+            .then((user) => setOwnId(user?.attributes?.sub || null))
+            .catch(() => setOwnId(null))
+            .finally(() => setIdLoading(false));
+    }, []);
+
+    const isHost = HOST_ROLES.includes(role);
+    const isPurelyPOM = isPOM && !isHost;
+    const managedHostId =
+        isPOM && Array.isArray(memberships) && memberships.length > 0
+            ? memberships[0].host_id
+            : null;
+    const effectiveHostId = isPurelyPOM ? (managedHostId ?? ownId) : ownId;
+
+    return { effectiveHostId, ownId, managedHostId, isPurelyPOM, loading: idLoading || userLoading };
+}

--- a/frontend/web/src/hooks/useEffectiveHostId.js
+++ b/frontend/web/src/hooks/useEffectiveHostId.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { Auth } from "aws-amplify";
 import { useUser } from "../features/auth/UserContext";
-import { HOST_ROLES } from "../features/auth/roles";
+import { ROLES } from "../features/auth/roles";
 
 export default function useEffectiveHostId() {
     const { role, isPOM, memberships, isLoading: userLoading } = useUser();
@@ -15,12 +15,13 @@ export default function useEffectiveHostId() {
             .finally(() => setIdLoading(false));
     }, []);
 
-    const isHost = HOST_ROLES.includes(role);
-    const isPurelyPOM = isPOM && !isHost;
+    const isPurelyPOM = isPOM && role === ROLES.PROPERTY_OPERATIONS_MANAGER;
+
     const managedHostId =
         isPOM && Array.isArray(memberships) && memberships.length > 0
             ? memberships[0].host_id
             : null;
+
     const effectiveHostId = isPurelyPOM ? (managedHostId ?? ownId) : ownId;
 
     return { effectiveHostId, ownId, managedHostId, isPurelyPOM, loading: idLoading || userLoading };

--- a/frontend/web/src/styles/sass/pages/dashboard/settingsDashboard.css
+++ b/frontend/web/src/styles/sass/pages/dashboard/settingsDashboard.css
@@ -888,6 +888,13 @@ dialog.team-modal h3 {
     line-height: 1.5;
 }
 
+.accept-invite-card .accept-invite-btn {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    text-align: center;
+}
+
 .accept-invite-btn {
     display: inline-block;
     background: #15803d;
@@ -904,4 +911,15 @@ dialog.team-modal h3 {
 
 .accept-invite-btn:hover {
     background: #166534;
+}
+
+.accept-invite-btn--secondary {
+    background: transparent;
+    color: #15803d;
+    border: 1.5px solid #15803d;
+    margin-top: 8px;
+}
+
+.accept-invite-btn--secondary:hover {
+    background: #f0fdf4;
 }


### PR DESCRIPTION
## Close or Relate the Issue
[//]: # (Only if this should close the issue)
- Closes #

[//]: # (in the issue a reference will be added to this pr)
- Related Issue: #2390

## Proposed Changes
[//]: # (Add a detailed description of the changes here)
Description: This PR implements co-host (Property Operations Manager) data access for the host dashboard, building on the previously merged team invitation and acceptance flow.

Backend — property-tasks Lambda:

- authManager.js: Extended to return both username and role from Cognito, replacing the previous username-only response.
- controller/controller.js: Replaced direct getHostId calls with a new resolveHost() helper that resolves the effective host ID before every operation. Accepts an optional ?asHostId=<hostId> query param to allow Host+POM context switching. Co-hosts are blocked from deleting tasks (401 returned).
- business/service/pomService.js (new): Resolves the effective host ID for a given caller. Pure POMs (role Property Operations Manager) are redirected to their managed host's data. Users with own-host roles (Host, Admin, General Manager, etc.) always receive their own ID. An explicit asHostId param is accepted and verified against the team_member table before use.

Frontend — auth & identity:

- UserContext.js: Now fetches and stores the full memberships array (not just the isPOM boolean), making it available to all consumers.
- hooks/useEffectiveHostId.js (new): Centralised hook that resolves the effective host ID. Exposes effectiveHostId, ownId, managedHostId, and isPurelyPOM. A user with a host role is never treated as a pure POM, even if they also hold a team membership.
- hooks/useDashboardIdentity.js: Refactored to use useEffectiveHostId, so the main dashboard overview (revenue, occupancy, listing count, messages) automatically reflects the correct host's data for POMs.

Frontend — Listings (HostListings.js):

- Pure POMs see the managed host's listings via the /bookingEngine/byHostId endpoint.
- Hosts who are also POMs see both their own listings and the managed host's listings (fetched in parallel and merged).
- Management actions (publish, archive) and the "Add new accommodation" button are hidden for pure POMs.
hostTaskPropertyService.js: fetchHostPropertySelectOptions now accepts an optional effectiveHostId and uses the byHostId fallback endpoint when in POM mode, so dashboard listing counts are correct.

Frontend — Tasks (Housekeeping.js / taskService.js):

- fetchTasks accepts a new optional asHostId parameter, appended as a query string when present.
- For Host+POM users, a segmented toggle ("My tasks" / "Co-host tasks") appears in the task page header. Switching reloads tasks in the selected context.
- For pure POMs, tasks always load from the managed host with no toggle shown.
- CSS added in Housekeeping.css for the toggle and its container.

Frontend — Accept invite (AcceptInvite.js):

- Added a "Create account" button alongside the existing "Log in to accept" button for users who do not yet have a Domits account. Both links carry the encoded redirect back to the accept URL.
- settingsDashboard.css: Added styles for the secondary button variant and ensured invite-card buttons stack full-width.

Frontend — Team management (HostTeam.js):

The team member list now shows an explicit error message ("Failed to load team members. Please refresh the page.") instead of silently showing an empty list when the API call fails.

## Change Type
- [x] Bug fix
- [x] New feature
- [ ] Optimization
- [ ] Documentation update

## Change Size
[//]: # (Indicate the size of this change.)
[//]: # (Clarify under Refactoring which parts are moved/unchanged code, so the reviewer doesn’t review old logic.)
- [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
- [ ] Big change (+-max 1000)
- [ ] Small change (less than 300)

## Refactoring
Refactors following files, but didn't change the code. This is to avoid reviewing old logic.
- src/features/example.xx

## Evidence
- [ ] Screenshots or screen recording added for UI changes
- [ ] Before/after images added when relevant
- [ ] Images clearly show the implemented change
- [ ] Image quality is readable (no cropped or blurry evidence)

## Responsiveness
- [ ] UI checked on mobile
- [ ] UI checked on tablet
- [ ] UI checked on desktop
- [ ] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages
- [ ] NPM Packages installed
- [ ] NPM Packages removed
- [ ] NPM Packages updated
- [ ] Checked for vulnerabilities using "npm audit"

## Checklist
[//]: # (All boxes must be checked before merging.)
- [x] Pull request has at least 2 reviewers assigned
- [x] PR title is descriptive and includes issue number
- [x] Conventions
  - [x] No config files have been added (Amplify config, cache files)
  - [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  - [x] No global styling (see [#1691](https://github.com/domits1/Domits/issues/1691))
  - [x] No `console.log` left in code
  - [x] No commented-out code remains
- [ ] Testing
  - [ ] Code tested locally
  - [ ] Jest tests are included
  - [ ] Jest tests are passing

## Keep or delete my branch
- [ ] Delete my branch after merge
- [x] Keep my branch  
