### PR TITLE
feat(channex): add admin connection setup flow

### DIFF
--- a/backend/functions/UnifiedMessaging/business/integrationService.channexAri.test.js
+++ b/backend/functions/UnifiedMessaging/business/integrationService.channexAri.test.js
@@ -349,6 +349,117 @@ const expectValidChannexRestrictionProviderValues = (payloads) => {
   }
 };
 
+describe("IntegrationService Channex setup mapping", () => {
+  const setupPayload = {
+    domitsPropertyId: "domits-property-1",
+    externalPropertyId: "external-property-1",
+    externalPropertyName: "Demo Channex property",
+    externalRoomTypeId: "room-type-1",
+    externalRoomTypeName: "Demo room",
+    externalRatePlanId: "rate-plan-1",
+    externalRatePlanName: "Standard rate",
+    status: "ACTIVE",
+    scope: "SINGLE_UNIT",
+  };
+
+  const buildMappingRepositories = () => ({
+    props: {
+      upsert: jest.fn(async (row) => ({ id: "property-mapping-1", ...row })),
+    },
+    roomTypes: {
+      upsert: jest.fn(async (row) => ({ id: "room-type-mapping-1", ...row })),
+    },
+    ratePlans: {
+      upsert: jest.fn(async (row) => ({ id: "rate-plan-mapping-1", ...row })),
+    },
+  });
+
+  test("validates required setup mapping fields", async () => {
+    const service = createService();
+
+    const result = await service.saveChannexSetupMapping("user-1", {
+      ...setupPayload,
+      externalRatePlanId: "",
+    });
+
+    expect(result.statusCode).toBe(400);
+    expect(result.response.error).toBe("Missing required field: externalRatePlanId");
+  });
+
+  test("upserts property, room type, and rate plan mappings and returns readiness", async () => {
+    const repositories = buildMappingRepositories();
+    const service = createService(repositories);
+    service.getChannexAriTargets.mockResolvedValue({
+      statusCode: 200,
+      response: {
+        channel: "CHANNEX",
+        integrationAccountId: "integration-account-1",
+        domitsPropertyId: "domits-property-1",
+        ready: true,
+        missingMappings: [],
+      },
+    });
+
+    const result = await service.saveChannexSetupMapping("user-1", setupPayload);
+
+    expect(result.statusCode).toBe(200);
+    expect(result.response).toEqual(
+      expect.objectContaining({
+        channel: "CHANNEX",
+        action: "setup-mapping",
+        scope: "SINGLE_UNIT",
+        saved: true,
+        integrationAccountId: "integration-account-1",
+        domitsPropertyId: "domits-property-1",
+        readinessStatusCode: 200,
+        ready: true,
+      })
+    );
+    expect(repositories.props.upsert).toHaveBeenCalledWith({
+      integrationAccountId: "integration-account-1",
+      domitsPropertyId: "domits-property-1",
+      externalPropertyId: "external-property-1",
+      externalPropertyName: "Demo Channex property",
+      status: "ACTIVE",
+    });
+    expect(repositories.roomTypes.upsert).toHaveBeenCalledWith({
+      integrationAccountId: "integration-account-1",
+      domitsPropertyId: "domits-property-1",
+      externalPropertyId: "external-property-1",
+      externalRoomTypeId: "room-type-1",
+      externalRoomTypeName: "Demo room",
+      status: "ACTIVE",
+    });
+    expect(repositories.ratePlans.upsert).toHaveBeenCalledWith({
+      integrationAccountId: "integration-account-1",
+      domitsPropertyId: "domits-property-1",
+      externalPropertyId: "external-property-1",
+      externalRoomTypeId: "room-type-1",
+      externalRatePlanId: "rate-plan-1",
+      externalRatePlanName: "Standard rate",
+      status: "ACTIVE",
+    });
+    expect(service.getChannexAriTargets).toHaveBeenCalledWith("user-1", "domits-property-1");
+    expect(JSON.stringify(result.response)).not.toContain("channex-secret-1");
+    expect(JSON.stringify(result.response)).not.toContain("credentialsRef");
+  });
+
+  test("returns saved mapping progress if setup mapping persistence fails", async () => {
+    const repositories = buildMappingRepositories();
+    repositories.ratePlans.upsert.mockRejectedValueOnce(new Error("rate plan write failed"));
+    const service = createService(repositories);
+
+    const result = await service.saveChannexSetupMapping("user-1", setupPayload);
+
+    expect(result.statusCode).toBe(500);
+    expect(result.response.errorCode).toBe("CHANNEX_SETUP_MAPPING_FAILED");
+    expect(result.response.savedMappings.property).toEqual(expect.objectContaining({ id: "property-mapping-1" }));
+    expect(result.response.savedMappings.roomType).toEqual(expect.objectContaining({ id: "room-type-mapping-1" }));
+    expect(result.response.savedMappings.ratePlan).toBeNull();
+    expect(service.getChannexAriTargets).not.toHaveBeenCalled();
+  });
+});
+
 describe("IntegrationService Channex ARI restriction mapping", () => {
   beforeEach(() => {
     Database.getInstance.mockResolvedValue(buildDatabaseClient());

--- a/backend/functions/UnifiedMessaging/business/integrationService.js
+++ b/backend/functions/UnifiedMessaging/business/integrationService.js
@@ -4155,6 +4155,91 @@ export default class IntegrationService {
     }
   }
 
+  async saveChannexSetupMapping(userId, body) {
+    const normalizedUserId = requireStr(userId);
+    if (!normalizedUserId) return bad(400, { error: "Missing required field: userId" });
+
+    const domitsPropertyId = requireStr(body?.domitsPropertyId);
+    const externalPropertyId = requireStr(body?.externalPropertyId);
+    const externalPropertyName = requireStr(body?.externalPropertyName);
+    const externalRoomTypeId = requireStr(body?.externalRoomTypeId);
+    const externalRoomTypeName = requireStr(body?.externalRoomTypeName);
+    const externalRatePlanId = requireStr(body?.externalRatePlanId);
+    const externalRatePlanName = requireStr(body?.externalRatePlanName);
+    const status = requireStr(body?.status) || "ACTIVE";
+    const scope = requireStr(body?.scope) || "SINGLE_UNIT";
+
+    if (!domitsPropertyId) return bad(400, { error: "Missing required field: domitsPropertyId" });
+    if (!externalPropertyId) return bad(400, { error: "Missing required field: externalPropertyId" });
+    if (!externalRoomTypeId) return bad(400, { error: "Missing required field: externalRoomTypeId" });
+    if (!externalRatePlanId) return bad(400, { error: "Missing required field: externalRatePlanId" });
+    if (scope !== "SINGLE_UNIT") {
+      return bad(400, {
+        error: "Channex setup mapping currently supports only SINGLE_UNIT scope.",
+        errorCode: "CHANNEX_SETUP_SCOPE_UNSUPPORTED",
+      });
+    }
+
+    const savedMappings = {
+      property: null,
+      roomType: null,
+      ratePlan: null,
+    };
+
+    try {
+      const channexContext = await this.resolveUsableChannexIntegration(normalizedUserId);
+      if (!channexContext.ok) return channexContext.response;
+
+      const { integration } = channexContext;
+      const mappingBase = {
+        integrationAccountId: integration.id,
+        domitsPropertyId,
+        externalPropertyId,
+        status,
+      };
+
+      savedMappings.property = await this.props.upsert({
+        ...mappingBase,
+        externalPropertyName,
+      });
+      savedMappings.roomType = await this.roomTypes.upsert({
+        ...mappingBase,
+        externalRoomTypeId,
+        externalRoomTypeName,
+      });
+      savedMappings.ratePlan = await this.ratePlans.upsert({
+        ...mappingBase,
+        externalRoomTypeId,
+        externalRatePlanId,
+        externalRatePlanName,
+      });
+
+      const readinessResult = await this.getChannexAriTargets(normalizedUserId, domitsPropertyId);
+      const readiness = readinessResult?.response ?? null;
+
+      return ok({
+        channel: "CHANNEX",
+        action: "setup-mapping",
+        scope,
+        saved: true,
+        integrationAccountId: integration.id,
+        domitsPropertyId,
+        savedMappings,
+        readinessStatusCode: readinessResult?.statusCode ?? null,
+        readiness,
+        ready: readiness?.ready === true,
+      });
+    } catch (error) {
+      const details = describeLocalError(error);
+      return bad(500, {
+        error: "Failed to save Channex setup mapping.",
+        errorCode: "CHANNEX_SETUP_MAPPING_FAILED",
+        details,
+        savedMappings,
+      });
+    }
+  }
+
   async listLinkedChannexRoomTypes(userId) {
     const normalizedUserId = requireStr(userId);
     if (!normalizedUserId) return bad(400, { error: "Missing required query param: userId" });

--- a/backend/functions/UnifiedMessaging/controller/integrationController.js
+++ b/backend/functions/UnifiedMessaging/controller/integrationController.js
@@ -359,6 +359,12 @@ class IntegrationController {
     return await this.integrationService.syncChannexCertificationTestCase(userId, domitsPropertyId, body);
   }
 
+  async saveChannexSetupMapping(event) {
+    const userId = event.queryStringParameters?.userId || null;
+    const body = safeJson(event.body) || {};
+    return await this.integrationService.saveChannexSetupMapping(userId, body);
+  }
+
   async linkChannexProperty(event) {
     const userId = event.queryStringParameters?.userId || null;
     const body = safeJson(event.body) || {};

--- a/backend/functions/UnifiedMessaging/index.channexCertificationAccess.test.js
+++ b/backend/functions/UnifiedMessaging/index.channexCertificationAccess.test.js
@@ -1,11 +1,20 @@
 const mockIntegrationControllerMethods = {
   checkChannexStatus: jest.fn(),
+  listChannexProperties: jest.fn(),
+  listChannexRoomTypes: jest.fn(),
+  listChannexRatePlans: jest.fn(),
+  listLinkedChannexRoomTypes: jest.fn(),
+  listLinkedChannexRatePlans: jest.fn(),
+  linkChannexProperty: jest.fn(),
+  linkChannexRoomType: jest.fn(),
+  linkChannexRatePlan: jest.fn(),
   listChannexBookingRevisions: jest.fn(),
   syncChannexRestrictions: jest.fn(),
   syncChannexFull: jest.fn(),
   syncChannexBookingAvailability: jest.fn(),
   syncChannexCertificationTestCase: jest.fn(),
   cancelChannexCertificationBooking: jest.fn(),
+  saveChannexSetupMapping: jest.fn(),
   receiveChannexBookingRevisions: jest.fn(),
   pullLatestChannexBookings: jest.fn(),
   pollLatestChannexBookings: jest.fn(),
@@ -162,6 +171,89 @@ describe("UnifiedMessaging Channex certification admin route guard", () => {
 
     expect(response.statusCode).toBe(403);
     expect(mockIntegrationControllerMethods.listChannexBookingRevisions).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ["GET", "/default/integrations/channex/properties", "listChannexProperties"],
+    ["GET", "/default/integrations/channex/room-types", "listChannexRoomTypes"],
+    ["GET", "/default/integrations/channex/rate-plans", "listChannexRatePlans"],
+    ["GET", "/default/integrations/channex/linked-room-types", "listLinkedChannexRoomTypes"],
+    ["GET", "/default/integrations/channex/linked-rate-plans", "listLinkedChannexRatePlans"],
+    ["POST", "/default/integrations/channex/properties", "linkChannexProperty"],
+    ["POST", "/default/integrations/channex/room-types", "linkChannexRoomType"],
+    ["POST", "/default/integrations/channex/rate-plans", "linkChannexRatePlan"],
+    ["POST", "/default/integrations/channex/setup/mapping", "saveChannexSetupMapping"],
+  ])("%s %s is protected before setup controller logic runs", async (method, path, controllerMethod) => {
+    const response = await handler(
+      buildEvent({
+        method,
+        path,
+        query: { userId: "not-allowed" },
+        body: method === "POST" ? "{}" : null,
+      })
+    );
+
+    expect(response.statusCode).toBe(403);
+    expect(mockIntegrationControllerMethods[controllerMethod]).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ["/default/integrations/channex/properties", "listChannexProperties"],
+    ["/default/integrations/channex/room-types", "listChannexRoomTypes"],
+    ["/default/integrations/channex/rate-plans", "listChannexRatePlans"],
+  ])("allowed user can call %s", async (path, controllerMethod) => {
+    mockIntegrationControllerMethods[controllerMethod].mockResolvedValue({
+      statusCode: 200,
+      response: { channel: "CHANNEX", status: "CONNECTED" },
+    });
+
+    const response = await handler(
+      buildEvent({
+        path,
+        query: {
+          userId: "allowed-user",
+          externalPropertyId: "external-property-1",
+          externalRoomTypeId: "room-type-1",
+        },
+      })
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(parseBody(response)).toEqual({ channel: "CHANNEX", status: "CONNECTED" });
+    expect(mockIntegrationControllerMethods[controllerMethod]).toHaveBeenCalledTimes(1);
+  });
+
+  test("allowed user can save Channex setup mapping", async () => {
+    mockIntegrationControllerMethods.saveChannexSetupMapping.mockResolvedValue({
+      statusCode: 200,
+      response: {
+        channel: "CHANNEX",
+        action: "setup-mapping",
+        ready: true,
+      },
+    });
+
+    const response = await handler(
+      buildEvent({
+        method: "POST",
+        path: "/default/integrations/channex/setup/mapping",
+        query: { userId: "allowed-user" },
+        body: JSON.stringify({
+          domitsPropertyId: "domits-property-1",
+          externalPropertyId: "external-property-1",
+          externalRoomTypeId: "room-type-1",
+          externalRatePlanId: "rate-plan-1",
+        }),
+      })
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(parseBody(response)).toEqual({
+      channel: "CHANNEX",
+      action: "setup-mapping",
+      ready: true,
+    });
+    expect(mockIntegrationControllerMethods.saveChannexSetupMapping).toHaveBeenCalledTimes(1);
   });
 
   test("sync restrictions endpoint is protected before side effects run", async () => {

--- a/backend/functions/UnifiedMessaging/index.js
+++ b/backend/functions/UnifiedMessaging/index.js
@@ -39,6 +39,11 @@ const getChannexCertificationAdminAccess = (event) => ({
 
 const protectedChannexCertificationAdminRoutes = [
   { methods: ["GET"], pattern: /\/integrations\/channex\/status$/ },
+  { methods: ["GET"], pattern: /\/integrations\/channex\/properties$/ },
+  { methods: ["GET"], pattern: /\/integrations\/channex\/room-types$/ },
+  { methods: ["GET"], pattern: /\/integrations\/channex\/rate-plans$/ },
+  { methods: ["GET"], pattern: /\/integrations\/channex\/linked-room-types$/ },
+  { methods: ["GET"], pattern: /\/integrations\/channex\/linked-rate-plans$/ },
   { methods: ["GET"], pattern: /\/integrations\/channex\/ari-targets$/ },
   { methods: ["GET"], pattern: /\/integrations\/channex\/ari-preview$/ },
   { methods: ["GET"], pattern: /\/integrations\/channex\/ari-payload-preview$/ },
@@ -55,6 +60,10 @@ const protectedChannexCertificationAdminRoutes = [
   { methods: ["POST"], pattern: /\/integrations\/channex\/bookings\/receive$/ },
   { methods: ["POST"], pattern: /\/integrations\/channex\/bookings\/pull$/ },
   { methods: ["POST"], pattern: /\/integrations\/channex\/bookings\/ack$/ },
+  { methods: ["POST"], pattern: /\/integrations\/channex\/setup\/mapping$/ },
+  { methods: ["POST"], pattern: /\/integrations\/channex\/properties$/ },
+  { methods: ["POST"], pattern: /\/integrations\/channex\/room-types$/ },
+  { methods: ["POST"], pattern: /\/integrations\/channex\/rate-plans$/ },
 ];
 
 const pathIncludesOrEndsWith = (path, suffix) => {
@@ -203,6 +212,10 @@ const routeDefinitions = [
   {
     matches: (method, path) => method === "GET" && String(path || "").endsWith("/integrations/channex/bookings/revisions"),
     handle: (event) => integrationController.listChannexBookingRevisions(event),
+  },
+  {
+    matches: (method, path) => method === "POST" && String(path || "").endsWith("/integrations/channex/setup/mapping"),
+    handle: (event) => integrationController.saveChannexSetupMapping(event),
   },
   {
     matches: (method, path) => method === "POST" && String(path || "").endsWith("/integrations/channex/bookings/receive"),

--- a/frontend/web/src/features/hostdashboard/hostintegrations/ChannexDiagnosticsPanel.jsx
+++ b/frontend/web/src/features/hostdashboard/hostintegrations/ChannexDiagnosticsPanel.jsx
@@ -8,7 +8,11 @@ import {
   getChannexAriTargets,
   getChannexStatus,
   getLatestChannexSyncEvidence,
+  listChannexProperties,
+  listChannexRatePlans,
+  listChannexRoomTypes,
   modifyBookingDates,
+  saveChannexSetupMapping,
   syncChannexAri,
   syncChannexAvailability,
   syncChannexFull,
@@ -17,6 +21,7 @@ import {
 
 const SECTION_TABS = [
   { key: "overview", label: "Overview" },
+  { key: "setup", label: "Setup & Connection" },
   { key: "mappings", label: "Mappings" },
   { key: "ari", label: "ARI Preview" },
   { key: "evidence", label: "Evidence" },
@@ -349,6 +354,41 @@ const normalizeCancelBookingForm = (form) => ({
 const validateCancelBookingForm = (form) => {
   const payload = normalizeCancelBookingForm(form);
   return payload.bookingId ? "" : "Enter the booking ID to cancel.";
+};
+
+const createSetupSelection = () => ({
+  externalPropertyId: "",
+  externalRoomTypeId: "",
+  externalRatePlanId: "",
+});
+
+const findById = (items, key, value) =>
+  (Array.isArray(items) ? items : []).find((item) => String(item?.[key] || "") === String(value || "")) || null;
+
+const buildSetupMappingPayload = ({
+  domitsPropertyId,
+  selection,
+  selectedProperty,
+  selectedRoomType,
+  selectedRatePlan,
+}) => ({
+  domitsPropertyId: String(domitsPropertyId || "").trim(),
+  externalPropertyId: selection.externalPropertyId,
+  externalPropertyName: selectedProperty?.externalPropertyName || null,
+  externalRoomTypeId: selection.externalRoomTypeId,
+  externalRoomTypeName: selectedRoomType?.externalRoomTypeName || null,
+  externalRatePlanId: selection.externalRatePlanId,
+  externalRatePlanName: selectedRatePlan?.externalRatePlanName || null,
+  status: "ACTIVE",
+  scope: "SINGLE_UNIT",
+});
+
+const validateSetupMappingPayload = (payload) => {
+  if (!payload.domitsPropertyId) return "Enter a Domits property ID before saving the mapping.";
+  if (!payload.externalPropertyId) return "Select a Channex property before saving the mapping.";
+  if (!payload.externalRoomTypeId) return "Select a Channex room type before saving the mapping.";
+  if (!payload.externalRatePlanId) return "Select a Channex rate plan before saving the mapping.";
+  return "";
 };
 
 const getPayloadPaginationSummary = (pagination = {}) => {
@@ -1218,6 +1258,11 @@ function ChannexDiagnosticsPanel({ userId }) {
   const [latestEvidenceState, setLatestEvidenceState] = useState(createRequestState);
   const [ariPreviewState, setAriPreviewState] = useState(createRequestState);
   const [payloadPreviewState, setPayloadPreviewState] = useState(createRequestState);
+  const [setupPropertiesState, setSetupPropertiesState] = useState(createRequestState);
+  const [setupRoomTypesState, setSetupRoomTypesState] = useState(createRequestState);
+  const [setupRatePlansState, setSetupRatePlansState] = useState(createRequestState);
+  const [setupMappingState, setSetupMappingState] = useState(createRequestState);
+  const [setupSelection, setSetupSelection] = useState(createSetupSelection);
   const [actionStates, setActionStates] = useState({});
   const [modifyBookingForm, setModifyBookingForm] = useState(MODIFY_BOOKING_DEMO_DEFAULTS);
   const [modifyBookingState, setModifyBookingState] = useState(createRequestState);
@@ -1235,6 +1280,21 @@ function ChannexDiagnosticsPanel({ userId }) {
       dateTo,
     }),
     [dateFrom, dateTo, domitsPropertyId, userId]
+  );
+  const setupProperties = setupPropertiesState.data?.properties || [];
+  const setupRoomTypes = setupRoomTypesState.data?.roomTypes || [];
+  const setupRatePlans = setupRatePlansState.data?.ratePlans || [];
+  const selectedSetupProperty = useMemo(
+    () => findById(setupProperties, "externalPropertyId", setupSelection.externalPropertyId),
+    [setupProperties, setupSelection.externalPropertyId]
+  );
+  const selectedSetupRoomType = useMemo(
+    () => findById(setupRoomTypes, "externalRoomTypeId", setupSelection.externalRoomTypeId),
+    [setupRoomTypes, setupSelection.externalRoomTypeId]
+  );
+  const selectedSetupRatePlan = useMemo(
+    () => findById(setupRatePlans, "externalRatePlanId", setupSelection.externalRatePlanId),
+    [setupRatePlans, setupSelection.externalRatePlanId]
   );
 
   const runRequest = useCallback(async ({ setState, request }) => {
@@ -1297,6 +1357,101 @@ function ChannexDiagnosticsPanel({ userId }) {
           pageSizeDays: PAYLOAD_PREVIEW_PAGE_SIZE_DAYS,
         }),
     });
+
+  const loadChannexResources = async () => {
+    setSetupSelection(createSetupSelection());
+    setSetupRoomTypesState(createRequestState());
+    setSetupRatePlansState(createRequestState());
+    setSetupMappingState(createRequestState());
+    return runRequest({
+      setState: setSetupPropertiesState,
+      request: () => listChannexProperties({ userId }),
+    });
+  };
+
+  const handleSetupPropertyChange = async (externalPropertyId) => {
+    setSetupSelection({
+      externalPropertyId,
+      externalRoomTypeId: "",
+      externalRatePlanId: "",
+    });
+    setSetupRatePlansState(createRequestState());
+    setSetupMappingState(createRequestState());
+
+    if (!externalPropertyId) {
+      setSetupRoomTypesState(createRequestState());
+      return;
+    }
+
+    await runRequest({
+      setState: setSetupRoomTypesState,
+      request: () => listChannexRoomTypes({ userId, externalPropertyId }),
+    });
+  };
+
+  const handleSetupRoomTypeChange = async (externalRoomTypeId) => {
+    setSetupSelection((current) => ({
+      ...current,
+      externalRoomTypeId,
+      externalRatePlanId: "",
+    }));
+    setSetupMappingState(createRequestState());
+
+    if (!externalRoomTypeId) {
+      setSetupRatePlansState(createRequestState());
+      return;
+    }
+
+    await runRequest({
+      setState: setSetupRatePlansState,
+      request: () => listChannexRatePlans({ userId, externalRoomTypeId }),
+    });
+  };
+
+  const handleSetupRatePlanChange = (externalRatePlanId) => {
+    setSetupSelection((current) => ({
+      ...current,
+      externalRatePlanId,
+    }));
+    setSetupMappingState(createRequestState());
+  };
+
+  const saveSetupMapping = async () => {
+    const mapping = buildSetupMappingPayload({
+      domitsPropertyId,
+      selection: setupSelection,
+      selectedProperty: selectedSetupProperty,
+      selectedRoomType: selectedSetupRoomType,
+      selectedRatePlan: selectedSetupRatePlan,
+    });
+    const validationMessage = validateSetupMappingPayload(mapping);
+
+    if (validationMessage) {
+      setSetupMappingState({
+        loading: false,
+        error: validationMessage,
+        errorDetails: null,
+        data: null,
+      });
+      return null;
+    }
+
+    const data = await runRequest({
+      setState: setSetupMappingState,
+      request: () => saveChannexSetupMapping({ userId, mapping }),
+    });
+
+    if (data?.readiness) {
+      setTargetsState({
+        loading: false,
+        error: "",
+        errorDetails: null,
+        data: data.readiness,
+      });
+    }
+
+    return data;
+  };
 
   const updateActionState = useCallback((key, updater) => {
     setActionStates((current) => {
@@ -1482,6 +1637,162 @@ function ChannexDiagnosticsPanel({ userId }) {
           </>
         ) : (
           <p className="host-integrations-muted">Status has not loaded yet.</p>
+        )}
+      </SectionCard>
+    </div>
+  );
+
+  const renderSetup = () => (
+    <div className="channex-diagnostics-grid">
+      <SectionCard
+        title="Setup & Connection"
+        description="Admin-only single-unit mapping setup for one Domits property, one Channex property, one room type, and one rate plan."
+      >
+        <div className="host-integrations-field-grid">
+          <label className="host-integrations-field">
+            <span>Setup Domits property ID</span>
+            <input
+              value={domitsPropertyId}
+              onChange={(event) => setDomitsPropertyId(event.target.value)}
+              placeholder="Domits property ID"
+            />
+          </label>
+          <label className="host-integrations-field">
+            <span>Channex property</span>
+            <select
+              value={setupSelection.externalPropertyId}
+              disabled={setupPropertiesState.loading || !setupProperties.length}
+              onChange={(event) => handleSetupPropertyChange(event.target.value)}
+            >
+              <option value="">Select Channex property</option>
+              {setupProperties.map((property) => (
+                <option key={property.externalPropertyId} value={property.externalPropertyId}>
+                  {property.externalPropertyName || property.externalPropertyId}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="host-integrations-field">
+            <span>Channex room type</span>
+            <select
+              value={setupSelection.externalRoomTypeId}
+              disabled={setupRoomTypesState.loading || !setupSelection.externalPropertyId || !setupRoomTypes.length}
+              onChange={(event) => handleSetupRoomTypeChange(event.target.value)}
+            >
+              <option value="">Select Channex room type</option>
+              {setupRoomTypes.map((roomType) => (
+                <option key={roomType.externalRoomTypeId} value={roomType.externalRoomTypeId}>
+                  {roomType.externalRoomTypeName || roomType.externalRoomTypeId}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="host-integrations-field">
+            <span>Channex rate plan</span>
+            <select
+              value={setupSelection.externalRatePlanId}
+              disabled={setupRatePlansState.loading || !setupSelection.externalRoomTypeId || !setupRatePlans.length}
+              onChange={(event) => handleSetupRatePlanChange(event.target.value)}
+            >
+              <option value="">Select Channex rate plan</option>
+              {setupRatePlans.map((ratePlan) => (
+                <option key={ratePlan.externalRatePlanId} value={ratePlan.externalRatePlanId}>
+                  {ratePlan.externalRatePlanName || ratePlan.externalRatePlanId}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className="channex-diagnostics-actions">
+          <button
+            type="button"
+            className="host-integrations-secondary-btn"
+            disabled={!userId || setupPropertiesState.loading}
+            onClick={loadChannexResources}
+          >
+            {setupPropertiesState.loading ? "Loading..." : "Load Channex resources"}
+          </button>
+          <button
+            type="button"
+            className="host-integrations-primary-btn"
+            disabled={!userId || setupMappingState.loading}
+            onClick={saveSetupMapping}
+          >
+            {setupMappingState.loading ? "Saving..." : "Save mapping"}
+          </button>
+          <button
+            type="button"
+            className="host-integrations-secondary-btn"
+            disabled={!userId || !hasProperty || targetsState.loading}
+            onClick={loadTargets}
+          >
+            {targetsState.loading ? "Validating..." : "Validate readiness"}
+          </button>
+        </div>
+
+        {setupPropertiesState.loading || setupRoomTypesState.loading || setupRatePlansState.loading ? (
+          <p className="host-integrations-loading">Loading Channex setup resources...</p>
+        ) : null}
+        {setupPropertiesState.error ? (
+          <ErrorCallout error={setupPropertiesState.error} details={setupPropertiesState.errorDetails} />
+        ) : null}
+        {setupRoomTypesState.error ? (
+          <ErrorCallout error={setupRoomTypesState.error} details={setupRoomTypesState.errorDetails} />
+        ) : null}
+        {setupRatePlansState.error ? (
+          <ErrorCallout error={setupRatePlansState.error} details={setupRatePlansState.errorDetails} />
+        ) : null}
+        {setupMappingState.error ? (
+          <ErrorCallout error={setupMappingState.error} details={setupMappingState.errorDetails} />
+        ) : null}
+
+        <DetailGrid
+          items={[
+            { label: "Loaded Channex properties", value: setupProperties.length },
+            { label: "Loaded room types", value: setupRoomTypes.length },
+            { label: "Loaded rate plans", value: setupRatePlans.length },
+            { label: "Selected property", value: selectedSetupProperty?.externalPropertyName || setupSelection.externalPropertyId || "-" },
+            { label: "Selected room type", value: selectedSetupRoomType?.externalRoomTypeName || setupSelection.externalRoomTypeId || "-" },
+            { label: "Selected rate plan", value: selectedSetupRatePlan?.externalRatePlanName || setupSelection.externalRatePlanId || "-" },
+          ]}
+        />
+
+        {setupMappingState.data ? (
+          <>
+            <p className="host-integrations-success-banner">Single-unit Channex mapping saved.</p>
+            <DetailGrid
+              items={[
+                { label: "Integration account", value: setupMappingState.data.integrationAccountId },
+                { label: "Scope", value: setupMappingState.data.scope },
+                { label: "Readiness", value: setupMappingState.data.ready ? "Ready" : "Not ready" },
+                { label: "Readiness status", value: setupMappingState.data.readinessStatusCode ?? "-" },
+              ]}
+            />
+            <JsonBlock title="Saved setup mapping" value={setupMappingState.data.savedMappings} />
+          </>
+        ) : null}
+      </SectionCard>
+
+      <SectionCard
+        title="Current mapping readiness"
+        description="Readiness after setup save, or the latest readiness loaded for the selected Domits property."
+        state={targetsState}
+      >
+        {targetsState.data ? (
+          <>
+            <DetailGrid
+              items={[
+                { label: "Ready", value: targets.ready === true ? "Yes" : "No" },
+                { label: "Domits property", value: targets.domitsPropertyId },
+                { label: "Integration account", value: targets.integrationAccountId },
+                { label: "Missing mappings", value: renderList(targets.missingMappings) },
+              ]}
+            />
+            <JsonBlock title="Readiness response" value={targetsState.data} />
+          </>
+        ) : (
+          <p className="host-integrations-muted">Save mapping or validate readiness to see the current setup result.</p>
         )}
       </SectionCard>
     </div>
@@ -1891,6 +2202,7 @@ function ChannexDiagnosticsPanel({ userId }) {
       </nav>
 
       {activeSection === "overview" ? renderOverview() : null}
+      {activeSection === "setup" ? renderSetup() : null}
       {activeSection === "mappings" ? renderMappings() : null}
       {activeSection === "ari" ? renderAriPreview() : null}
       {activeSection === "evidence" ? renderEvidence() : null}

--- a/frontend/web/src/features/hostdashboard/hostintegrations/ChannexDiagnosticsPanel.test.js
+++ b/frontend/web/src/features/hostdashboard/hostintegrations/ChannexDiagnosticsPanel.test.js
@@ -6,9 +6,13 @@ import {
   getChannexAriPreview,
   getLatestChannexSyncEvidence,
   getChannexStatus,
+  listChannexProperties,
+  listChannexRatePlans,
+  listChannexRoomTypes,
   listChannexBookingRevisions,
   modifyBookingDates,
   pullLatestChannexBookings,
+  saveChannexSetupMapping,
   syncChannexCertificationTestCase,
   syncChannexFull,
   syncChannexRestrictions,
@@ -21,9 +25,13 @@ jest.mock("./channexApi", () => ({
   getChannexAriTargets: jest.fn(),
   getChannexStatus: jest.fn(),
   getLatestChannexSyncEvidence: jest.fn(),
+  listChannexProperties: jest.fn(),
+  listChannexRatePlans: jest.fn(),
+  listChannexRoomTypes: jest.fn(),
   listChannexBookingRevisions: jest.fn(),
   modifyBookingDates: jest.fn(),
   pullLatestChannexBookings: jest.fn(),
+  saveChannexSetupMapping: jest.fn(),
   ackChannexBookingRevisions: jest.fn(),
   receiveChannexBookingRevisions: jest.fn(),
   syncChannexAri: jest.fn(),
@@ -140,6 +148,113 @@ describe("ChannexDiagnosticsPanel certification actions", () => {
     }
     expect(screen.queryByRole("button", { name: "Receive booking revisions" })).toBeNull();
     expect(syncChannexCertificationTestCase).not.toHaveBeenCalled();
+  });
+
+  test("saves a single-unit Channex setup mapping from the setup tab", async () => {
+    listChannexProperties.mockResolvedValue({
+      properties: [
+        {
+          externalPropertyId: "external-property-1",
+          externalPropertyName: "Demo Channex property",
+        },
+      ],
+    });
+    listChannexRoomTypes.mockResolvedValue({
+      roomTypes: [
+        {
+          externalRoomTypeId: "room-type-1",
+          externalRoomTypeName: "Demo room",
+        },
+      ],
+    });
+    listChannexRatePlans.mockResolvedValue({
+      ratePlans: [
+        {
+          externalRatePlanId: "rate-plan-1",
+          externalRatePlanName: "Standard rate",
+        },
+      ],
+    });
+    saveChannexSetupMapping.mockResolvedValue({
+      action: "setup-mapping",
+      scope: "SINGLE_UNIT",
+      integrationAccountId: "integration-account-1",
+      ready: true,
+      readinessStatusCode: 200,
+      savedMappings: {
+        property: { externalPropertyId: "external-property-1" },
+        roomType: { externalRoomTypeId: "room-type-1" },
+        ratePlan: { externalRatePlanId: "rate-plan-1" },
+      },
+      readiness: {
+        ready: true,
+        domitsPropertyId: "domits-property-1",
+        integrationAccountId: "integration-account-1",
+        missingMappings: [],
+      },
+    });
+
+    await renderDiagnosticsPanel();
+    fillRequiredInputs({ openActions: false });
+    fireEvent.click(screen.getByRole("button", { name: "Setup & Connection" }));
+    fireEvent.click(screen.getByRole("button", { name: "Load Channex resources" }));
+
+    await waitFor(() => expect(listChannexProperties).toHaveBeenCalledTimes(1));
+    expect(listChannexProperties).toHaveBeenCalledWith({ userId: "user-1" });
+
+    fireEvent.change(await screen.findByLabelText("Channex property"), {
+      target: { value: "external-property-1" },
+    });
+    await waitFor(() => expect(listChannexRoomTypes).toHaveBeenCalledTimes(1));
+    expect(listChannexRoomTypes).toHaveBeenCalledWith({
+      userId: "user-1",
+      externalPropertyId: "external-property-1",
+    });
+
+    fireEvent.change(await screen.findByLabelText("Channex room type"), {
+      target: { value: "room-type-1" },
+    });
+    await waitFor(() => expect(listChannexRatePlans).toHaveBeenCalledTimes(1));
+    expect(listChannexRatePlans).toHaveBeenCalledWith({
+      userId: "user-1",
+      externalRoomTypeId: "room-type-1",
+    });
+
+    fireEvent.change(await screen.findByLabelText("Channex rate plan"), {
+      target: { value: "rate-plan-1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save mapping" }));
+
+    await waitFor(() => expect(saveChannexSetupMapping).toHaveBeenCalledTimes(1));
+    expect(saveChannexSetupMapping).toHaveBeenCalledWith({
+      userId: "user-1",
+      mapping: {
+        domitsPropertyId: "domits-property-1",
+        externalPropertyId: "external-property-1",
+        externalPropertyName: "Demo Channex property",
+        externalRoomTypeId: "room-type-1",
+        externalRoomTypeName: "Demo room",
+        externalRatePlanId: "rate-plan-1",
+        externalRatePlanName: "Standard rate",
+        status: "ACTIVE",
+        scope: "SINGLE_UNIT",
+      },
+    });
+    expect(await screen.findByText("Single-unit Channex mapping saved.")).toBeTruthy();
+    expect(screen.getAllByText("Ready").length).toBeGreaterThan(0);
+    expect(screen.getByText("Readiness response")).toBeTruthy();
+  });
+
+  test("shows setup resource load errors", async () => {
+    listChannexProperties.mockRejectedValueOnce(new Error("Channex property list failed"));
+
+    await renderDiagnosticsPanel();
+    fillRequiredInputs({ openActions: false });
+    fireEvent.click(screen.getByRole("button", { name: "Setup & Connection" }));
+    fireEvent.click(screen.getByRole("button", { name: "Load Channex resources" }));
+
+    await waitFor(() => expect(listChannexProperties).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText("Channex property list failed")).toBeTruthy();
   });
 
   test("runs full/certification sync from the admin actions UI", async () => {

--- a/frontend/web/src/features/hostdashboard/hostintegrations/channexApi.js
+++ b/frontend/web/src/features/hostdashboard/hostintegrations/channexApi.js
@@ -135,6 +135,28 @@ export const getChannexAriTargets = ({ userId, domitsPropertyId }) =>
     query: { userId, domitsPropertyId },
   });
 
+export const listChannexProperties = ({ userId }) =>
+  requestChannex("/integrations/channex/properties", {
+    query: { userId },
+  });
+
+export const listChannexRoomTypes = ({ userId, externalPropertyId }) =>
+  requestChannex("/integrations/channex/room-types", {
+    query: { userId, externalPropertyId },
+  });
+
+export const listChannexRatePlans = ({ userId, externalRoomTypeId }) =>
+  requestChannex("/integrations/channex/rate-plans", {
+    query: { userId, externalRoomTypeId },
+  });
+
+export const saveChannexSetupMapping = ({ userId, mapping }) =>
+  requestChannex("/integrations/channex/setup/mapping", {
+    method: "POST",
+    query: { userId },
+    body: mapping,
+  });
+
 export const getChannexAriPreview = ({ userId, domitsPropertyId, dateFrom, dateTo }) =>
   requestChannex("/integrations/channex/ari-preview", {
     query: { userId, domitsPropertyId, dateFrom, dateTo },


### PR DESCRIPTION
## Close or Relate the Issue

[//]: # 

* Closes: N/A

[//]: # "in the issue a reference will be added to this pr"

* Related Issue: #2861

## Proposed Changes

[//]: # "Add a detailed description of the changes here"

Description:

This PR adds a Channex Setup & Connection flow to the Channex admin/certification panel.

Before this change, the admin panel could check existing mappings/readiness and run certification actions, but the actual Domits-to-Channex mapping still depended on existing backend/database records. This made the connection setup feel too manual for a certification/demo flow.

With this change, an allowlisted Channex admin user can now manage the basic single-unit connection setup from the admin UI:

* load Channex properties from the connected Channex account;
* select a Channex property;
* load/select the related Channex room type;
* load/select the related Channex rate plan;
* save the Domits property to Channex mapping;
* immediately validate readiness after saving.

The setup flow uses the existing mapping tables:

* `channel_integration_property`
* `channel_integration_room_type`
* `channel_integration_rate_plan`

A new admin-only setup mapping endpoint was added:

* `POST /integrations/channex/setup/mapping`

The existing setup/list/link routes are now protected by the same Channex certification allowlist as the rest of the admin/certification routes.

This PR does not change Full Sync, booking create/modify/cancel sync, external booking pull/import, polling, or Channex provider behavior.

## Change Type

* [ ] Bug fix
* [x] New feature
* [ ] Optimization
* [ ] Documentation update

## Change Size

[//]: # "Indicate the size of this change."
[//]: # "Clarify under [Refactoring](https://chatgpt.com/g/g-p-697f7ff03c808191b0c04598bc66b5c0/c/6a06ea98-e38c-8386-88d5-1ccaf8a0cabb#Refactoring) which parts are moved/unchanged code, so the reviewer doesn’t review old logic."

* [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
* [x] Big change (+-max 1000)
* [ ] Small change (less than 300)

## Refactoring

Refactors following files, but didn't change the code. This is to avoid reviewing old logic.

* N/A

## Evidence

* [ ] Screenshots or screen recording added for UI changes
* [ ] Before/after images added when relevant
* [ ] Images clearly show the implemented change
* [ ] Image quality is readable (no cropped or blurry evidence)

## Responsiveness

* [ ] UI checked on mobile
* [ ] UI checked on tablet
* [ ] UI checked on desktop
* [ ] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages

* [ ] NPM Packages installed
* [ ] NPM Packages removed
* [ ] NPM Packages updated
* [ ] Checked for vulnerabilities using "npm audit"

No npm package changes were made.

## Checklist

[//]: # "All boxes must be checked before merging."

* [ ] Pull request has at least 2 reviewers assigned
* [x] PR title is descriptive and includes issue number
* [x] Conventions

  * [x] No config files have been added (Amplify config, cache files)
  * [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  * [x] No global styling (see [[#1691](https://github.com/domits1/Domits/issues/1691)](https://github.com/domits1/Domits/issues/1691))
  * [x] No `console.log` left in code
  * [x] No commented-out code remains
* [x] Testing

  * [x] Code tested locally
  * [x] Jest tests are included
  * [x] Jest tests are passing

## Keep or delete my branch

* [x] Delete my branch after merge
* [ ] Keep my branch