### PR TITLE
fix(listing): keep cohost availability selection consistent

### DIFF
--- a/backend/functions/PropertyHandler/auth/authManager.js
+++ b/backend/functions/PropertyHandler/auth/authManager.js
@@ -6,6 +6,7 @@ import { CognitoRepository } from "../data/repository/cognitoRepository.js";
 import { PropertyRepository } from "../data/repository/propertyRepository.js";
 import { BookingRepository } from "../data/repository/bookingRepository.js";
 import { PropertyDraftRepository } from "../data/repository/propertyDraftRepository.js";
+import { TeamMemberRepository } from "../data/repository/teamMemberRepository.js";
 
 export class AuthManager {
 
@@ -13,12 +14,14 @@ export class AuthManager {
     propertyRepository;
     bookingRepository;
     propertyDraftRepository;
+    teamMemberRepository;
 
     constructor(dynamoDbClient, systemManagerRepository) {
         this.cognitoRepository = new CognitoRepository();
         this.propertyRepository = new PropertyRepository(dynamoDbClient, systemManagerRepository);
         this.bookingRepository = new BookingRepository(dynamoDbClient, systemManagerRepository);
         this.propertyDraftRepository = new PropertyDraftRepository(systemManagerRepository);
+        this.teamMemberRepository = new TeamMemberRepository();
     }
 
     async getAuthorizedUser(accessToken) {
@@ -50,6 +53,26 @@ export class AuthManager {
             throw new Forbidden("You must be the owner of the property to access it.")
         }
         return user.Username;
+    }
+
+    async authorizePropertyCalendarOverrideRequest(accessToken, id) {
+        const user = await this.getAuthorizedUser(accessToken);
+        const property = await this.propertyRepository.getPropertyById(id)
+        if (!property) {
+            throw new NotFoundException("Property not found.")
+        }
+        if (property.hostId === user.Username) {
+            return property.hostId;
+        }
+
+        const membership = await this.teamMemberRepository.findActiveMembershipByMemberAndHost(
+            user.Username,
+            property.hostId
+        );
+        if (!membership) {
+            throw new Forbidden("You must be the owner or an active co-host of the property to access it.")
+        }
+        return property.hostId;
     }
 
     async authorizeDraftOwnerRequest(accessToken, draftId) {

--- a/backend/functions/PropertyHandler/controller/propertyController.js
+++ b/backend/functions/PropertyHandler/controller/propertyController.js
@@ -533,7 +533,7 @@ export class PropertyController {
             }
 
             const normalizedRange = this.normalizeCalendarOverrideRangePayload(query);
-            await this.authManager.authorizeOwnerRequest(accessToken, propertyId);
+            await this.authManager.authorizePropertyCalendarOverrideRequest(accessToken, propertyId);
 
             const overrides = await this.propertyService.getPropertyCalendarOverrides(propertyId, normalizedRange);
             return {
@@ -578,7 +578,7 @@ export class PropertyController {
             }
 
             const normalizedRange = this.normalizeCalendarOverrideRangePayload(body);
-            const hostId = await this.authManager.authorizeOwnerRequest(accessToken, propertyId);
+            const hostId = await this.authManager.authorizePropertyCalendarOverrideRequest(accessToken, propertyId);
 
             const overrides = await this.propertyService.updatePropertyCalendarOverrides(
                 propertyId,

--- a/backend/functions/PropertyHandler/data/repository/teamMemberRepository.js
+++ b/backend/functions/PropertyHandler/data/repository/teamMemberRepository.js
@@ -1,0 +1,17 @@
+import Database from "database";
+import { Team_Member } from "database/models/Team_Member";
+
+export class TeamMemberRepository {
+    async findActiveMembershipByMemberAndHost(memberUserId, hostId) {
+        const dataSource = await Database.getInstance();
+        return await dataSource
+            .getRepository(Team_Member)
+            .findOne({
+                where: {
+                    member_user_id: memberUserId,
+                    host_id: hostId,
+                    status: "active",
+                },
+            });
+    }
+}

--- a/backend/test/PropertyHandler/calendar-overrides-unit.test.js
+++ b/backend/test/PropertyHandler/calendar-overrides-unit.test.js
@@ -1,5 +1,38 @@
-import { describe, expect, it } from "@jest/globals";
+import { describe, expect, it, jest } from "@jest/globals";
+import { AuthManager } from "../../functions/PropertyHandler/auth/authManager.js";
 import { PropertyController } from "../../functions/PropertyHandler/controller/propertyController.js";
+
+const buildAuthManager = ({ username = "caller-user", property, membership = null }) => {
+  const authManager = new AuthManager();
+  authManager.getAuthorizedUser = jest.fn().mockResolvedValue({ Username: username });
+  authManager.propertyRepository = {
+    getPropertyById: jest.fn().mockResolvedValue(property),
+  };
+  authManager.teamMemberRepository = {
+    findActiveMembershipByMemberAndHost: jest.fn().mockResolvedValue(membership),
+  };
+  return authManager;
+};
+
+const buildCalendarController = ({ authorizeResult = "owner-host", authorizeError = null } = {}) => {
+  const controller = new PropertyController();
+  controller.authManager = {
+    authorizePropertyCalendarOverrideRequest: authorizeError
+      ? jest.fn().mockRejectedValue(authorizeError)
+      : jest.fn().mockResolvedValue(authorizeResult),
+  };
+  controller.propertyService = {
+    getPropertyCalendarOverrides: jest.fn().mockResolvedValue([{ date: 20260610, isAvailable: true }]),
+    updatePropertyCalendarOverrides: jest.fn().mockResolvedValue([{ date: 20260610, isAvailable: true }]),
+  };
+  return controller;
+};
+
+const forbiddenError = (message = "Forbidden") => {
+  const error = new Error(message);
+  error.statusCode = 403;
+  return error;
+};
 
 describe("PropertyController calendar override normalization", () => {
   it("normalizes per-date restriction fields to camelCase values", () => {
@@ -73,5 +106,93 @@ describe("PropertyController calendar override normalization", () => {
         },
       ])
     ).toThrow("Calendar override minStay must be a number greater than or equal to 0.");
+  });
+});
+
+describe("Property calendar override authorization", () => {
+  it("allows the property owner to edit calendar overrides", async () => {
+    const authManager = buildAuthManager({
+      username: "owner-host",
+      property: { id: "property-1", hostId: "owner-host" },
+    });
+
+    await expect(authManager.authorizePropertyCalendarOverrideRequest("token", "property-1")).resolves.toBe(
+      "owner-host"
+    );
+    expect(authManager.teamMemberRepository.findActiveMembershipByMemberAndHost).not.toHaveBeenCalled();
+  });
+
+  it("allows an active cohost for the property owner to edit calendar overrides", async () => {
+    const authManager = buildAuthManager({
+      username: "cohost-user",
+      property: { id: "property-1", hostId: "owner-host" },
+      membership: { id: "membership-1", status: "active" },
+    });
+
+    await expect(authManager.authorizePropertyCalendarOverrideRequest("token", "property-1")).resolves.toBe(
+      "owner-host"
+    );
+    expect(authManager.teamMemberRepository.findActiveMembershipByMemberAndHost).toHaveBeenCalledWith(
+      "cohost-user",
+      "owner-host"
+    );
+  });
+
+  it("rejects users without owner or active cohost access", async () => {
+    const authManager = buildAuthManager({
+      username: "other-user",
+      property: { id: "property-1", hostId: "owner-host" },
+    });
+
+    await expect(authManager.authorizePropertyCalendarOverrideRequest("token", "property-1")).rejects.toThrow(
+      "You must be the owner or an active co-host of the property to access it."
+    );
+  });
+
+  it("uses calendar override authorization for GET and PATCH requests", async () => {
+    const controller = buildCalendarController();
+    const getResponse = await controller.getPropertyCalendarOverrides({
+      headers: { Authorization: "token" },
+      queryStringParameters: { propertyId: "property-1" },
+    });
+    const patchResponse = await controller.updatePropertyCalendarOverrides({
+      headers: { Authorization: "token" },
+      body: JSON.stringify({
+        propertyId: "property-1",
+        overrides: [{ date: 20260610, isAvailable: true }],
+      }),
+    });
+
+    expect(getResponse.statusCode).toBe(200);
+    expect(patchResponse.statusCode).toBe(200);
+    expect(controller.authManager.authorizePropertyCalendarOverrideRequest).toHaveBeenCalledTimes(2);
+    expect(controller.propertyService.updatePropertyCalendarOverrides).toHaveBeenCalledWith(
+      "property-1",
+      [
+        expect.objectContaining({
+          calendarDate: 20260610,
+          isAvailable: true,
+        }),
+      ],
+      {}
+    );
+  });
+
+  it("keeps unauthorized calendar override requests forbidden", async () => {
+    const controller = buildCalendarController({
+      authorizeError: forbiddenError("You must be the owner or an active co-host of the property to access it."),
+    });
+
+    const response = await controller.updatePropertyCalendarOverrides({
+      headers: { Authorization: "token" },
+      body: JSON.stringify({
+        propertyId: "property-1",
+        overrides: [{ date: 20260610, isAvailable: true }],
+      }),
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(JSON.parse(response.body)).toBe("You must be the owner or an active co-host of the property to access it.");
+    expect(controller.propertyService.updatePropertyCalendarOverrides).not.toHaveBeenCalled();
   });
 });

--- a/frontend/web/src/features/hostdashboard/hostproperty/components/HostPropertyAvailabilityTab.test.js
+++ b/frontend/web/src/features/hostdashboard/hostproperty/components/HostPropertyAvailabilityTab.test.js
@@ -4,6 +4,8 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { createInitialPricingForm } from "../constants";
 import { HostPropertyAvailabilityTab, HostPropertyTabContent } from "./HostPropertyTabContent";
+import { fetchPropertyAndListings } from "../services/hostPropertyApi";
+import { extractFetchedPropertyData } from "../utils/hostPropertyUtils";
 import { getAccessToken } from "../../../../services/getAccessToken";
 
 jest.mock("../../../../services/getAccessToken", () => ({
@@ -13,6 +15,14 @@ jest.mock("../../../../services/getAccessToken", () => ({
 const okJsonResponse = (body) => ({
   ok: true,
   json: async () => body,
+});
+
+const propertyResponse = ({ id, title, status = "INACTIVE" }) => ({
+  property: { id, title, status },
+});
+
+const hostListingResponse = ({ id, title, status = "INACTIVE" }) => ({
+  property: { id, title, status },
 });
 
 const renderAvailabilityTab = (props = {}) =>
@@ -172,7 +182,7 @@ describe("HostPropertyAvailabilityTab", () => {
 
     expect(
       screen.getByRole("gridcell", {
-        name: /2026-06-10, Outside listing window/i,
+        name: /2026-06-10, Outside base window/i,
       })
     ).toBeInTheDocument();
   });
@@ -254,6 +264,29 @@ describe("HostPropertyAvailabilityTab", () => {
     expect(await screen.findByText(/2 dates marked available/i)).toBeInTheDocument();
   });
 
+  test("saves an outside-window available override to the current editor listing", async () => {
+    mockOverrideLoadThenSave({
+      savedOverrides: [{ date: 20260610, isAvailable: true }],
+    });
+
+    renderAvailabilityTab({
+      propertyId: "cohost-draft-listing",
+      listingTitle: "Cohost draft",
+    });
+
+    await saveAvailabilityRange({
+      startDate: "2026-06-10",
+      endDate: "2026-06-10",
+      availability: "available",
+    });
+
+    await expectCalendarOverridePatch({
+      propertyId: "cohost-draft-listing",
+      overrides: [{ date: 20260610, isAvailable: true }],
+    });
+    expect(await screen.findByText(/1 date marked available/i)).toBeInTheDocument();
+  });
+
   test("denies access safely when the host token is missing", async () => {
     getAccessToken.mockReturnValue("");
 
@@ -261,5 +294,56 @@ describe("HostPropertyAvailabilityTab", () => {
 
     expect(await screen.findByText("Sign in again to load availability.")).toBeInTheDocument();
     expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("Listing Editor cohost availability context", () => {
+  beforeEach(() => {
+    getAccessToken.mockReturnValue("test-token");
+    globalThis.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    delete globalThis.fetch;
+  });
+
+  test("keeps owner listings selectable when the opened editor listing is managed through a cohost context", async () => {
+    globalThis.fetch
+      .mockResolvedValueOnce(okJsonResponse(propertyResponse({ id: "cohost-listing", title: "Cohost draft" })))
+      .mockResolvedValueOnce(okJsonResponse([hostListingResponse({ id: "owner-listing", title: "Owner listing" })]))
+      .mockResolvedValueOnce(okJsonResponse([hostListingResponse({ id: "cohost-listing", title: "Cohost draft" })]));
+
+    const { data, hostPropertiesData } = await fetchPropertyAndListings("cohost-listing", "managed-host-id");
+    const fetchedPropertyData = extractFetchedPropertyData(data, hostPropertiesData);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/hostDashboard/single?property=cohost-listing"),
+      expect.objectContaining({ method: "GET" })
+    );
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/hostDashboard/all"),
+      expect.objectContaining({ method: "GET" })
+    );
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/hostDashboard/byHostId?hostId=managed-host-id"),
+      expect.objectContaining({ method: "GET" })
+    );
+    expect(fetchedPropertyData.hostProperties).toEqual([
+      { id: "owner-listing", title: "Owner listing", status: "INACTIVE" },
+      { id: "cohost-listing", title: "Cohost draft", status: "INACTIVE" },
+    ]);
+  });
+
+  test("uses the currently opened listing when the managed listing is not returned in the dropdown list", () => {
+    const fetchedPropertyData = extractFetchedPropertyData(
+      propertyResponse({ id: "cohost-listing", title: "Cohost draft" }),
+      [hostListingResponse({ id: "owner-listing", title: "Owner listing" })]
+    );
+
+    expect(fetchedPropertyData.hostProperties).toEqual([
+      { id: "cohost-listing", title: "Cohost draft", status: "INACTIVE" },
+      { id: "owner-listing", title: "Owner listing", status: "INACTIVE" },
+    ]);
   });
 });

--- a/frontend/web/src/features/hostdashboard/hostproperty/components/HostPropertyAvailabilityTab.test.js
+++ b/frontend/web/src/features/hostdashboard/hostproperty/components/HostPropertyAvailabilityTab.test.js
@@ -17,6 +17,12 @@ const okJsonResponse = (body) => ({
   json: async () => body,
 });
 
+const errorJsonResponse = (status, body) => ({
+  ok: false,
+  status,
+  json: async () => body,
+});
+
 const propertyResponse = ({ id, title, status = "INACTIVE" }) => ({
   property: { id, title, status },
 });
@@ -285,6 +291,33 @@ describe("HostPropertyAvailabilityTab", () => {
       overrides: [{ date: 20260610, isAvailable: true }],
     });
     expect(await screen.findByText(/1 date marked available/i)).toBeInTheDocument();
+  });
+
+  test("shows backend authorization errors when saving availability is denied", async () => {
+    globalThis.fetch
+      .mockResolvedValueOnce(okJsonResponse({ overrides: [] }))
+      .mockResolvedValueOnce(
+        errorJsonResponse(403, "You must be the owner or an active co-host of the property to access it.")
+      );
+
+    renderAvailabilityTab({
+      propertyId: "cohost-draft-listing",
+      listingTitle: "Cohost draft",
+    });
+
+    await saveAvailabilityRange({
+      startDate: "2026-06-10",
+      endDate: "2026-06-10",
+      availability: "available",
+    });
+
+    await expectCalendarOverridePatch({
+      propertyId: "cohost-draft-listing",
+      overrides: [{ date: 20260610, isAvailable: true }],
+    });
+    expect(
+      await screen.findByText("You must be the owner or an active co-host of the property to access it.")
+    ).toBeInTheDocument();
   });
 
   test("denies access safely when the host token is missing", async () => {

--- a/frontend/web/src/features/hostdashboard/hostproperty/components/HostPropertyTabContent.js
+++ b/frontend/web/src/features/hostdashboard/hostproperty/components/HostPropertyTabContent.js
@@ -164,6 +164,21 @@ const buildAvailabilityOverridePayload = ({ dateKeys, available }) => ({
     .filter(Boolean),
 });
 
+const resolveAvailabilityResponseError = async (response, fallbackMessage) => {
+  try {
+    const body = await response.json();
+    if (typeof body === "string" && body.trim()) {
+      return body.trim();
+    }
+    if (typeof body?.message === "string" && body.message.trim()) {
+      return body.message.trim();
+    }
+  } catch {
+    return fallbackMessage;
+  }
+  return fallbackMessage;
+};
+
 const getAvailabilityMonthCursor = (dateKey) =>
   startOfMonthUTC(keyToUtcDate(dateKey) || new Date());
 
@@ -1165,7 +1180,9 @@ export function HostPropertyAvailabilityTab({ propertyId, listingTitle, availabi
           },
         });
         if (!response.ok) {
-          throw new Error(`Could not load availability overrides (${response.status}).`);
+          throw new Error(
+            await resolveAvailabilityResponseError(response, `Could not load availability overrides (${response.status}).`)
+          );
         }
         const body = await response.json();
         if (mounted) {
@@ -1263,7 +1280,9 @@ export function HostPropertyAvailabilityTab({ propertyId, listingTitle, availabi
         }),
       });
       if (!response.ok) {
-        throw new Error(`Could not save availability override (${response.status}).`);
+        throw new Error(
+          await resolveAvailabilityResponseError(response, `Could not save availability override (${response.status}).`)
+        );
       }
       const body = await response.json();
       const confirmedOverrides = normalizeAvailabilityOverrideMap(body?.overrides);

--- a/frontend/web/src/features/hostdashboard/hostproperty/components/HostPropertyTabContent.js
+++ b/frontend/web/src/features/hostdashboard/hostproperty/components/HostPropertyTabContent.js
@@ -146,7 +146,7 @@ const resolveAvailabilityLabel = ({ dateKey, availabilityOverrides, availability
 
   const dateNumber = keyToDateNumber(dateKey);
   const isInBaseWindow = availabilityRanges.some((range) => dateNumber >= range.start && dateNumber <= range.end);
-  return isInBaseWindow ? "Available from listing window" : "Unavailable outside listing window";
+  return isInBaseWindow ? "Available from listing window" : "Unavailable outside base window";
 };
 
 const buildAvailabilityOverridePayload = ({ dateKeys, available }) => ({
@@ -186,7 +186,7 @@ const resolveAvailabilityDetails = ({ dateKey, availabilityOverrides, availabili
   const isInBaseWindow = availabilityRanges.some((range) => dateNumber >= range.start && dateNumber <= range.end);
   return isInBaseWindow
     ? { label: "Available", tone: "available" }
-    : { label: "Outside listing window", tone: "outside" };
+    : { label: "Outside base window", tone: "outside" };
 };
 
 function ToggleSwitch({ checked, onChange, disabled }) {
@@ -1382,7 +1382,7 @@ export function HostPropertyAvailabilityTab({ propertyId, listingTitle, availabi
           </span>
           <span className={styles.availabilityLegendItem}>
             <span className={`${styles.availabilityLegendSwatch} ${styles.availabilityLegendOutside}`} />
-            <span>Outside window</span>
+            <span>Outside base window</span>
           </span>
           <span className={styles.availabilityLegendItem}>
             <span className={`${styles.availabilityLegendSwatch} ${styles.availabilityLegendBlocked}`} />
@@ -1436,6 +1436,7 @@ export function HostPropertyAvailabilityTab({ propertyId, listingTitle, availabi
       </p>
       <p className={styles.pricingHint}>
         Active bookings and imported external bookings still block availability even if a date is marked available here.
+        Marking an outside-window date available saves an explicit available override.
       </p>
 
       <button

--- a/frontend/web/src/features/hostdashboard/hostproperty/services/hostPropertyApi.js
+++ b/frontend/web/src/features/hostdashboard/hostproperty/services/hostPropertyApi.js
@@ -62,24 +62,38 @@ const getRestrictionValueWithFallbacks = (restrictionValueMap, restrictionName) 
   return matchedFallbackKey ? restrictionValueMap.get(matchedFallbackKey) : undefined;
 };
 
-export const fetchPropertyAndListings = async (propertyId, managedHostId = null) => {
-  const hostPropertiesUrl = managedHostId
-    ? `${PROPERTY_API_BASE}/hostDashboard/byHostId?hostId=${encodeURIComponent(managedHostId)}`
-    : `${PROPERTY_API_BASE}/hostDashboard/all`;
+const fetchHostPropertyOptions = async (url) => {
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      Authorization: getAccessToken(),
+    },
+  });
 
-  const [response, hostPropertiesResponse] = await Promise.all([
+  if (!response.ok) {
+    return [];
+  }
+
+  const data = await response.json();
+  return Array.isArray(data) ? data : [];
+};
+
+export const fetchPropertyAndListings = async (propertyId, managedHostId = null) => {
+  const hostPropertiesUrls = [`${PROPERTY_API_BASE}/hostDashboard/all`];
+  if (managedHostId) {
+    hostPropertiesUrls.push(
+      `${PROPERTY_API_BASE}/hostDashboard/byHostId?hostId=${encodeURIComponent(managedHostId)}`
+    );
+  }
+
+  const [response, ...hostPropertiesResults] = await Promise.all([
     fetch(`${PROPERTY_API_BASE}/hostDashboard/single?property=${encodeURIComponent(propertyId)}`, {
       method: "GET",
       headers: {
         Authorization: getAccessToken(),
       },
     }),
-    fetch(hostPropertiesUrl, {
-      method: "GET",
-      headers: {
-        Authorization: getAccessToken(),
-      },
-    }),
+    ...hostPropertiesUrls.map(fetchHostPropertyOptions),
   ]);
 
   if (!response.ok) {
@@ -87,7 +101,7 @@ export const fetchPropertyAndListings = async (propertyId, managedHostId = null)
   }
 
   const data = await response.json();
-  const hostPropertiesData = hostPropertiesResponse.ok ? await hostPropertiesResponse.json() : [];
+  const hostPropertiesData = hostPropertiesResults.flat();
   return { data, hostPropertiesData };
 };
 

--- a/frontend/web/src/features/hostdashboard/hostproperty/utils/hostPropertyUtils.js
+++ b/frontend/web/src/features/hostdashboard/hostproperty/utils/hostPropertyUtils.js
@@ -364,15 +364,23 @@ const findDetailValue = (generalDetails, key) => {
 };
 
 const mapHostProperties = (hostPropertiesData, property) => {
+  const mappedPropertyIds = new Set();
   const mappedHostProperties = (Array.isArray(hostPropertiesData) ? hostPropertiesData : [])
-    .map((accommodation) => ({
-      id: accommodation?.property?.id || "",
-      title: accommodation?.property?.title || "Untitled listing",
-      status: accommodation?.property?.status || "INACTIVE",
-    }))
-    .filter((accommodation) => Boolean(accommodation.id));
+    .map((accommodation) => {
+      const id = accommodation?.property?.id || "";
+      if (!id || mappedPropertyIds.has(id)) {
+        return null;
+      }
+      mappedPropertyIds.add(id);
+      return {
+        id,
+        title: accommodation?.property?.title || "Untitled listing",
+        status: accommodation?.property?.status || "INACTIVE",
+      };
+    })
+    .filter(Boolean);
 
-  if (property?.id && !mappedHostProperties.some((accommodation) => accommodation.id === property.id)) {
+  if (property?.id && !mappedPropertyIds.has(property.id)) {
     mappedHostProperties.unshift({
       id: property.id,
       title: property.title || "Untitled listing",


### PR DESCRIPTION
## Close or Relate the Issue

[//]: # "Only if this should close the issue"

* Closes: N/A

[//]: # "in the issue a reference will be added to this pr"

* Related Issue: N/A

## Proposed Changes

[//]: # "Add a detailed description of the changes here"

Description:

This PR fixes a cohost-related inconsistency in the Listing Editor availability flow.

This PR also fixes calendar override authorization for managed/cohost listings. The Listing Editor could already open the managed listing, but saving availability returned 403 because the calendar override endpoint only allowed the property owner. The backend now allows the property owner or an active cohost/team member linked to the property owner to GET/PATCH calendar overrides. Unauthorized users still receive 403.

Before this change, opening a managed/cohost draft listing could replace the Listing Editor dropdown list with only the managed host’s listings. This could make the signed-in user’s own listings disappear from the editor selector.

The Listing Editor now loads the signed-in user’s own listings and also loads the managed-host listings when a managed host context exists. The dropdown options are deduplicated, and the currently opened listing is still inserted as a fallback if it is missing from the returned lists.

Calendar & Pricing is intentionally kept separate and unchanged. Availability editing in the Listing Editor still uses the existing calendar override source and endpoints.

This PR also clarifies the “outside window” wording in the Availability tab. Outside-window dates can still be marked available by saving an explicit available override.

## Change Type

* [x] Bug fix
* [ ] New feature
* [x] Optimization
* [ ] Documentation update

## Change Size

[//]: # "Indicate the size of this change."
[//]: # "Clarify under [Refactoring](https://chatgpt.com/g/g-p-697f7ff03c808191b0c04598bc66b5c0/c/6a06ea98-e38c-8386-88d5-1ccaf8a0cabb#Refactoring) which parts are moved/unchanged code, so the reviewer doesn’t review old logic."

* [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
* [ ] Big change (+-max 1000)
* [x] Small change (less than 300)

## Refactoring

Refactors following files, but didn't change the code. This is to avoid reviewing old logic.

* N/A

## Evidence

* [ ] Screenshots or screen recording added for UI changes
* [ ] Before/after images added when relevant
* [ ] Images clearly show the implemented change
* [ ] Image quality is readable (no cropped or blurry evidence)

## Responsiveness

* [ ] UI checked on mobile
* [ ] UI checked on tablet
* [ ] UI checked on desktop
* [ ] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages

* [ ] NPM Packages installed
* [ ] NPM Packages removed
* [ ] NPM Packages updated
* [ ] Checked for vulnerabilities using "npm audit"

No tracked npm package changes were made.

## Checklist

[//]: # "All boxes must be checked before merging."

* [ ] Pull request has at least 2 reviewers assigned
* [x] PR title is descriptive and includes issue number
* [x] Conventions

  * [x] No config files have been added (Amplify config, cache files)
  * [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  * [x] No global styling (see [[#1691](https://github.com/domits1/Domits/issues/1691)](https://github.com/domits1/Domits/issues/1691))
  * [x] No `console.log` left in code
  * [x] No commented-out code remains
* [x] Testing

  * [x] Code tested locally
  * [x] Jest tests are included
  * [x] Jest tests are passing

## Keep or delete my branch

* [x] Delete my branch after merge
* [ ] Keep my branch