### PR TITLE
feat(channex): sync host calendar changes

### DIFF
--- a/backend/functions/PropertyHandler/business/service/channexCalendarChangeSyncClient.js
+++ b/backend/functions/PropertyHandler/business/service/channexCalendarChangeSyncClient.js
@@ -24,6 +24,12 @@ const decodePayload = (payload) => {
     return new TextDecoder("utf-8").decode(payload);
 };
 
+const buildFallbackError = ({ code, message, httpStatus }) => ({
+    code,
+    message,
+    httpStatus,
+});
+
 export const createCalendarChangeFallbackEvidence = ({
     payload = null,
     skipped,
@@ -47,6 +53,32 @@ export const createCalendarChangeFallbackEvidence = ({
     reason,
 });
 
+const buildCalendarChangeSyncPayload = (payload, internalToken) => ({
+    httpMethod: "POST",
+    path: "/integrations/channex/calendar-change/sync",
+    headers: {
+        "x-domits-internal-token": internalToken,
+    },
+    queryStringParameters: {},
+    body: JSON.stringify(payload),
+});
+
+const createCalendarChangeFailureEvidence = ({ payload, error }) =>
+    createCalendarChangeFallbackEvidence({
+        payload,
+        skipped: false,
+        reason: CHANNEX_CALENDAR_CHANGE_SYNC_FAILED,
+        errors: [buildFallbackError(error)],
+    });
+
+const parseUnifiedMessagingCalendarChangeResponse = (response) => {
+    const lambdaBody = parseJsonSafely(decodePayload(response?.Payload)) || {};
+    return {
+        lambdaBody,
+        evidence: parseJsonSafely(lambdaBody?.body) || lambdaBody?.response || null,
+    };
+};
+
 export default class ChannexCalendarChangeSyncClient {
     constructor({ lambda = lambdaClient, functionName = process.env.UNIFIED_MESSAGING_FUNCTION_NAME } = {}) {
         this.lambda = lambda;
@@ -67,48 +99,31 @@ export default class ChannexCalendarChangeSyncClient {
             const response = await this.lambda.send(
                 new InvokeCommand({
                     FunctionName: this.functionName,
-                    Payload: JSON.stringify({
-                        httpMethod: "POST",
-                        path: "/integrations/channex/calendar-change/sync",
-                        headers: {
-                            "x-domits-internal-token": internalToken,
-                        },
-                        queryStringParameters: {},
-                        body: JSON.stringify(payload),
-                    }),
+                    Payload: JSON.stringify(buildCalendarChangeSyncPayload(payload, internalToken)),
                 })
             );
 
-            const lambdaBody = parseJsonSafely(decodePayload(response?.Payload)) || {};
-            const evidence = parseJsonSafely(lambdaBody?.body) || lambdaBody?.response || null;
+            const { lambdaBody, evidence } = parseUnifiedMessagingCalendarChangeResponse(response);
             if (response?.FunctionError || Number(lambdaBody?.statusCode) >= 400 || !evidence) {
-                return createCalendarChangeFallbackEvidence({
+                return createCalendarChangeFailureEvidence({
                     payload,
-                    skipped: false,
-                    reason: CHANNEX_CALENDAR_CHANGE_SYNC_FAILED,
-                    errors: [
-                        {
-                            code: response?.FunctionError || lambdaBody?.statusCode || "UNIFIED_MESSAGING_ERROR",
-                            message: evidence?.message || evidence?.error || "UnifiedMessaging calendar-change sync failed.",
-                            httpStatus: lambdaBody?.statusCode ?? null,
-                        },
-                    ],
+                    error: {
+                        code: response?.FunctionError || lambdaBody?.statusCode || "UNIFIED_MESSAGING_ERROR",
+                        message: evidence?.message || evidence?.error || "UnifiedMessaging calendar-change sync failed.",
+                        httpStatus: lambdaBody?.statusCode ?? null,
+                    },
                 });
             }
 
             return evidence;
         } catch (error) {
-            return createCalendarChangeFallbackEvidence({
+            return createCalendarChangeFailureEvidence({
                 payload,
-                skipped: false,
-                reason: CHANNEX_CALENDAR_CHANGE_SYNC_FAILED,
-                errors: [
-                    {
-                        code: error?.code || error?.name || "LAMBDA_INVOKE_FAILED",
-                        message: error?.message || "UnifiedMessaging calendar-change sync invoke failed.",
-                        httpStatus: error?.statusCode ?? null,
-                    },
-                ],
+                error: {
+                    code: error?.code || error?.name || "LAMBDA_INVOKE_FAILED",
+                    message: error?.message || "UnifiedMessaging calendar-change sync invoke failed.",
+                    httpStatus: error?.statusCode ?? null,
+                },
             });
         }
     }

--- a/backend/functions/PropertyHandler/business/service/channexCalendarChangeSyncClient.js
+++ b/backend/functions/PropertyHandler/business/service/channexCalendarChangeSyncClient.js
@@ -1,0 +1,115 @@
+import { InvokeCommand, LambdaClient } from "@aws-sdk/client-lambda";
+
+const REGION = process.env.AWS_REGION || "eu-north-1";
+const DEFAULT_UNIFIED_MESSAGING_FUNCTION_NAME = "UnifiedMessaging";
+export const CHANNEX_CALENDAR_CHANGE_SYNC_TYPE = "calendar-change";
+export const CHANNEX_CALENDAR_CHANGE_SYNC_DISABLED = "CHANNEX_CALENDAR_CHANGE_SYNC_DISABLED";
+export const CHANNEX_CALENDAR_CHANGE_SYNC_FAILED = "CHANNEX_CALENDAR_CHANGE_SYNC_FAILED";
+
+const lambdaClient = new LambdaClient({ region: REGION });
+const requireStr = (value) => (typeof value === "string" && value.trim() ? value.trim() : null);
+
+const parseJsonSafely = (value) => {
+    try {
+        if (!value) return null;
+        return typeof value === "string" ? JSON.parse(value) : value;
+    } catch {
+        return null;
+    }
+};
+
+const decodePayload = (payload) => {
+    if (!payload) return null;
+    if (typeof payload === "string") return payload;
+    return new TextDecoder("utf-8").decode(payload);
+};
+
+export const createCalendarChangeFallbackEvidence = ({
+    payload = null,
+    skipped,
+    reason,
+    errors = [],
+}) => ({
+    syncType: CHANNEX_CALENDAR_CHANGE_SYNC_TYPE,
+    source: payload?.source ?? null,
+    domitsPropertyId: payload?.domitsPropertyId ?? null,
+    changedDates: Array.isArray(payload?.changedDates) ? payload.changedDates : [],
+    dateFrom: payload?.dateFrom ?? null,
+    dateTo: payload?.dateTo ?? null,
+    changeTypes: Array.isArray(payload?.changeTypes) ? payload.changeTypes : [],
+    requestTypes: [],
+    requestCount: 0,
+    taskIds: [],
+    warnings: [],
+    errors,
+    overallSuccess: false,
+    skipped,
+    reason,
+});
+
+export default class ChannexCalendarChangeSyncClient {
+    constructor({ lambda = lambdaClient, functionName = process.env.UNIFIED_MESSAGING_FUNCTION_NAME } = {}) {
+        this.lambda = lambda;
+        this.functionName = functionName || DEFAULT_UNIFIED_MESSAGING_FUNCTION_NAME;
+    }
+
+    async syncCalendarChange(payload) {
+        const internalToken = requireStr(process.env.CHANNEX_BOOKING_AVAILABILITY_INTERNAL_TOKEN);
+        if (!internalToken) {
+            return createCalendarChangeFallbackEvidence({
+                payload,
+                skipped: true,
+                reason: "CHANNEX_BOOKING_AVAILABILITY_INTERNAL_TOKEN_MISSING",
+            });
+        }
+
+        try {
+            const response = await this.lambda.send(
+                new InvokeCommand({
+                    FunctionName: this.functionName,
+                    Payload: JSON.stringify({
+                        httpMethod: "POST",
+                        path: "/integrations/channex/calendar-change/sync",
+                        headers: {
+                            "x-domits-internal-token": internalToken,
+                        },
+                        queryStringParameters: {},
+                        body: JSON.stringify(payload),
+                    }),
+                })
+            );
+
+            const lambdaBody = parseJsonSafely(decodePayload(response?.Payload)) || {};
+            const evidence = parseJsonSafely(lambdaBody?.body) || lambdaBody?.response || null;
+            if (response?.FunctionError || Number(lambdaBody?.statusCode) >= 400 || !evidence) {
+                return createCalendarChangeFallbackEvidence({
+                    payload,
+                    skipped: false,
+                    reason: CHANNEX_CALENDAR_CHANGE_SYNC_FAILED,
+                    errors: [
+                        {
+                            code: response?.FunctionError || lambdaBody?.statusCode || "UNIFIED_MESSAGING_ERROR",
+                            message: evidence?.message || evidence?.error || "UnifiedMessaging calendar-change sync failed.",
+                            httpStatus: lambdaBody?.statusCode ?? null,
+                        },
+                    ],
+                });
+            }
+
+            return evidence;
+        } catch (error) {
+            return createCalendarChangeFallbackEvidence({
+                payload,
+                skipped: false,
+                reason: CHANNEX_CALENDAR_CHANGE_SYNC_FAILED,
+                errors: [
+                    {
+                        code: error?.code || error?.name || "LAMBDA_INVOKE_FAILED",
+                        message: error?.message || "UnifiedMessaging calendar-change sync invoke failed.",
+                        httpStatus: error?.statusCode ?? null,
+                    },
+                ],
+            });
+        }
+    }
+}

--- a/backend/functions/PropertyHandler/controller/propertyController.js
+++ b/backend/functions/PropertyHandler/controller/propertyController.js
@@ -11,6 +11,9 @@ import { DirectBookingWebsiteSiteRepository } from "../data/repository/directBoo
 import { DirectBookingWebsiteDomainRepository } from "../data/repository/directBookingWebsiteDomainRepository.js";
 import { randomUUID } from "node:crypto";
 import { PriceLabsCalendarNotifier } from "../business/service/priceLabsCalendarNotifier.js";
+import ChannexCalendarChangeSyncClient, {
+    createCalendarChangeFallbackEvidence,
+} from "../business/service/channexCalendarChangeSyncClient.js";
 
 import responseHeaders from "../util/constant/responseHeader.json" with { type: "json" };
 import { NotFoundException } from "../util/exception/NotFoundException.js";
@@ -45,6 +48,12 @@ const WEBSITE_ANALYTICS_VIEWPORTS = new Set(["mobile", "tablet", "desktop"]);
 const DIRECT_BOOKING_WEBSITE_PUBLIC_STATUSES = new Set(["DRAFT", "PREVIEW", "PUBLISHED", "SUSPENDED"]);
 const DIRECT_BOOKING_WEBSITE_DOMAIN_STATUSES = new Set(["PENDING", "VERIFIED", "ACTIVE", "FAILED", "DISABLED"]);
 const DIRECT_BOOKING_WEBSITE_DOMAIN_TYPE_FALLBACK = "FALLBACK";
+const CHANNEX_GLOBAL_CALENDAR_CHANGE_SYNC_DAYS = 500;
+const CALENDAR_CHANGE_FIELD_GROUPS = Object.freeze({
+    availability: ["isAvailable"],
+    rates: ["nightlyPrice"],
+    restrictions: ["stopSell", "closedToArrival", "closedToDeparture", "minStay", "maxStay"],
+});
 
 const cleanWebsiteText = (value) => String(value || "").replaceAll(/\s+/g, " ").trim();
 const isPlainObject = (value) => Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -133,7 +142,11 @@ export class PropertyController {
     propertyService;
     authManager;
 
-    constructor(dynamoDbClient = new DynamoDBClient({}), systemManagerRepository = new SystemManagerRepository()) {
+    constructor(
+        dynamoDbClient = new DynamoDBClient({}),
+        systemManagerRepository = new SystemManagerRepository(),
+        { channexCalendarChangeSyncClient = new ChannexCalendarChangeSyncClient() } = {}
+    ) {
         this.authManager = new AuthManager(dynamoDbClient, systemManagerRepository);
         this.propertyService = new PropertyService(dynamoDbClient, systemManagerRepository);
         this.propertyImageRepository = new PropertyImageRepository(systemManagerRepository);
@@ -142,6 +155,7 @@ export class PropertyController {
         this.directBookingWebsiteEventRepository = new DirectBookingWebsiteEventRepository(systemManagerRepository);
         this.directBookingWebsiteSiteRepository = new DirectBookingWebsiteSiteRepository(systemManagerRepository);
         this.directBookingWebsiteDomainRepository = new DirectBookingWebsiteDomainRepository(systemManagerRepository);
+        this.channexCalendarChangeSyncClient = channexCalendarChangeSyncClient;
     }
 
     // -------------------------
@@ -484,6 +498,11 @@ export class PropertyController {
             );
 
             await new PriceLabsCalendarNotifier().notifyListingChange(hostId);
+            await this.notifyChannexOverviewCalendarChange({
+                hostId,
+                propertyId: normalizedOverviewPayload.propertyId,
+                normalizedOverviewPayload,
+            });
 
             return {
                 statusCode: 204,
@@ -561,6 +580,7 @@ export class PropertyController {
 
             const normalizedRange = this.normalizeCalendarOverrideRangePayload(body);
             const hostId = await this.authManager.authorizePropertyCalendarOverrideRequest(accessToken, propertyId);
+            const previousOverrides = await this.getPreviousCalendarOverridesForChanges(propertyId, normalizedOverrides);
 
             const overrides = await this.propertyService.updatePropertyCalendarOverrides(
                 propertyId,
@@ -569,6 +589,12 @@ export class PropertyController {
             );
 
             await new PriceLabsCalendarNotifier().notifyCalendarChange(hostId);
+            const channexCalendarChangeSync = await this.notifyChannexCalendarOverrideChange({
+                hostId,
+                propertyId,
+                previousOverrides,
+                normalizedOverrides,
+            });
 
             return {
                 statusCode: 200,
@@ -576,6 +602,7 @@ export class PropertyController {
                 body: JSON.stringify({
                     propertyId,
                     overrides,
+                    channexCalendarChangeSync,
                 }),
             };
         } catch (error) {
@@ -589,6 +616,132 @@ export class PropertyController {
                 body: JSON.stringify(error.message || "Something went wrong, please contact support.")
             };
         }
+    }
+
+    calendarDateIntToIsoDate(value) {
+        const rawValue = String(value || "").trim();
+        if (!/^\d{8}$/.test(rawValue)) {
+            return null;
+        }
+        return `${rawValue.slice(0, 4)}-${rawValue.slice(4, 6)}-${rawValue.slice(6, 8)}`;
+    }
+
+    buildCalendarOverrideMap(overrides) {
+        return new Map(
+            (Array.isArray(overrides) ? overrides : [])
+                .map((override) => {
+                    const date = Number(override?.calendarDate ?? override?.date);
+                    return Number.isInteger(date) ? [date, override] : null;
+                })
+                .filter(Boolean)
+        );
+    }
+
+    compareCalendarOverrideField(previousOverride, nextOverride, field) {
+        const previousValue = previousOverride?.[field] ?? null;
+        const nextValue = nextOverride?.[field] ?? null;
+        return previousValue !== nextValue;
+    }
+
+    collectCalendarOverrideChangeTypes(previousOverrides, normalizedOverrides) {
+        const previousByDate = this.buildCalendarOverrideMap(previousOverrides);
+        const changeTypes = new Set();
+        const changedDates = [];
+
+        for (const override of normalizedOverrides) {
+            const previousOverride = previousByDate.get(override.calendarDate) || {};
+            const dateChangeTypes = Object.entries(CALENDAR_CHANGE_FIELD_GROUPS)
+                .filter(([, fields]) =>
+                    fields.some((field) => this.compareCalendarOverrideField(previousOverride, override, field))
+                )
+                .map(([changeType]) => changeType);
+
+            if (dateChangeTypes.length) {
+                changedDates.push(this.calendarDateIntToIsoDate(override.calendarDate));
+                dateChangeTypes.forEach((changeType) => changeTypes.add(changeType));
+            }
+        }
+
+        return {
+            changedDates: changedDates.filter(Boolean).sort(),
+            changeTypes: Array.from(changeTypes).sort(),
+        };
+    }
+
+    async getPreviousCalendarOverridesForChanges(propertyId, normalizedOverrides) {
+        const dates = normalizedOverrides.map((override) => Number(override.calendarDate)).filter(Number.isInteger);
+        if (!dates.length) return [];
+
+        return await this.propertyService.getPropertyCalendarOverrides(propertyId, {
+            startDate: Math.min(...dates),
+            endDate: Math.max(...dates),
+        });
+    }
+
+    async notifyChannexCalendarOverrideChange({
+        hostId,
+        propertyId,
+        previousOverrides,
+        normalizedOverrides,
+    }) {
+        const { changedDates, changeTypes } = this.collectCalendarOverrideChangeTypes(
+            previousOverrides,
+            normalizedOverrides
+        );
+        const payload = {
+            userId: hostId,
+            domitsPropertyId: propertyId,
+            changedDates,
+            changeTypes,
+            source: "HOST_CALENDAR_OVERRIDES_CHANGED",
+        };
+
+        if (!changedDates.length || !changeTypes.length) {
+            return createCalendarChangeFallbackEvidence({
+                payload,
+                skipped: true,
+                reason: "NO_CHANNEX_RELEVANT_CALENDAR_CHANGES",
+            });
+        }
+
+        return await this.channexCalendarChangeSyncClient.syncCalendarChange(payload);
+    }
+
+    getForwardCalendarSyncRange() {
+        const startDate = new Date();
+        const endDate = new Date(startDate);
+        endDate.setUTCDate(endDate.getUTCDate() + CHANNEX_GLOBAL_CALENDAR_CHANGE_SYNC_DAYS - 1);
+
+        return {
+            dateFrom: startDate.toISOString().slice(0, 10),
+            dateTo: endDate.toISOString().slice(0, 10),
+        };
+    }
+
+    getOverviewCalendarChangeTypes(normalizedOverviewPayload) {
+        const changeTypes = [];
+        if (normalizedOverviewPayload.pricing !== undefined) {
+            changeTypes.push("rates");
+        }
+        if (normalizedOverviewPayload.availabilityRestrictions !== undefined) {
+            changeTypes.push("restrictions");
+        }
+        return changeTypes;
+    }
+
+    async notifyChannexOverviewCalendarChange({ hostId, propertyId, normalizedOverviewPayload }) {
+        const changeTypes = this.getOverviewCalendarChangeTypes(normalizedOverviewPayload);
+        if (!changeTypes.length) return null;
+
+        const payload = {
+            userId: hostId,
+            domitsPropertyId: propertyId,
+            ...this.getForwardCalendarSyncRange(),
+            changeTypes,
+            source: "HOST_CALENDAR_GLOBAL_SETTINGS_CHANGED",
+        };
+
+        return await this.channexCalendarChangeSyncClient.syncCalendarChange(payload);
     }
 
     extractOverviewPayload(body) {

--- a/backend/functions/PropertyHandler/controller/propertyController.js
+++ b/backend/functions/PropertyHandler/controller/propertyController.js
@@ -74,6 +74,7 @@ const trimRepeatedCharacterEdges = (value, character) => {
 
     return value.slice(startIndex, endIndex);
 };
+const compareAsString = (left, right) => String(left).localeCompare(String(right));
 const slugifyWebsiteDomainLabel = (value) => {
     const normalizedValue = cleanWebsiteText(value).normalize("NFKD").toLowerCase();
     let sanitizedValue = "";
@@ -663,8 +664,8 @@ export class PropertyController {
         }
 
         return {
-            changedDates: changedDates.filter(Boolean).sort(),
-            changeTypes: Array.from(changeTypes).sort(),
+            changedDates: changedDates.filter(Boolean).sort(compareAsString),
+            changeTypes: Array.from(changeTypes).sort(compareAsString),
         };
     }
 

--- a/backend/functions/UnifiedMessaging/business/integrationService.channexAri.test.js
+++ b/backend/functions/UnifiedMessaging/business/integrationService.channexAri.test.js
@@ -321,6 +321,34 @@ const createSuccessfulRestrictionsPush = () => createRestrictionsPush();
 
 const createSuccessfulAvailabilityPush = () => createAvailabilityPush();
 
+const buildCalendarChangeRequest = (overrides = {}) => ({
+  userId: "user-1",
+  domitsPropertyId: "domits-property-1",
+  changedDates: ["2026-05-01"],
+  changeTypes: ["availability"],
+  source: "HOST_CALENDAR_OVERRIDES_CHANGED",
+  ...overrides,
+});
+
+const createCalendarChangeService = ({
+  pushAvailability = jest.fn().mockResolvedValue({ results: [] }),
+  pushRestrictions = jest.fn().mockResolvedValue({ results: [] }),
+} = {}) => ({
+  pushAvailability,
+  pushRestrictions,
+  service: createService({
+    channexProviderClient: {
+      pushAvailability,
+      pushRestrictions,
+    },
+  }),
+});
+
+const syncCalendarChangeForTest = (service, overrides = {}) =>
+  service.syncChannexCalendarChange(buildCalendarChangeRequest(overrides), { skipEvidence: true });
+
+const extractFirstRestrictionsValue = (pushRestrictions) => pushRestrictions.mock.calls[0]?.[1]?.[0]?.values?.[0];
+
 const expectValidChannexRestrictionProviderValues = (payloads) => {
   for (const payload of Array.isArray(payloads) ? payloads : []) {
     for (const value of Array.isArray(payload?.values) ? payload.values : []) {
@@ -802,8 +830,6 @@ describe("IntegrationService Channex ARI restriction mapping", () => {
   });
 
   test("host calendar availability changes send booking-aware change-only availability", async () => {
-    const pushAvailability = createAvailabilityPush();
-    const pushRestrictions = jest.fn().mockResolvedValue({ results: [] });
     Database.getInstance.mockResolvedValue(
       buildDatabaseClient({
         availabilityWindows: [buildAvailableWindow(20260601, 20260603)],
@@ -816,23 +842,14 @@ describe("IntegrationService Channex ARI restriction mapping", () => {
         ],
       })
     );
-    const service = createService({
-      channexProviderClient: {
-        pushAvailability,
-        pushRestrictions,
-      },
+    const { service, pushAvailability, pushRestrictions } = createCalendarChangeService({
+      pushAvailability: createAvailabilityPush(),
     });
 
-    const result = await service.syncChannexCalendarChange(
-      {
-        userId: "user-1",
-        domitsPropertyId: "domits-property-1",
-        changedDates: ["2026-06-01", "2026-06-02"],
-        changeTypes: ["availability"],
-        source: "HOST_CALENDAR_OVERRIDES_CHANGED",
-      },
-      { skipEvidence: true }
-    );
+    const result = await syncCalendarChangeForTest(service, {
+      changedDates: ["2026-06-01", "2026-06-02"],
+      changeTypes: ["availability"],
+    });
 
     expect(result.statusCode).toBe(200);
     expect(result.response.syncType).toBe("calendar-change");
@@ -847,31 +864,17 @@ describe("IntegrationService Channex ARI restriction mapping", () => {
   });
 
   test("host calendar rate changes send rates only through restrictions endpoint", async () => {
-    const pushAvailability = jest.fn().mockResolvedValue({ results: [] });
-    const pushRestrictions = createRestrictionsPush();
-    const service = createService({
-      channexProviderClient: {
-        pushAvailability,
-        pushRestrictions,
-      },
+    const { service, pushAvailability, pushRestrictions } = createCalendarChangeService({
+      pushRestrictions: createRestrictionsPush(),
     });
 
-    const result = await service.syncChannexCalendarChange(
-      {
-        userId: "user-1",
-        domitsPropertyId: "domits-property-1",
-        changedDates: ["2026-05-01"],
-        changeTypes: ["rates"],
-        source: "HOST_CALENDAR_OVERRIDES_CHANGED",
-      },
-      { skipEvidence: true }
-    );
+    const result = await syncCalendarChangeForTest(service, { changeTypes: ["rates"] });
 
     expect(result.statusCode).toBe(200);
     expect(result.response.requestTypes).toEqual(["restrictions/rates"]);
     expect(pushAvailability).not.toHaveBeenCalled();
     expect(pushRestrictions).toHaveBeenCalledTimes(1);
-    const [value] = pushRestrictions.mock.calls[0][1][0].values;
+    const value = extractFirstRestrictionsValue(pushRestrictions);
     expect(value).toEqual({
       property_id: "external-property-1",
       rate_plan_id: "rate-plan-1",
@@ -881,31 +884,17 @@ describe("IntegrationService Channex ARI restriction mapping", () => {
   });
 
   test("host calendar restriction changes include explicit false values without rate", async () => {
-    const pushAvailability = jest.fn().mockResolvedValue({ results: [] });
-    const pushRestrictions = createRestrictionsPush();
-    const service = createService({
-      channexProviderClient: {
-        pushAvailability,
-        pushRestrictions,
-      },
+    const { service, pushAvailability, pushRestrictions } = createCalendarChangeService({
+      pushRestrictions: createRestrictionsPush(),
     });
 
-    const result = await service.syncChannexCalendarChange(
-      {
-        userId: "user-1",
-        domitsPropertyId: "domits-property-1",
-        changedDates: ["2026-05-01"],
-        changeTypes: ["restrictions"],
-        source: "HOST_CALENDAR_OVERRIDES_CHANGED",
-      },
-      { skipEvidence: true }
-    );
+    const result = await syncCalendarChangeForTest(service, { changeTypes: ["restrictions"] });
 
     expect(result.statusCode).toBe(200);
     expect(result.response.requestTypes).toEqual(["restrictions/rates"]);
     expect(pushAvailability).not.toHaveBeenCalled();
     expect(pushRestrictions).toHaveBeenCalledTimes(1);
-    const [value] = pushRestrictions.mock.calls[0][1][0].values;
+    const value = extractFirstRestrictionsValue(pushRestrictions);
     expect(value).toEqual({
       property_id: "external-property-1",
       rate_plan_id: "rate-plan-1",

--- a/backend/functions/UnifiedMessaging/business/integrationService.channexAri.test.js
+++ b/backend/functions/UnifiedMessaging/business/integrationService.channexAri.test.js
@@ -801,6 +801,123 @@ describe("IntegrationService Channex ARI restriction mapping", () => {
     });
   });
 
+  test("host calendar availability changes send booking-aware change-only availability", async () => {
+    const pushAvailability = createAvailabilityPush();
+    const pushRestrictions = jest.fn().mockResolvedValue({ results: [] });
+    Database.getInstance.mockResolvedValue(
+      buildDatabaseClient({
+        availabilityWindows: [buildAvailableWindow(20260601, 20260603)],
+        bookings: [
+          buildBookingRow({
+            arrivaldate: "2026-06-01",
+            departuredate: "2026-06-03",
+            status: "Paid",
+          }),
+        ],
+      })
+    );
+    const service = createService({
+      channexProviderClient: {
+        pushAvailability,
+        pushRestrictions,
+      },
+    });
+
+    const result = await service.syncChannexCalendarChange(
+      {
+        userId: "user-1",
+        domitsPropertyId: "domits-property-1",
+        changedDates: ["2026-06-01", "2026-06-02"],
+        changeTypes: ["availability"],
+        source: "HOST_CALENDAR_OVERRIDES_CHANGED",
+      },
+      { skipEvidence: true }
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(result.response.syncType).toBe("calendar-change");
+    expect(result.response.requestTypes).toEqual(["availability"]);
+    expect(result.response.requestCount).toBe(1);
+    expect(pushAvailability).toHaveBeenCalledTimes(1);
+    expect(pushRestrictions).not.toHaveBeenCalled();
+    expectAvailabilityByDate(pushAvailability, {
+      "2026-06-01": 0,
+      "2026-06-02": 0,
+    });
+  });
+
+  test("host calendar rate changes send rates only through restrictions endpoint", async () => {
+    const pushAvailability = jest.fn().mockResolvedValue({ results: [] });
+    const pushRestrictions = createRestrictionsPush();
+    const service = createService({
+      channexProviderClient: {
+        pushAvailability,
+        pushRestrictions,
+      },
+    });
+
+    const result = await service.syncChannexCalendarChange(
+      {
+        userId: "user-1",
+        domitsPropertyId: "domits-property-1",
+        changedDates: ["2026-05-01"],
+        changeTypes: ["rates"],
+        source: "HOST_CALENDAR_OVERRIDES_CHANGED",
+      },
+      { skipEvidence: true }
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(result.response.requestTypes).toEqual(["restrictions/rates"]);
+    expect(pushAvailability).not.toHaveBeenCalled();
+    expect(pushRestrictions).toHaveBeenCalledTimes(1);
+    const [value] = pushRestrictions.mock.calls[0][1][0].values;
+    expect(value).toEqual({
+      property_id: "external-property-1",
+      rate_plan_id: "rate-plan-1",
+      date: "2026-05-01",
+      rate: "123.00",
+    });
+  });
+
+  test("host calendar restriction changes include explicit false values without rate", async () => {
+    const pushAvailability = jest.fn().mockResolvedValue({ results: [] });
+    const pushRestrictions = createRestrictionsPush();
+    const service = createService({
+      channexProviderClient: {
+        pushAvailability,
+        pushRestrictions,
+      },
+    });
+
+    const result = await service.syncChannexCalendarChange(
+      {
+        userId: "user-1",
+        domitsPropertyId: "domits-property-1",
+        changedDates: ["2026-05-01"],
+        changeTypes: ["restrictions"],
+        source: "HOST_CALENDAR_OVERRIDES_CHANGED",
+      },
+      { skipEvidence: true }
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(result.response.requestTypes).toEqual(["restrictions/rates"]);
+    expect(pushAvailability).not.toHaveBeenCalled();
+    expect(pushRestrictions).toHaveBeenCalledTimes(1);
+    const [value] = pushRestrictions.mock.calls[0][1][0].values;
+    expect(value).toEqual({
+      property_id: "external-property-1",
+      rate_plan_id: "rate-plan-1",
+      date: "2026-05-01",
+      stop_sell: true,
+      closed_to_arrival: true,
+      closed_to_departure: false,
+      min_stay_through: 4,
+    });
+    expect(value).not.toHaveProperty("rate");
+  });
+
   test("restrictions sync supports a 500-day range and sends one combined provider request", async () => {
     const pushRestrictions = createSuccessfulRestrictionsPush();
     const service = createService({

--- a/backend/functions/UnifiedMessaging/business/integrationService.channexAri.test.js
+++ b/backend/functions/UnifiedMessaging/business/integrationService.channexAri.test.js
@@ -321,6 +321,23 @@ const createSuccessfulRestrictionsPush = () => createRestrictionsPush();
 
 const createSuccessfulAvailabilityPush = () => createAvailabilityPush();
 
+const BOOKED_CALENDAR_DATES = ["2026-06-01", "2026-06-02"];
+
+const mockAvailabilityWindowWithPaidBooking = () => {
+  Database.getInstance.mockResolvedValue(
+    buildDatabaseClient({
+      availabilityWindows: [buildAvailableWindow(20260601, 20260603)],
+      bookings: [
+        buildBookingRow({
+          arrivaldate: "2026-06-01",
+          departuredate: "2026-06-03",
+          status: "Paid",
+        }),
+      ],
+    })
+  );
+};
+
 const buildCalendarChangeRequest = (overrides = {}) => ({
   userId: "user-1",
   domitsPropertyId: "domits-property-1",
@@ -348,6 +365,35 @@ const syncCalendarChangeForTest = (service, overrides = {}) =>
   service.syncChannexCalendarChange(buildCalendarChangeRequest(overrides), { skipEvidence: true });
 
 const extractFirstRestrictionsValue = (pushRestrictions) => pushRestrictions.mock.calls[0]?.[1]?.[0]?.values?.[0];
+
+const expectOnlyAvailabilityCalendarChange = ({ result, pushAvailability, pushRestrictions, expectedAvailability }) => {
+  expect(result.statusCode).toBe(200);
+  expect(result.response.syncType).toBe("calendar-change");
+  expect(result.response.requestTypes).toEqual(["availability"]);
+  expect(result.response.requestCount).toBe(1);
+  expect(pushAvailability).toHaveBeenCalledTimes(1);
+  expect(pushRestrictions).not.toHaveBeenCalled();
+  expectAvailabilityByDate(pushAvailability, expectedAvailability);
+};
+
+const expectOnlyRestrictionsCalendarChange = ({ result, pushAvailability, pushRestrictions }) => {
+  expect(result.statusCode).toBe(200);
+  expect(result.response.requestTypes).toEqual(["restrictions/rates"]);
+  expect(pushAvailability).not.toHaveBeenCalled();
+  expect(pushRestrictions).toHaveBeenCalledTimes(1);
+};
+
+const syncRestrictionsCalendarChangeForTest = async (changeTypes) => {
+  const calendarChange = createCalendarChangeService({
+    pushRestrictions: createRestrictionsPush(),
+  });
+  const result = await syncCalendarChangeForTest(calendarChange.service, { changeTypes });
+  return {
+    ...calendarChange,
+    result,
+    value: extractFirstRestrictionsValue(calendarChange.pushRestrictions),
+  };
+};
 
 const expectValidChannexRestrictionProviderValues = (payloads) => {
   for (const payload of Array.isArray(payloads) ? payloads : []) {
@@ -792,18 +838,7 @@ describe("IntegrationService Channex ARI restriction mapping", () => {
 
   test("availability sync sends booking-aware effective availability", async () => {
     const pushAvailability = createAvailabilityPush();
-    Database.getInstance.mockResolvedValue(
-      buildDatabaseClient({
-        availabilityWindows: [buildAvailableWindow(20260601, 20260603)],
-        bookings: [
-          buildBookingRow({
-            arrivaldate: "2026-06-01",
-            departuredate: "2026-06-03",
-            status: "Paid",
-          }),
-        ],
-      })
-    );
+    mockAvailabilityWindowWithPaidBooking();
     const service = createService({
       channexProviderClient: {
         pushAvailability,
@@ -830,51 +865,33 @@ describe("IntegrationService Channex ARI restriction mapping", () => {
   });
 
   test("host calendar availability changes send booking-aware change-only availability", async () => {
-    Database.getInstance.mockResolvedValue(
-      buildDatabaseClient({
-        availabilityWindows: [buildAvailableWindow(20260601, 20260603)],
-        bookings: [
-          buildBookingRow({
-            arrivaldate: "2026-06-01",
-            departuredate: "2026-06-03",
-            status: "Paid",
-          }),
-        ],
-      })
-    );
+    mockAvailabilityWindowWithPaidBooking();
     const { service, pushAvailability, pushRestrictions } = createCalendarChangeService({
       pushAvailability: createAvailabilityPush(),
     });
 
     const result = await syncCalendarChangeForTest(service, {
-      changedDates: ["2026-06-01", "2026-06-02"],
+      changedDates: BOOKED_CALENDAR_DATES,
       changeTypes: ["availability"],
     });
 
-    expect(result.statusCode).toBe(200);
-    expect(result.response.syncType).toBe("calendar-change");
-    expect(result.response.requestTypes).toEqual(["availability"]);
-    expect(result.response.requestCount).toBe(1);
-    expect(pushAvailability).toHaveBeenCalledTimes(1);
-    expect(pushRestrictions).not.toHaveBeenCalled();
-    expectAvailabilityByDate(pushAvailability, {
-      "2026-06-01": 0,
-      "2026-06-02": 0,
+    expectOnlyAvailabilityCalendarChange({
+      result,
+      pushAvailability,
+      pushRestrictions,
+      expectedAvailability: {
+        "2026-06-01": 0,
+        "2026-06-02": 0,
+      },
     });
   });
 
   test("host calendar rate changes send rates only through restrictions endpoint", async () => {
-    const { service, pushAvailability, pushRestrictions } = createCalendarChangeService({
-      pushRestrictions: createRestrictionsPush(),
-    });
+    const { result, pushAvailability, pushRestrictions, value } = await syncRestrictionsCalendarChangeForTest([
+      "rates",
+    ]);
 
-    const result = await syncCalendarChangeForTest(service, { changeTypes: ["rates"] });
-
-    expect(result.statusCode).toBe(200);
-    expect(result.response.requestTypes).toEqual(["restrictions/rates"]);
-    expect(pushAvailability).not.toHaveBeenCalled();
-    expect(pushRestrictions).toHaveBeenCalledTimes(1);
-    const value = extractFirstRestrictionsValue(pushRestrictions);
+    expectOnlyRestrictionsCalendarChange({ result, pushAvailability, pushRestrictions });
     expect(value).toEqual({
       property_id: "external-property-1",
       rate_plan_id: "rate-plan-1",
@@ -884,17 +901,11 @@ describe("IntegrationService Channex ARI restriction mapping", () => {
   });
 
   test("host calendar restriction changes include explicit false values without rate", async () => {
-    const { service, pushAvailability, pushRestrictions } = createCalendarChangeService({
-      pushRestrictions: createRestrictionsPush(),
-    });
+    const { result, pushAvailability, pushRestrictions, value } = await syncRestrictionsCalendarChangeForTest([
+      "restrictions",
+    ]);
 
-    const result = await syncCalendarChangeForTest(service, { changeTypes: ["restrictions"] });
-
-    expect(result.statusCode).toBe(200);
-    expect(result.response.requestTypes).toEqual(["restrictions/rates"]);
-    expect(pushAvailability).not.toHaveBeenCalled();
-    expect(pushRestrictions).toHaveBeenCalledTimes(1);
-    const value = extractFirstRestrictionsValue(pushRestrictions);
+    expectOnlyRestrictionsCalendarChange({ result, pushAvailability, pushRestrictions });
     expect(value).toEqual({
       property_id: "external-property-1",
       rate_plan_id: "rate-plan-1",

--- a/backend/functions/UnifiedMessaging/business/integrationService.js
+++ b/backend/functions/UnifiedMessaging/business/integrationService.js
@@ -8097,307 +8097,344 @@ export default class IntegrationService {
     }
   }
 
-  async syncChannexCalendarChange(body = {}, options = {}) {
+  buildChannexCalendarChangeContext(body = {}) {
     const startedAt = nowMs();
-    const normalizedUserId = requireStr(body?.userId);
-    const normalizedDomitsPropertyId = requireStr(body?.domitsPropertyId);
-    const source = requireStr(body?.source) || "HOST_CALENDAR_CHANGED";
-    const changeTypes = normalizeChannexCalendarChangeTypes(body?.changeTypes);
-    const dateContext = buildChannexCalendarChangeDateContext(body);
-    const finalize = this.createChannexSyncFinalizer({
-      normalizedUserId,
-      normalizedDomitsPropertyId,
-      normalizedDateFrom: dateContext.dateFrom,
-      normalizedDateTo: dateContext.dateTo,
+    return {
+      startedAt,
+      normalizedUserId: requireStr(body?.userId),
+      normalizedDomitsPropertyId: requireStr(body?.domitsPropertyId),
+      source: requireStr(body?.source) || "HOST_CALENDAR_CHANGED",
+      changeTypes: normalizeChannexCalendarChangeTypes(body?.changeTypes),
+      dateContext: buildChannexCalendarChangeDateContext(body),
       rawDateFrom: body?.dateFrom,
       rawDateTo: body?.dateTo,
-      startedAt,
+    };
+  }
+
+  createChannexCalendarChangeFinalizer(context, options) {
+    return this.createChannexSyncFinalizer({
+      normalizedUserId: context.normalizedUserId,
+      normalizedDomitsPropertyId: context.normalizedDomitsPropertyId,
+      normalizedDateFrom: context.dateContext.dateFrom,
+      normalizedDateTo: context.dateContext.dateTo,
+      rawDateFrom: context.rawDateFrom,
+      rawDateTo: context.rawDateTo,
+      startedAt: context.startedAt,
       syncType: CHANNEX_CALENDAR_CHANGE_SYNC_TYPE,
       options,
     });
+  }
 
-    if (!normalizedUserId) {
-      return await finalize(bad(400, { error: "Missing required field: userId" }), {
-        status: "INVALID_REQUEST",
-        errors: [{ errorCode: "MISSING_USER_ID", errorMessage: "Missing required field: userId" }],
-      });
+  buildChannexCalendarChangeValidationFailure(context) {
+    if (!context.normalizedUserId) {
+      return {
+        response: bad(400, { error: "Missing required field: userId" }),
+        evidencePatch: {
+          status: "INVALID_REQUEST",
+          errors: [{ errorCode: "MISSING_USER_ID", errorMessage: "Missing required field: userId" }],
+        },
+      };
     }
-    if (!normalizedDomitsPropertyId) {
-      return await finalize(bad(400, { error: "Missing required field: domitsPropertyId" }), {
-        status: "INVALID_REQUEST",
-        errors: [
-          { errorCode: "MISSING_DOMITS_PROPERTY_ID", errorMessage: "Missing required field: domitsPropertyId" },
-        ],
-      });
+    if (!context.normalizedDomitsPropertyId) {
+      return {
+        response: bad(400, { error: "Missing required field: domitsPropertyId" }),
+        evidencePatch: {
+          status: "INVALID_REQUEST",
+          errors: [
+            { errorCode: "MISSING_DOMITS_PROPERTY_ID", errorMessage: "Missing required field: domitsPropertyId" },
+          ],
+        },
+      };
     }
-    if (!dateContext.dateFrom || !dateContext.dateTo || dateContext.dateFrom > dateContext.dateTo) {
-      return await finalize(bad(400, { error: "Invalid or missing calendar-change date range." }), {
-        status: "INVALID_REQUEST",
-        errors: [
-          {
-            errorCode: "CHANNEX_CALENDAR_CHANGE_DATE_RANGE_INVALID",
-            errorMessage: "Calendar-change sync needs changedDates or a valid dateFrom/dateTo range.",
-          },
-        ],
-      });
+    if (
+      !context.dateContext.dateFrom ||
+      !context.dateContext.dateTo ||
+      context.dateContext.dateFrom > context.dateContext.dateTo
+    ) {
+      return {
+        response: bad(400, { error: "Invalid or missing calendar-change date range." }),
+        evidencePatch: {
+          status: "INVALID_REQUEST",
+          errors: [
+            {
+              errorCode: "CHANNEX_CALENDAR_CHANGE_DATE_RANGE_INVALID",
+              errorMessage: "Calendar-change sync needs changedDates or a valid dateFrom/dateTo range.",
+            },
+          ],
+        },
+      };
     }
     const validationFailure = buildSyncDateRangeValidationFailure({
-      normalizedUserId,
-      normalizedDomitsPropertyId,
-      normalizedDateFrom: dateContext.dateFrom,
-      normalizedDateTo: dateContext.dateTo,
+      normalizedUserId: context.normalizedUserId,
+      normalizedDomitsPropertyId: context.normalizedDomitsPropertyId,
+      normalizedDateFrom: context.dateContext.dateFrom,
+      normalizedDateTo: context.dateContext.dateTo,
     });
-    if (validationFailure) return await finalize(validationFailure.response, validationFailure.evidencePatch);
-    if (!changeTypes.length) {
-      return await finalize(bad(400, { error: "Missing required field: changeTypes" }), {
-        status: "INVALID_REQUEST",
-        errors: [
-          {
-            errorCode: "CHANNEX_CALENDAR_CHANGE_TYPES_MISSING",
-            errorMessage: "Calendar-change sync needs at least one supported change type.",
-          },
-        ],
-      });
+    if (validationFailure) return validationFailure;
+    if (!context.changeTypes.length) {
+      return {
+        response: bad(400, { error: "Missing required field: changeTypes" }),
+        evidencePatch: {
+          status: "INVALID_REQUEST",
+          errors: [
+            {
+              errorCode: "CHANNEX_CALENDAR_CHANGE_TYPES_MISSING",
+              errorMessage: "Calendar-change sync needs at least one supported change type.",
+            },
+          ],
+        },
+      };
     }
+    return null;
+  }
 
-    const baseNotes = [
+  getChannexCalendarChangeBaseNotes() {
+    return [
       "Host calendar change-only sync. This endpoint sends only the Channex provider payloads needed for the changed calendar fields.",
       "Availability values are rebuilt from Domits effective availability, including active booking occupancy, before sending to Channex.",
     ];
+  }
 
-    try {
-      const readinessResult = await this.getChannexAriTargets(normalizedUserId, normalizedDomitsPropertyId);
-      if (readinessResult?.statusCode !== 200) {
-        return await finalize(readinessResult, this.buildChannexAriTargetsFailureEvidencePatch(readinessResult));
-      }
+  buildChannexCalendarChangeBlockedResult({ readiness, context, baseNotes, mappingSnapshot }) {
+    const response = ok({
+      channel: readiness.channel || "CHANNEX",
+      integrationAccountId: readiness.integrationAccountId || null,
+      domitsPropertyId: context.normalizedDomitsPropertyId,
+      source: context.source,
+      dateFrom: context.dateContext.dateFrom,
+      dateTo: context.dateContext.dateTo,
+      changedDates: context.dateContext.changedDates,
+      changeTypes: context.changeTypes,
+      requestTypes: [],
+      ready: false,
+      calledProvider: false,
+      requestCount: 0,
+      taskIds: [],
+      warnings: [],
+      errors: [],
+      overallSuccess: false,
+      missingMappings: Array.isArray(readiness.missingMappings) ? readiness.missingMappings : [],
+      notes: appendMissingMappingNotes(baseNotes, readiness.missingMappings),
+    });
+    return {
+      response,
+      evidencePatch: {
+        integrationAccountId: readiness.integrationAccountId ?? null,
+        status: "BLOCKED",
+        overallSuccess: false,
+        mappingSnapshot,
+        groupedOutboundPayloadSnapshot: { availability: [], restrictions: [] },
+        providerResponseSummary: { calledProvider: false, requestCount: 0, results: [] },
+        notes: response.response.notes,
+        rawDetails: {
+          readiness,
+          source: context.source,
+          changeTypes: context.changeTypes,
+          changedDates: context.dateContext.changedDates,
+        },
+      },
+    };
+  }
 
-      const readiness = readinessResult.response || {};
-      const mappingSnapshot = this.buildChannexMultiStepMappingSnapshot(readiness);
-      if (!readiness.ready) {
-        const response = ok({
-          channel: readiness.channel || "CHANNEX",
-          integrationAccountId: readiness.integrationAccountId || null,
-          domitsPropertyId: normalizedDomitsPropertyId,
-          source,
-          dateFrom: dateContext.dateFrom,
-          dateTo: dateContext.dateTo,
-          changedDates: dateContext.changedDates,
-          changeTypes,
-          requestTypes: [],
-          ready: false,
-          calledProvider: false,
-          requestCount: 0,
-          taskIds: [],
-          warnings: [],
-          errors: [],
-          overallSuccess: false,
-          missingMappings: Array.isArray(readiness.missingMappings) ? readiness.missingMappings : [],
-          notes: appendMissingMappingNotes(baseNotes, readiness.missingMappings),
-        });
-        return await finalize(response, {
-          integrationAccountId: readiness.integrationAccountId ?? null,
-          status: "BLOCKED",
-          overallSuccess: false,
-          mappingSnapshot,
-          groupedOutboundPayloadSnapshot: { availability: [], restrictions: [] },
-          providerResponseSummary: { calledProvider: false, requestCount: 0, results: [] },
-          notes: response.response.notes,
-          rawDetails: { readiness, source, changeTypes, changedDates: dateContext.changedDates },
-        });
-      }
-
-      const needsAvailability = changeTypes.includes(CHANNEX_CALENDAR_CHANGE_TYPES.AVAILABILITY);
-      const needsRestrictionsOrRates =
-        changeTypes.includes(CHANNEX_CALENDAR_CHANGE_TYPES.RESTRICTIONS) ||
-        changeTypes.includes(CHANNEX_CALENDAR_CHANGE_TYPES.RATES);
-      const availabilityContext = needsAvailability
-        ? await this.buildChannexFullSyncAvailabilityPayloadContext({
-            readiness,
-            normalizedDomitsPropertyId,
-            normalizedDateFrom: dateContext.dateFrom,
-            normalizedDateTo: dateContext.dateTo,
-          })
-        : null;
-      const fullPayloadContext = needsRestrictionsOrRates
-        ? await this.buildChannexFullSyncPayloadContext({
-            readiness,
-            normalizedDomitsPropertyId,
-            normalizedDateFrom: dateContext.dateFrom,
-            normalizedDateTo: dateContext.dateTo,
-          })
-        : null;
-      const availabilityPayloads = needsAvailability
-        ? filterChannexPayloadValuesByDate(
-            availabilityContext?.availabilityProviderPayloads,
-            dateContext.exactDateSet
-          )
-        : [];
-      const restrictionPayloads = needsRestrictionsOrRates
-        ? buildChannexCalendarRestrictionSyncPayloads({
-            payloads: fullPayloadContext?.restrictionProviderPayloads,
-            changeTypes,
-            exactDateSet: dateContext.exactDateSet,
-          })
-        : [];
-      const requestTypes = [
+  async buildChannexCalendarChangePayloadPlan({ readiness, context }) {
+    const needsAvailability = context.changeTypes.includes(CHANNEX_CALENDAR_CHANGE_TYPES.AVAILABILITY);
+    const needsRestrictionsOrRates =
+      context.changeTypes.includes(CHANNEX_CALENDAR_CHANGE_TYPES.RESTRICTIONS) ||
+      context.changeTypes.includes(CHANNEX_CALENDAR_CHANGE_TYPES.RATES);
+    const availabilityContext = needsAvailability
+      ? await this.buildChannexFullSyncAvailabilityPayloadContext({
+          readiness,
+          normalizedDomitsPropertyId: context.normalizedDomitsPropertyId,
+          normalizedDateFrom: context.dateContext.dateFrom,
+          normalizedDateTo: context.dateContext.dateTo,
+        })
+      : null;
+    const fullPayloadContext = needsRestrictionsOrRates
+      ? await this.buildChannexFullSyncPayloadContext({
+          readiness,
+          normalizedDomitsPropertyId: context.normalizedDomitsPropertyId,
+          normalizedDateFrom: context.dateContext.dateFrom,
+          normalizedDateTo: context.dateContext.dateTo,
+        })
+      : null;
+    const availabilityPayloads = needsAvailability
+      ? filterChannexPayloadValuesByDate(
+          availabilityContext?.availabilityProviderPayloads,
+          context.dateContext.exactDateSet
+        )
+      : [];
+    const restrictionPayloads = needsRestrictionsOrRates
+      ? buildChannexCalendarRestrictionSyncPayloads({
+          payloads: fullPayloadContext?.restrictionProviderPayloads,
+          changeTypes: context.changeTypes,
+          exactDateSet: context.dateContext.exactDateSet,
+        })
+      : [];
+    return {
+      availabilityContext,
+      fullPayloadContext,
+      availabilityPayloads,
+      restrictionPayloads,
+      requestTypes: [
         ...(availabilityPayloads.length ? ["availability"] : []),
         ...(restrictionPayloads.length ? ["restrictions/rates"] : []),
-      ];
+      ],
+    };
+  }
 
-      if (!requestTypes.length) {
-        const response = ok({
-          channel: "CHANNEX",
-          integrationAccountId: readiness.integrationAccountId ?? null,
-          domitsPropertyId: normalizedDomitsPropertyId,
-          source,
-          dateFrom: dateContext.dateFrom,
-          dateTo: dateContext.dateTo,
-          changedDates: dateContext.changedDates,
-          changeTypes,
-          requestTypes: [],
-          ready: true,
-          calledProvider: false,
-          requestCount: 0,
-          taskIds: [],
-          warnings: [],
-          errors: [],
-          overallSuccess: false,
-          notes: [
-            ...baseNotes,
-            "No Channex provider values were generated for the requested host calendar change.",
-          ],
-        });
-        return await finalize(response, {
-          integrationAccountId: readiness.integrationAccountId ?? null,
-          status: "NOOP",
-          overallSuccess: false,
-          mappingSnapshot,
-          groupedOutboundPayloadSnapshot: { availability: [], restrictions: [] },
-          providerResponseSummary: { calledProvider: false, requestCount: 0, results: [] },
-          notes: response.response.notes,
-          rawDetails: {
-            source,
-            changeTypes,
-            changedDates: dateContext.changedDates,
-            availabilityPayloadSummary: availabilityContext?.availabilityPayloadSummary ?? [],
-            restrictionsPayloadSummary: fullPayloadContext?.restrictionsPayloadSummary ?? [],
-          },
-        });
-      }
-
-      const credentialContext = await this.resolveChannexSyncCredentialContext({
-        userId: normalizedUserId,
+  buildChannexCalendarChangeNoopResult({ readiness, context, baseNotes, mappingSnapshot, payloadPlan }) {
+    const response = ok({
+      channel: "CHANNEX",
+      integrationAccountId: readiness.integrationAccountId ?? null,
+      domitsPropertyId: context.normalizedDomitsPropertyId,
+      source: context.source,
+      dateFrom: context.dateContext.dateFrom,
+      dateTo: context.dateContext.dateTo,
+      changedDates: context.dateContext.changedDates,
+      changeTypes: context.changeTypes,
+      requestTypes: [],
+      ready: true,
+      calledProvider: false,
+      requestCount: 0,
+      taskIds: [],
+      warnings: [],
+      errors: [],
+      overallSuccess: false,
+      notes: [
+        ...baseNotes,
+        "No Channex provider values were generated for the requested host calendar change.",
+      ],
+    });
+    return {
+      response,
+      evidencePatch: {
+        integrationAccountId: readiness.integrationAccountId ?? null,
+        status: "NOOP",
+        overallSuccess: false,
         mappingSnapshot,
-        groupedPayloads: {
-          availability: summarizeChannexGroupedPayloads(availabilityPayloads),
-          restrictions: summarizeChannexGroupedPayloads(restrictionPayloads),
+        groupedOutboundPayloadSnapshot: { availability: [], restrictions: [] },
+        providerResponseSummary: { calledProvider: false, requestCount: 0, results: [] },
+        notes: response.response.notes,
+        rawDetails: {
+          source: context.source,
+          changeTypes: context.changeTypes,
+          changedDates: context.dateContext.changedDates,
+          availabilityPayloadSummary: payloadPlan.availabilityContext?.availabilityPayloadSummary ?? [],
+          restrictionsPayloadSummary: payloadPlan.fullPayloadContext?.restrictionsPayloadSummary ?? [],
         },
-        baseNotes,
-        payloadPreview: {
-          source,
-          changeTypes,
-          changedDates: dateContext.changedDates,
-          dateFrom: dateContext.dateFrom,
-          dateTo: dateContext.dateTo,
-        },
-      });
-      if (!credentialContext.ok) {
-        return await finalize(credentialContext.response, credentialContext.evidencePatch);
-      }
+      },
+    };
+  }
 
-      const { integration, secret } = credentialContext;
-      const providerSteps = [];
-      if (availabilityPayloads.length) {
-        const providerResult = await this.channexProviderClient.pushAvailability(secret, availabilityPayloads, {
-          requestTimeoutMs: options?.providerRequestTimeoutMs,
-          stopOnFailure: true,
-        });
-        const results = (Array.isArray(providerResult?.results) ? providerResult.results : []).map(
-          formatChannexAvailabilityProviderResult
-        );
-        providerSteps.push({
+  async pushChannexCalendarChangeStep({ secret, step, payloads, options }) {
+    const providerResult =
+      step === "availability"
+        ? await this.channexProviderClient.pushAvailability(secret, payloads, {
+            requestTimeoutMs: options?.providerRequestTimeoutMs,
+            stopOnFailure: true,
+          })
+        : await this.channexProviderClient.pushRestrictions(secret, payloads, {
+            requestTimeoutMs: options?.providerRequestTimeoutMs,
+            stopOnFailure: true,
+          });
+    const formatter =
+      step === "availability" ? formatChannexAvailabilityProviderResult : formatChannexRestrictionProviderResult;
+    const results = (Array.isArray(providerResult?.results) ? providerResult.results : []).map(formatter);
+    return {
+      step: step === "availability" ? "availability" : "restrictions/rates",
+      requestCount: payloads.length,
+      results,
+      taskIds: collectTaskIdsFromResultList(results),
+      warnings: collectWarningsFromResultList(results),
+      errors: collectErrorsFromResultList(results),
+    };
+  }
+
+  async collectChannexCalendarChangeProviderSteps({ secret, payloadPlan, options }) {
+    const steps = [];
+    if (payloadPlan.availabilityPayloads.length) {
+      steps.push(
+        await this.pushChannexCalendarChangeStep({
+          secret,
           step: "availability",
-          requestCount: availabilityPayloads.length,
-          results,
-          taskIds: collectTaskIdsFromResultList(results),
-          warnings: collectWarningsFromResultList(results),
-          errors: collectErrorsFromResultList(results),
-        });
-      }
-      if (restrictionPayloads.length) {
-        const providerResult = await this.channexProviderClient.pushRestrictions(secret, restrictionPayloads, {
-          requestTimeoutMs: options?.providerRequestTimeoutMs,
-          stopOnFailure: true,
-        });
-        const results = (Array.isArray(providerResult?.results) ? providerResult.results : []).map(
-          formatChannexRestrictionProviderResult
-        );
-        providerSteps.push({
-          step: "restrictions/rates",
-          requestCount: restrictionPayloads.length,
-          results,
-          taskIds: collectTaskIdsFromResultList(results),
-          warnings: collectWarningsFromResultList(results),
-          errors: collectErrorsFromResultList(results),
-        });
-      }
+          payloads: payloadPlan.availabilityPayloads,
+          options,
+        })
+      );
+    }
+    if (payloadPlan.restrictionPayloads.length) {
+      steps.push(
+        await this.pushChannexCalendarChangeStep({
+          secret,
+          step: "restrictions",
+          payloads: payloadPlan.restrictionPayloads,
+          options,
+        })
+      );
+    }
+    return steps;
+  }
 
-      const allResults = providerSteps.flatMap((step) => step.results);
-      const taskIds = collectTaskIdsFromResultList(allResults);
-      const warnings = collectWarningsFromResultList(allResults);
-      const errors = collectErrorsFromResultList(allResults);
-      const hasErrors = resultListHasErrors(allResults);
-      const hasWarnings = resultListHasWarnings(allResults);
-      const overallSuccess = !hasErrors && !hasWarnings;
-      const responseBody = {
-        channel: "CHANNEX",
-        integrationAccountId: integration.id,
-        domitsPropertyId: normalizedDomitsPropertyId,
-        source,
-        syncType: CHANNEX_CALENDAR_CHANGE_SYNC_TYPE,
-        dateFrom: dateContext.dateFrom,
-        dateTo: dateContext.dateTo,
-        changedDates: dateContext.changedDates,
-        changeTypes,
-        requestTypes,
-        ready: true,
-        calledProvider: true,
-        requestCount: availabilityPayloads.length + restrictionPayloads.length,
-        taskIds,
-        warnings,
-        errors,
-        overallSuccess,
-        steps: providerSteps,
-        notes: baseNotes,
-        ...(hasErrors
-          ? {
-              error: "Failed to sync Channex host calendar change.",
-              errorCode: "CHANNEX_CALENDAR_CHANGE_SYNC_FAILED",
-            }
-          : {}),
-      };
-      const response = hasErrors ? bad(500, responseBody) : ok(responseBody);
-      const outcome = deriveEvidenceOutcome({
-        statusCode: response.statusCode,
-        ready: true,
-        calledProvider: true,
-        results: allResults,
-        overallSuccess,
-      });
+  buildChannexCalendarChangeProviderResult({ integration, context, baseNotes, mappingSnapshot, payloadPlan, providerSteps }) {
+    const allResults = providerSteps.flatMap((step) => step.results);
+    const taskIds = collectTaskIdsFromResultList(allResults);
+    const warnings = collectWarningsFromResultList(allResults);
+    const errors = collectErrorsFromResultList(allResults);
+    const hasErrors = resultListHasErrors(allResults);
+    const hasWarnings = resultListHasWarnings(allResults);
+    const overallSuccess = !hasErrors && !hasWarnings;
+    const requestCount = payloadPlan.availabilityPayloads.length + payloadPlan.restrictionPayloads.length;
+    const responseBody = {
+      channel: "CHANNEX",
+      integrationAccountId: integration.id,
+      domitsPropertyId: context.normalizedDomitsPropertyId,
+      source: context.source,
+      syncType: CHANNEX_CALENDAR_CHANGE_SYNC_TYPE,
+      dateFrom: context.dateContext.dateFrom,
+      dateTo: context.dateContext.dateTo,
+      changedDates: context.dateContext.changedDates,
+      changeTypes: context.changeTypes,
+      requestTypes: payloadPlan.requestTypes,
+      ready: true,
+      calledProvider: true,
+      requestCount,
+      taskIds,
+      warnings,
+      errors,
+      overallSuccess,
+      steps: providerSteps,
+      notes: baseNotes,
+      ...(hasErrors
+        ? {
+            error: "Failed to sync Channex host calendar change.",
+            errorCode: "CHANNEX_CALENDAR_CHANGE_SYNC_FAILED",
+          }
+        : {}),
+    };
+    const response = hasErrors ? bad(500, responseBody) : ok(responseBody);
+    const outcome = deriveEvidenceOutcome({
+      statusCode: response.statusCode,
+      ready: true,
+      calledProvider: true,
+      results: allResults,
+      overallSuccess,
+    });
 
-      return await finalize(response, {
+    return {
+      response,
+      evidencePatch: {
         integrationAccountId: integration.id,
         status: outcome.status,
         overallSuccess: outcome.overallSuccess && overallSuccess,
         mappingSnapshot,
         groupedOutboundPayloadSnapshot: {
-          availability: summarizeChannexGroupedPayloads(availabilityPayloads),
-          restrictions: summarizeChannexGroupedPayloads(restrictionPayloads),
+          availability: summarizeChannexGroupedPayloads(payloadPlan.availabilityPayloads),
+          restrictions: summarizeChannexGroupedPayloads(payloadPlan.restrictionPayloads),
         },
         providerResponseSummary: {
           calledProvider: true,
-          requestCount: responseBody.requestCount,
-          requestTypes,
+          requestCount,
+          requestTypes: payloadPlan.requestTypes,
           results: allResults,
           steps: providerSteps,
         },
@@ -8406,14 +8443,104 @@ export default class IntegrationService {
         errors,
         notes: baseNotes,
         rawDetails: {
-          source,
-          changeTypes,
-          changedDates: dateContext.changedDates,
+          source: context.source,
+          changeTypes: context.changeTypes,
+          changedDates: context.dateContext.changedDates,
           activeBookingCount:
-            availabilityContext?.activeBookingCount ?? fullPayloadContext?.activeBookingCount ?? null,
+            payloadPlan.availabilityContext?.activeBookingCount ?? payloadPlan.fullPayloadContext?.activeBookingCount ?? null,
           activeBookingNightCount:
-            availabilityContext?.activeBookingNightCount ?? fullPayloadContext?.activeBookingNightCount ?? null,
+            payloadPlan.availabilityContext?.activeBookingNightCount ??
+            payloadPlan.fullPayloadContext?.activeBookingNightCount ??
+            null,
         },
+      },
+    };
+  }
+
+  async runChannexCalendarChangeSync({ context, finalize, baseNotes, options }) {
+    const readinessResult = await this.getChannexAriTargets(
+      context.normalizedUserId,
+      context.normalizedDomitsPropertyId
+    );
+    if (readinessResult?.statusCode !== 200) {
+      return await finalize(readinessResult, this.buildChannexAriTargetsFailureEvidencePatch(readinessResult));
+    }
+
+    const readiness = readinessResult.response || {};
+    const mappingSnapshot = this.buildChannexMultiStepMappingSnapshot(readiness);
+    if (!readiness.ready) {
+      const blocked = this.buildChannexCalendarChangeBlockedResult({
+        readiness,
+        context,
+        baseNotes,
+        mappingSnapshot,
+      });
+      return await finalize(blocked.response, blocked.evidencePatch);
+    }
+
+    const payloadPlan = await this.buildChannexCalendarChangePayloadPlan({ readiness, context });
+    if (!payloadPlan.requestTypes.length) {
+      const noop = this.buildChannexCalendarChangeNoopResult({
+        readiness,
+        context,
+        baseNotes,
+        mappingSnapshot,
+        payloadPlan,
+      });
+      return await finalize(noop.response, noop.evidencePatch);
+    }
+
+    const credentialContext = await this.resolveChannexSyncCredentialContext({
+      userId: context.normalizedUserId,
+      mappingSnapshot,
+      groupedPayloads: {
+        availability: summarizeChannexGroupedPayloads(payloadPlan.availabilityPayloads),
+        restrictions: summarizeChannexGroupedPayloads(payloadPlan.restrictionPayloads),
+      },
+      baseNotes,
+      payloadPreview: {
+        source: context.source,
+        changeTypes: context.changeTypes,
+        changedDates: context.dateContext.changedDates,
+        dateFrom: context.dateContext.dateFrom,
+        dateTo: context.dateContext.dateTo,
+      },
+    });
+    if (!credentialContext.ok) {
+      return await finalize(credentialContext.response, credentialContext.evidencePatch);
+    }
+
+    const providerSteps = await this.collectChannexCalendarChangeProviderSteps({
+      secret: credentialContext.secret,
+      payloadPlan,
+      options,
+    });
+    const providerResult = this.buildChannexCalendarChangeProviderResult({
+      integration: credentialContext.integration,
+      context,
+      baseNotes,
+      mappingSnapshot,
+      payloadPlan,
+      providerSteps,
+    });
+    return await finalize(providerResult.response, providerResult.evidencePatch);
+  }
+
+  async syncChannexCalendarChange(body = {}, options = {}) {
+    const context = this.buildChannexCalendarChangeContext(body);
+    const finalize = this.createChannexCalendarChangeFinalizer(context, options);
+    const validationFailure = this.buildChannexCalendarChangeValidationFailure(context);
+    if (validationFailure) {
+      return await finalize(validationFailure.response, validationFailure.evidencePatch);
+    }
+
+    const baseNotes = this.getChannexCalendarChangeBaseNotes();
+    try {
+      return await this.runChannexCalendarChangeSync({
+        context,
+        finalize,
+        baseNotes,
+        options,
       });
     } catch (error) {
       const details = describeLocalError(error);
@@ -8433,7 +8560,12 @@ export default class IntegrationService {
               details,
             },
           ],
-          rawDetails: { caughtError: details, source, changeTypes, changedDates: dateContext.changedDates },
+          rawDetails: {
+            caughtError: details,
+            source: context.source,
+            changeTypes: context.changeTypes,
+            changedDates: context.dateContext.changedDates,
+          },
         }
       );
     }

--- a/backend/functions/UnifiedMessaging/business/integrationService.js
+++ b/backend/functions/UnifiedMessaging/business/integrationService.js
@@ -198,6 +198,23 @@ const CHANNEX_SUPPORTED_RESTRICTION_FIELDS = [
   "max_stay",
   "min_stay_through",
 ];
+const CHANNEX_CALENDAR_CHANGE_SYNC_TYPE = "calendar-change";
+const CHANNEX_CALENDAR_CHANGE_TYPES = Object.freeze({
+  AVAILABILITY: "availability",
+  RATES: "rates",
+  RESTRICTIONS: "restrictions",
+});
+const CHANNEX_CALENDAR_CHANGE_TYPE_ALIASES = new Map([
+  ["availability", CHANNEX_CALENDAR_CHANGE_TYPES.AVAILABILITY],
+  ["available", CHANNEX_CALENDAR_CHANGE_TYPES.AVAILABILITY],
+  ["isavailable", CHANNEX_CALENDAR_CHANGE_TYPES.AVAILABILITY],
+  ["rates", CHANNEX_CALENDAR_CHANGE_TYPES.RATES],
+  ["rate", CHANNEX_CALENDAR_CHANGE_TYPES.RATES],
+  ["pricing", CHANNEX_CALENDAR_CHANGE_TYPES.RATES],
+  ["price", CHANNEX_CALENDAR_CHANGE_TYPES.RATES],
+  ["restrictions", CHANNEX_CALENDAR_CHANGE_TYPES.RESTRICTIONS],
+  ["restriction", CHANNEX_CALENDAR_CHANGE_TYPES.RESTRICTIONS],
+]);
 const normalizeRestrictionInteger = (value) => {
   if (value === undefined || value === null || value === "") return null;
 
@@ -2192,6 +2209,84 @@ const buildChannexRestrictionSyncPayloads = (groupedPayloads) =>
       };
     })
     .filter((group) => group.values.length > 0);
+const normalizeChannexCalendarChangeTypes = (changeTypes) =>
+  Array.from(
+    new Set(
+      (Array.isArray(changeTypes) ? changeTypes : [changeTypes])
+        .map((changeType) => requireStr(changeType)?.toLowerCase().replaceAll(/[^a-z]/g, ""))
+        .map((changeType) => CHANNEX_CALENDAR_CHANGE_TYPE_ALIASES.get(changeType))
+        .filter(Boolean)
+    )
+  ).sort(compareAlphabetically);
+const normalizeChannexCalendarChangeDates = (changedDates) =>
+  Array.from(
+    new Set(
+      (Array.isArray(changedDates) ? changedDates : [])
+        .map((date) => parseIsoDateParam(date))
+        .filter(Boolean)
+    )
+  ).sort(compareAlphabetically);
+const buildChannexCalendarChangeDateContext = (body) => {
+  const changedDates = normalizeChannexCalendarChangeDates(body?.changedDates);
+  if (changedDates.length) {
+    return {
+      changedDates,
+      dateFrom: changedDates[0],
+      dateTo: changedDates.at(-1),
+      exactDateSet: new Set(changedDates),
+    };
+  }
+
+  const dateFrom = parseIsoDateParam(body?.dateFrom);
+  const dateTo = parseIsoDateParam(body?.dateTo);
+  return {
+    changedDates: [],
+    dateFrom,
+    dateTo,
+    exactDateSet: null,
+  };
+};
+const filterChannexPayloadValuesByDate = (payloads, exactDateSet) =>
+  (Array.isArray(payloads) ? payloads : [])
+    .map((payload) => ({
+      ...payload,
+      values: (Array.isArray(payload?.values) ? payload.values : []).filter(
+        (value) => !exactDateSet || exactDateSet.has(value?.date)
+      ),
+    }))
+    .filter((payload) => payload.values.length > 0);
+const buildChannexCalendarRestrictionSyncValue = (value, changeTypes) => {
+  const includeRates = changeTypes.includes(CHANNEX_CALENDAR_CHANGE_TYPES.RATES);
+  const includeRestrictions = changeTypes.includes(CHANNEX_CALENDAR_CHANGE_TYPES.RESTRICTIONS);
+  const out = {
+    property_id: value.property_id,
+    rate_plan_id: value.rate_plan_id,
+    date: value.date,
+  };
+
+  if (includeRates && Object.hasOwn(value || {}, "rate")) {
+    out.rate = value.rate;
+  }
+
+  if (includeRestrictions) {
+    for (const field of CHANNEX_SUPPORTED_RESTRICTION_FIELDS) {
+      if (Object.hasOwn(value || {}, field)) {
+        out[field] = value[field];
+      }
+    }
+  }
+
+  return Object.keys(out).length > 3 ? out : null;
+};
+const buildChannexCalendarRestrictionSyncPayloads = ({ payloads, changeTypes, exactDateSet }) =>
+  filterChannexPayloadValuesByDate(payloads, exactDateSet)
+    .map((payload) => ({
+      ...payload,
+      values: payload.values
+        .map((value) => buildChannexCalendarRestrictionSyncValue(value, changeTypes))
+        .filter(Boolean),
+    }))
+    .filter((payload) => payload.values.length > 0);
 const appendRestrictionSyncOutboundNotes = (notes, transformedPayloads) => {
   const sentChannexRestrictionFields = collectChannexRestrictionFieldsFromGroups(transformedPayloads);
   if (sentChannexRestrictionFields.length) {
@@ -7997,6 +8092,348 @@ export default class IntegrationService {
             },
           ],
           rawDetails: { caughtError: details },
+        }
+      );
+    }
+  }
+
+  async syncChannexCalendarChange(body = {}, options = {}) {
+    const startedAt = nowMs();
+    const normalizedUserId = requireStr(body?.userId);
+    const normalizedDomitsPropertyId = requireStr(body?.domitsPropertyId);
+    const source = requireStr(body?.source) || "HOST_CALENDAR_CHANGED";
+    const changeTypes = normalizeChannexCalendarChangeTypes(body?.changeTypes);
+    const dateContext = buildChannexCalendarChangeDateContext(body);
+    const finalize = this.createChannexSyncFinalizer({
+      normalizedUserId,
+      normalizedDomitsPropertyId,
+      normalizedDateFrom: dateContext.dateFrom,
+      normalizedDateTo: dateContext.dateTo,
+      rawDateFrom: body?.dateFrom,
+      rawDateTo: body?.dateTo,
+      startedAt,
+      syncType: CHANNEX_CALENDAR_CHANGE_SYNC_TYPE,
+      options,
+    });
+
+    if (!normalizedUserId) {
+      return await finalize(bad(400, { error: "Missing required field: userId" }), {
+        status: "INVALID_REQUEST",
+        errors: [{ errorCode: "MISSING_USER_ID", errorMessage: "Missing required field: userId" }],
+      });
+    }
+    if (!normalizedDomitsPropertyId) {
+      return await finalize(bad(400, { error: "Missing required field: domitsPropertyId" }), {
+        status: "INVALID_REQUEST",
+        errors: [
+          { errorCode: "MISSING_DOMITS_PROPERTY_ID", errorMessage: "Missing required field: domitsPropertyId" },
+        ],
+      });
+    }
+    if (!dateContext.dateFrom || !dateContext.dateTo || dateContext.dateFrom > dateContext.dateTo) {
+      return await finalize(bad(400, { error: "Invalid or missing calendar-change date range." }), {
+        status: "INVALID_REQUEST",
+        errors: [
+          {
+            errorCode: "CHANNEX_CALENDAR_CHANGE_DATE_RANGE_INVALID",
+            errorMessage: "Calendar-change sync needs changedDates or a valid dateFrom/dateTo range.",
+          },
+        ],
+      });
+    }
+    const validationFailure = buildSyncDateRangeValidationFailure({
+      normalizedUserId,
+      normalizedDomitsPropertyId,
+      normalizedDateFrom: dateContext.dateFrom,
+      normalizedDateTo: dateContext.dateTo,
+    });
+    if (validationFailure) return await finalize(validationFailure.response, validationFailure.evidencePatch);
+    if (!changeTypes.length) {
+      return await finalize(bad(400, { error: "Missing required field: changeTypes" }), {
+        status: "INVALID_REQUEST",
+        errors: [
+          {
+            errorCode: "CHANNEX_CALENDAR_CHANGE_TYPES_MISSING",
+            errorMessage: "Calendar-change sync needs at least one supported change type.",
+          },
+        ],
+      });
+    }
+
+    const baseNotes = [
+      "Host calendar change-only sync. This endpoint sends only the Channex provider payloads needed for the changed calendar fields.",
+      "Availability values are rebuilt from Domits effective availability, including active booking occupancy, before sending to Channex.",
+    ];
+
+    try {
+      const readinessResult = await this.getChannexAriTargets(normalizedUserId, normalizedDomitsPropertyId);
+      if (readinessResult?.statusCode !== 200) {
+        return await finalize(readinessResult, this.buildChannexAriTargetsFailureEvidencePatch(readinessResult));
+      }
+
+      const readiness = readinessResult.response || {};
+      const mappingSnapshot = this.buildChannexMultiStepMappingSnapshot(readiness);
+      if (!readiness.ready) {
+        const response = ok({
+          channel: readiness.channel || "CHANNEX",
+          integrationAccountId: readiness.integrationAccountId || null,
+          domitsPropertyId: normalizedDomitsPropertyId,
+          source,
+          dateFrom: dateContext.dateFrom,
+          dateTo: dateContext.dateTo,
+          changedDates: dateContext.changedDates,
+          changeTypes,
+          requestTypes: [],
+          ready: false,
+          calledProvider: false,
+          requestCount: 0,
+          taskIds: [],
+          warnings: [],
+          errors: [],
+          overallSuccess: false,
+          missingMappings: Array.isArray(readiness.missingMappings) ? readiness.missingMappings : [],
+          notes: appendMissingMappingNotes(baseNotes, readiness.missingMappings),
+        });
+        return await finalize(response, {
+          integrationAccountId: readiness.integrationAccountId ?? null,
+          status: "BLOCKED",
+          overallSuccess: false,
+          mappingSnapshot,
+          groupedOutboundPayloadSnapshot: { availability: [], restrictions: [] },
+          providerResponseSummary: { calledProvider: false, requestCount: 0, results: [] },
+          notes: response.response.notes,
+          rawDetails: { readiness, source, changeTypes, changedDates: dateContext.changedDates },
+        });
+      }
+
+      const needsAvailability = changeTypes.includes(CHANNEX_CALENDAR_CHANGE_TYPES.AVAILABILITY);
+      const needsRestrictionsOrRates =
+        changeTypes.includes(CHANNEX_CALENDAR_CHANGE_TYPES.RESTRICTIONS) ||
+        changeTypes.includes(CHANNEX_CALENDAR_CHANGE_TYPES.RATES);
+      const availabilityContext = needsAvailability
+        ? await this.buildChannexFullSyncAvailabilityPayloadContext({
+            readiness,
+            normalizedDomitsPropertyId,
+            normalizedDateFrom: dateContext.dateFrom,
+            normalizedDateTo: dateContext.dateTo,
+          })
+        : null;
+      const fullPayloadContext = needsRestrictionsOrRates
+        ? await this.buildChannexFullSyncPayloadContext({
+            readiness,
+            normalizedDomitsPropertyId,
+            normalizedDateFrom: dateContext.dateFrom,
+            normalizedDateTo: dateContext.dateTo,
+          })
+        : null;
+      const availabilityPayloads = needsAvailability
+        ? filterChannexPayloadValuesByDate(
+            availabilityContext?.availabilityProviderPayloads,
+            dateContext.exactDateSet
+          )
+        : [];
+      const restrictionPayloads = needsRestrictionsOrRates
+        ? buildChannexCalendarRestrictionSyncPayloads({
+            payloads: fullPayloadContext?.restrictionProviderPayloads,
+            changeTypes,
+            exactDateSet: dateContext.exactDateSet,
+          })
+        : [];
+      const requestTypes = [
+        ...(availabilityPayloads.length ? ["availability"] : []),
+        ...(restrictionPayloads.length ? ["restrictions/rates"] : []),
+      ];
+
+      if (!requestTypes.length) {
+        const response = ok({
+          channel: "CHANNEX",
+          integrationAccountId: readiness.integrationAccountId ?? null,
+          domitsPropertyId: normalizedDomitsPropertyId,
+          source,
+          dateFrom: dateContext.dateFrom,
+          dateTo: dateContext.dateTo,
+          changedDates: dateContext.changedDates,
+          changeTypes,
+          requestTypes: [],
+          ready: true,
+          calledProvider: false,
+          requestCount: 0,
+          taskIds: [],
+          warnings: [],
+          errors: [],
+          overallSuccess: false,
+          notes: [
+            ...baseNotes,
+            "No Channex provider values were generated for the requested host calendar change.",
+          ],
+        });
+        return await finalize(response, {
+          integrationAccountId: readiness.integrationAccountId ?? null,
+          status: "NOOP",
+          overallSuccess: false,
+          mappingSnapshot,
+          groupedOutboundPayloadSnapshot: { availability: [], restrictions: [] },
+          providerResponseSummary: { calledProvider: false, requestCount: 0, results: [] },
+          notes: response.response.notes,
+          rawDetails: {
+            source,
+            changeTypes,
+            changedDates: dateContext.changedDates,
+            availabilityPayloadSummary: availabilityContext?.availabilityPayloadSummary ?? [],
+            restrictionsPayloadSummary: fullPayloadContext?.restrictionsPayloadSummary ?? [],
+          },
+        });
+      }
+
+      const credentialContext = await this.resolveChannexSyncCredentialContext({
+        userId: normalizedUserId,
+        mappingSnapshot,
+        groupedPayloads: {
+          availability: summarizeChannexGroupedPayloads(availabilityPayloads),
+          restrictions: summarizeChannexGroupedPayloads(restrictionPayloads),
+        },
+        baseNotes,
+        payloadPreview: {
+          source,
+          changeTypes,
+          changedDates: dateContext.changedDates,
+          dateFrom: dateContext.dateFrom,
+          dateTo: dateContext.dateTo,
+        },
+      });
+      if (!credentialContext.ok) {
+        return await finalize(credentialContext.response, credentialContext.evidencePatch);
+      }
+
+      const { integration, secret } = credentialContext;
+      const providerSteps = [];
+      if (availabilityPayloads.length) {
+        const providerResult = await this.channexProviderClient.pushAvailability(secret, availabilityPayloads, {
+          requestTimeoutMs: options?.providerRequestTimeoutMs,
+          stopOnFailure: true,
+        });
+        const results = (Array.isArray(providerResult?.results) ? providerResult.results : []).map(
+          formatChannexAvailabilityProviderResult
+        );
+        providerSteps.push({
+          step: "availability",
+          requestCount: availabilityPayloads.length,
+          results,
+          taskIds: collectTaskIdsFromResultList(results),
+          warnings: collectWarningsFromResultList(results),
+          errors: collectErrorsFromResultList(results),
+        });
+      }
+      if (restrictionPayloads.length) {
+        const providerResult = await this.channexProviderClient.pushRestrictions(secret, restrictionPayloads, {
+          requestTimeoutMs: options?.providerRequestTimeoutMs,
+          stopOnFailure: true,
+        });
+        const results = (Array.isArray(providerResult?.results) ? providerResult.results : []).map(
+          formatChannexRestrictionProviderResult
+        );
+        providerSteps.push({
+          step: "restrictions/rates",
+          requestCount: restrictionPayloads.length,
+          results,
+          taskIds: collectTaskIdsFromResultList(results),
+          warnings: collectWarningsFromResultList(results),
+          errors: collectErrorsFromResultList(results),
+        });
+      }
+
+      const allResults = providerSteps.flatMap((step) => step.results);
+      const taskIds = collectTaskIdsFromResultList(allResults);
+      const warnings = collectWarningsFromResultList(allResults);
+      const errors = collectErrorsFromResultList(allResults);
+      const hasErrors = resultListHasErrors(allResults);
+      const hasWarnings = resultListHasWarnings(allResults);
+      const overallSuccess = !hasErrors && !hasWarnings;
+      const responseBody = {
+        channel: "CHANNEX",
+        integrationAccountId: integration.id,
+        domitsPropertyId: normalizedDomitsPropertyId,
+        source,
+        syncType: CHANNEX_CALENDAR_CHANGE_SYNC_TYPE,
+        dateFrom: dateContext.dateFrom,
+        dateTo: dateContext.dateTo,
+        changedDates: dateContext.changedDates,
+        changeTypes,
+        requestTypes,
+        ready: true,
+        calledProvider: true,
+        requestCount: availabilityPayloads.length + restrictionPayloads.length,
+        taskIds,
+        warnings,
+        errors,
+        overallSuccess,
+        steps: providerSteps,
+        notes: baseNotes,
+        ...(hasErrors
+          ? {
+              error: "Failed to sync Channex host calendar change.",
+              errorCode: "CHANNEX_CALENDAR_CHANGE_SYNC_FAILED",
+            }
+          : {}),
+      };
+      const response = hasErrors ? bad(500, responseBody) : ok(responseBody);
+      const outcome = deriveEvidenceOutcome({
+        statusCode: response.statusCode,
+        ready: true,
+        calledProvider: true,
+        results: allResults,
+        overallSuccess,
+      });
+
+      return await finalize(response, {
+        integrationAccountId: integration.id,
+        status: outcome.status,
+        overallSuccess: outcome.overallSuccess && overallSuccess,
+        mappingSnapshot,
+        groupedOutboundPayloadSnapshot: {
+          availability: summarizeChannexGroupedPayloads(availabilityPayloads),
+          restrictions: summarizeChannexGroupedPayloads(restrictionPayloads),
+        },
+        providerResponseSummary: {
+          calledProvider: true,
+          requestCount: responseBody.requestCount,
+          requestTypes,
+          results: allResults,
+          steps: providerSteps,
+        },
+        taskIds,
+        warnings,
+        errors,
+        notes: baseNotes,
+        rawDetails: {
+          source,
+          changeTypes,
+          changedDates: dateContext.changedDates,
+          activeBookingCount:
+            availabilityContext?.activeBookingCount ?? fullPayloadContext?.activeBookingCount ?? null,
+          activeBookingNightCount:
+            availabilityContext?.activeBookingNightCount ?? fullPayloadContext?.activeBookingNightCount ?? null,
+        },
+      });
+    } catch (error) {
+      const details = describeLocalError(error);
+      return await finalize(
+        bad(500, {
+          error: "Failed to sync Channex host calendar change.",
+          errorCode: "CHANNEX_CALENDAR_CHANGE_SYNC_FAILED",
+          details,
+        }),
+        {
+          status: "FAILED",
+          overallSuccess: false,
+          errors: [
+            {
+              errorCode: "CHANNEX_CALENDAR_CHANGE_SYNC_FAILED",
+              errorMessage: "Failed to sync Channex host calendar change.",
+              details,
+            },
+          ],
+          rawDetails: { caughtError: details, source, changeTypes, changedDates: dateContext.changedDates },
         }
       );
     }

--- a/backend/functions/UnifiedMessaging/controller/integrationController.calendarChange.test.js
+++ b/backend/functions/UnifiedMessaging/controller/integrationController.calendarChange.test.js
@@ -1,0 +1,109 @@
+jest.mock(
+  "@aws-sdk/client-secrets-manager",
+  () => require("../business/integrationService.secretsManagerMock.js"),
+  { virtual: true }
+);
+
+const IntegrationController = require("./integrationController.js").default;
+
+const buildCalendarChangeEvent = ({ token, body = {} } = {}) => ({
+  headers: token ? { "x-domits-internal-token": token } : {},
+  body: JSON.stringify({
+    userId: "host-1",
+    domitsPropertyId: "property-1",
+    changedDates: ["2026-06-10"],
+    changeTypes: ["availability"],
+    ...body,
+  }),
+});
+
+describe("IntegrationController Channex calendar-change internal guard", () => {
+  const originalToken = process.env.CHANNEX_BOOKING_AVAILABILITY_INTERNAL_TOKEN;
+  const originalTestEnv = process.env.TEST;
+
+  const createController = () => {
+    const integrationService = {
+      syncChannexCalendarChange: jest.fn().mockResolvedValue({
+        statusCode: 200,
+        response: {
+          syncType: "calendar-change",
+          requestCount: 1,
+        },
+      }),
+    };
+    return {
+      controller: new IntegrationController({
+        integrationService,
+        channexBookingAvailabilityBridge: { syncAvailabilityForBookingChange: jest.fn() },
+      }),
+      integrationService,
+    };
+  };
+
+  beforeEach(() => {
+    process.env.CHANNEX_BOOKING_AVAILABILITY_INTERNAL_TOKEN = "expected-token";
+    process.env.TEST = "false";
+  });
+
+  afterEach(() => {
+    if (originalToken === undefined) {
+      delete process.env.CHANNEX_BOOKING_AVAILABILITY_INTERNAL_TOKEN;
+    } else {
+      process.env.CHANNEX_BOOKING_AVAILABILITY_INTERNAL_TOKEN = originalToken;
+    }
+    if (originalTestEnv === undefined) {
+      delete process.env.TEST;
+    } else {
+      process.env.TEST = originalTestEnv;
+    }
+  });
+
+  test("rejects missing internal token before syncing calendar changes", async () => {
+    const { controller, integrationService } = createController();
+
+    const result = await controller.syncChannexCalendarChange(buildCalendarChangeEvent());
+
+    expect(result).toEqual({
+      statusCode: 403,
+      response: {
+        error: "FORBIDDEN",
+        message: "Invalid internal calendar-change sync token.",
+      },
+    });
+    expect(integrationService.syncChannexCalendarChange).not.toHaveBeenCalled();
+  });
+
+  test("rejects wrong internal token before syncing calendar changes", async () => {
+    const { controller, integrationService } = createController();
+
+    const result = await controller.syncChannexCalendarChange(buildCalendarChangeEvent({ token: "wrong-token" }));
+
+    expect(result.statusCode).toBe(403);
+    expect(result.response.message).toBe("Invalid internal calendar-change sync token.");
+    expect(integrationService.syncChannexCalendarChange).not.toHaveBeenCalled();
+  });
+
+  test("accepts matching internal token and forwards calendar change body", async () => {
+    const { controller, integrationService } = createController();
+
+    const result = await controller.syncChannexCalendarChange(
+      buildCalendarChangeEvent({
+        token: "expected-token",
+        body: { source: "HOST_CALENDAR_OVERRIDES_CHANGED" },
+      })
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(result.response).toEqual({
+      syncType: "calendar-change",
+      requestCount: 1,
+    });
+    expect(integrationService.syncChannexCalendarChange).toHaveBeenCalledWith({
+      userId: "host-1",
+      domitsPropertyId: "property-1",
+      changedDates: ["2026-06-10"],
+      changeTypes: ["availability"],
+      source: "HOST_CALENDAR_OVERRIDES_CHANGED",
+    });
+  });
+});

--- a/backend/functions/UnifiedMessaging/controller/integrationController.js
+++ b/backend/functions/UnifiedMessaging/controller/integrationController.js
@@ -276,6 +276,25 @@ class IntegrationController {
     };
   }
 
+  async syncChannexCalendarChange(event) {
+    const expectedToken = requireStr(process.env.CHANNEX_BOOKING_AVAILABILITY_INTERNAL_TOKEN);
+    const providedToken = requireStr(getHeader(event?.headers, "x-domits-internal-token"));
+    const allowWithoutToken = process.env.TEST === "true" && !expectedToken;
+
+    if (!allowWithoutToken && (!expectedToken || providedToken !== expectedToken)) {
+      return {
+        statusCode: 403,
+        response: {
+          error: "FORBIDDEN",
+          message: "Invalid internal calendar-change sync token.",
+        },
+      };
+    }
+
+    const body = safeJson(event.body) || {};
+    return await this.integrationService.syncChannexCalendarChange(body);
+  }
+
   async syncChannexRestrictions(event) {
     const userId = event.queryStringParameters?.userId || null;
     const domitsPropertyId = event.queryStringParameters?.domitsPropertyId || null;

--- a/backend/functions/UnifiedMessaging/index.channexCertificationAccess.test.js
+++ b/backend/functions/UnifiedMessaging/index.channexCertificationAccess.test.js
@@ -12,6 +12,7 @@ const mockIntegrationControllerMethods = {
   syncChannexRestrictions: jest.fn(),
   syncChannexFull: jest.fn(),
   syncChannexBookingAvailability: jest.fn(),
+  syncChannexCalendarChange: jest.fn(),
   syncChannexCertificationTestCase: jest.fn(),
   cancelChannexCertificationBooking: jest.fn(),
   saveChannexSetupMapping: jest.fn(),
@@ -353,6 +354,36 @@ describe("UnifiedMessaging Channex certification admin route guard", () => {
     });
     expect(mockIntegrationControllerMethods.pollLatestChannexBookings).toHaveBeenCalledWith(event);
     expect(mockIntegrationControllerMethods.pullLatestChannexBookings).not.toHaveBeenCalled();
+  });
+
+  test("internal Channex calendar-change sync route calls controller without admin guard", async () => {
+    mockIntegrationControllerMethods.syncChannexCalendarChange.mockResolvedValue({
+      statusCode: 200,
+      response: {
+        syncType: "calendar-change",
+        requestCount: 1,
+      },
+    });
+
+    const response = await handler(
+      buildEvent({
+        method: "POST",
+        path: "/default/integrations/channex/calendar-change/sync",
+        body: JSON.stringify({
+          userId: "host-1",
+          domitsPropertyId: "property-1",
+          changedDates: ["2026-06-10"],
+          changeTypes: ["availability"],
+        }),
+      })
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(parseBody(response)).toEqual({
+      syncType: "calendar-change",
+      requestCount: 1,
+    });
+    expect(mockIntegrationControllerMethods.syncChannexCalendarChange).toHaveBeenCalledTimes(1);
   });
 
   test("certification test-case endpoint is protected before side effects run", async () => {

--- a/backend/functions/UnifiedMessaging/index.js
+++ b/backend/functions/UnifiedMessaging/index.js
@@ -235,6 +235,11 @@ const routeDefinitions = [
     handle: (event) => integrationController.syncChannexBookingAvailability(event),
   },
   {
+    matches: (method, path) =>
+      method === "POST" && String(path || "").endsWith("/integrations/channex/calendar-change/sync"),
+    handle: (event) => integrationController.syncChannexCalendarChange(event),
+  },
+  {
     matches: (method, path) => method === "POST" && String(path || "").endsWith("/integrations/channex/sync/availability"),
     handle: (event) => integrationController.syncChannexAvailability(event),
   },

--- a/backend/test/PropertyHandler/calendar-overrides-unit.test.js
+++ b/backend/test/PropertyHandler/calendar-overrides-unit.test.js
@@ -14,7 +14,18 @@ const buildAuthManager = ({ username = "caller-user", property, membership = nul
   return authManager;
 };
 
-const buildCalendarController = ({ authorizeResult = "owner-host", authorizeError = null } = {}) => {
+const buildCalendarController = ({
+  authorizeResult = "owner-host",
+  authorizeError = null,
+  previousOverrides = [{ date: 20260610, isAvailable: true }],
+  updatedOverrides = [{ date: 20260610, isAvailable: true }],
+  channexSyncResult = {
+    syncType: "calendar-change",
+    requestCount: 1,
+    taskIds: ["task-calendar-1"],
+    overallSuccess: true,
+  },
+} = {}) => {
   const controller = new PropertyController();
   controller.authManager = {
     authorizePropertyCalendarOverrideRequest: authorizeError
@@ -22,8 +33,11 @@ const buildCalendarController = ({ authorizeResult = "owner-host", authorizeErro
       : jest.fn().mockResolvedValue(authorizeResult),
   };
   controller.propertyService = {
-    getPropertyCalendarOverrides: jest.fn().mockResolvedValue([{ date: 20260610, isAvailable: true }]),
-    updatePropertyCalendarOverrides: jest.fn().mockResolvedValue([{ date: 20260610, isAvailable: true }]),
+    getPropertyCalendarOverrides: jest.fn().mockResolvedValue(previousOverrides),
+    updatePropertyCalendarOverrides: jest.fn().mockResolvedValue(updatedOverrides),
+  };
+  controller.channexCalendarChangeSyncClient = {
+    syncCalendarChange: jest.fn().mockResolvedValue(channexSyncResult),
   };
   return controller;
 };
@@ -176,6 +190,100 @@ describe("Property calendar override authorization", () => {
       ],
       {}
     );
+    expect(controller.channexCalendarChangeSyncClient.syncCalendarChange).not.toHaveBeenCalled();
+    expect(JSON.parse(patchResponse.body).channexCalendarChangeSync).toEqual(
+      expect.objectContaining({
+        syncType: "calendar-change",
+        reason: "NO_CHANNEX_RELEVANT_CALENDAR_CHANGES",
+      })
+    );
+  });
+
+  it("notifies Channex when host calendar availability changes", async () => {
+    const controller = buildCalendarController({
+      previousOverrides: [{ date: 20260610, isAvailable: false }],
+      updatedOverrides: [{ date: 20260610, isAvailable: true }],
+    });
+
+    const response = await controller.updatePropertyCalendarOverrides({
+      headers: { Authorization: "token" },
+      body: JSON.stringify({
+        propertyId: "property-1",
+        overrides: [{ date: 20260610, isAvailable: true }],
+      }),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(controller.channexCalendarChangeSyncClient.syncCalendarChange).toHaveBeenCalledWith({
+      userId: "owner-host",
+      domitsPropertyId: "property-1",
+      changedDates: ["2026-06-10"],
+      changeTypes: ["availability"],
+      source: "HOST_CALENDAR_OVERRIDES_CHANGED",
+    });
+    expect(JSON.parse(response.body).channexCalendarChangeSync).toEqual(
+      expect.objectContaining({
+        requestCount: 1,
+        taskIds: ["task-calendar-1"],
+      })
+    );
+  });
+
+  it("notifies Channex when host calendar rates and restrictions change", async () => {
+    const controller = buildCalendarController({
+      previousOverrides: [
+        {
+          date: 20260610,
+          isAvailable: true,
+          nightlyPrice: 100,
+          stopSell: false,
+          closedToArrival: false,
+          closedToDeparture: false,
+          minStay: 1,
+          maxStay: 0,
+        },
+      ],
+      updatedOverrides: [
+        {
+          date: 20260610,
+          isAvailable: true,
+          nightlyPrice: 125,
+          stopSell: true,
+          closedToArrival: true,
+          closedToDeparture: false,
+          minStay: 2,
+          maxStay: 5,
+        },
+      ],
+    });
+
+    const response = await controller.updatePropertyCalendarOverrides({
+      headers: { Authorization: "token" },
+      body: JSON.stringify({
+        propertyId: "property-1",
+        overrides: [
+          {
+            date: 20260610,
+            isAvailable: true,
+            nightlyPrice: 125,
+            stopSell: true,
+            closedToArrival: true,
+            closedToDeparture: false,
+            minStay: 2,
+            maxStay: 5,
+          },
+        ],
+      }),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(controller.channexCalendarChangeSyncClient.syncCalendarChange).toHaveBeenCalledWith({
+      userId: "owner-host",
+      domitsPropertyId: "property-1",
+      changedDates: ["2026-06-10"],
+      changeTypes: ["rates", "restrictions"],
+      source: "HOST_CALENDAR_OVERRIDES_CHANGED",
+    });
   });
 
   it("keeps unauthorized calendar override requests forbidden", async () => {


### PR DESCRIPTION
## Close or Relate the Issue

[//]: # "Only if this should close the issue"

* Closes: N/A

[//]: # "in the issue a reference will be added to this pr"

* Related Issue: #2861

## Proposed Changes

[//]: # "Add a detailed description of the changes here"

Description:

This PR adds automatic Domits → Channex change-only sync for host-side calendar changes.

Before this change, host calendar edits in Domits updated Domits availability/pricing/restriction data, but Channex only received those updates after a manual availability sync or Full Sync. This created a risk that Domits and Channex could temporarily show different availability, restriction, or rate data.

With this change, host-side calendar changes now trigger an immediate Channex change-only sync after the Domits save succeeds.

Covered changes:

* Availability changes:

  * available
  * unavailable
  * outside base window available override
  * outside base window unavailable override

* Advanced restriction changes:

  * stop sell
  * closed to arrival / no check-in
  * closed to departure / no check-out
  * minimum stay
  * maximum stay

* Rate/pricing changes:

  * per-date nightly price changes
  * global pricing changes through `/property/overview` with a bounded 500-day forward sync

A new internal UnifiedMessaging route was added:

* `POST /integrations/channex/calendar-change/sync`

This route is protected with `CHANNEX_BOOKING_AVAILABILITY_INTERNAL_TOKEN`. PropertyHandler calls this internal endpoint after calendar changes are saved.

The sync uses the existing Channex ARI/Full Sync payload builders, filtered to the affected dates and changed field types. Booked nights remain protected because availability is rebuilt through the existing booking-aware availability context.

This PR does not change Full Sync, booking create/modify/cancel sync, external booking pull/import, polling, setup/mapping flow, or multi-room scope.

Important caveat:

* Per-date calendar override responses include `channexCalendarChangeSync` evidence.
* Global `/property/overview` saves still return `204`, so Channex sync success/failure is not visible directly in that HTTP response. Evidence is available only when UnifiedMessaging is invoked successfully.

## Change Type

* [x] Bug fix
* [x] New feature
* [ ] Optimization
* [ ] Documentation update

## Change Size

[//]: # "Indicate the size of this change."
[//]: # "Clarify under [Refactoring](https://chatgpt.com/g/g-p-697f7ff03c808191b0c04598bc66b5c0/c/6a06ea98-e38c-8386-88d5-1ccaf8a0cabb#Refactoring) which parts are moved/unchanged code, so the reviewer doesn’t review old logic."

* [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
* [x] Big change (+-max 1000)
* [ ] Small change (less than 300)

## Refactoring

Refactors following files, but didn't change the code. This is to avoid reviewing old logic.

* N/A

## Evidence

* [ ] Screenshots or screen recording added for UI changes
* [ ] Before/after images added when relevant
* [ ] Images clearly show the implemented change
* [ ] Image quality is readable (no cropped or blurry evidence)

No frontend UI was changed in this PR. Backend response evidence is added for per-date calendar override sync results.

## Responsiveness

* [ ] UI checked on mobile
* [ ] UI checked on tablet
* [ ] UI checked on desktop
* [x] No broken layout, overflow, or hidden content on tested screen sizes

No frontend UI was changed in this PR.

## Npm Packages

* [ ] NPM Packages installed
* [ ] NPM Packages removed
* [ ] NPM Packages updated
* [ ] Checked for vulnerabilities using "npm audit"

No npm package changes were made.

## Checklist

[//]: # "All boxes must be checked before merging."

* [ ] Pull request has at least 2 reviewers assigned
* [x] PR title is descriptive and includes issue number
* [x] Conventions

  * [x] No config files have been added (Amplify config, cache files)
  * [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  * [x] No global styling (see [[#1691](https://github.com/domits1/Domits/issues/1691)](https://github.com/domits1/Domits/issues/1691))
  * [x] No `console.log` left in code
  * [x] No commented-out code remains
* [x] Testing

  * [x] Code tested locally
  * [x] Jest tests are included
  * [x] Jest tests are passing

Tested locally:

* `npm test -- test/PropertyHandler/calendar-overrides-unit.test.js`
* `npm test -- functions/UnifiedMessaging/business/integrationService.channexAri.test.js`
* `npm test -- functions/UnifiedMessaging/business/channexBookingAvailabilityBridge.test.js`
* `npm test -- test/General-Bookings-CRUD-Bookings-develop/bookingService.channex.test.js`
* `npm test -- functions/UnifiedMessaging/index.channexCertificationAccess.test.js`
* `npm test -- functions/UnifiedMessaging/business/integrationService.channexBookingRevisions.test.js`
* `npm test -- test/General-Bookings-CRUD-Bookings-develop/propertyRepository.availability.test.js`
* `npm test -- test/PropertyHandler/routing-unit.test.js`

Also checked:

* `git diff --check`

## Keep or delete my branch

* [x] Delete my branch after merge
* [ ] Keep my branch