### PR TITLE
fix(booking): qualify availability schema and show booked editor dates

### DIFF
--- a/backend/functions/General-Bookings-CRUD-Bookings-develop/data/propertyRepository.js
+++ b/backend/functions/General-Bookings-CRUD-Bookings-develop/data/propertyRepository.js
@@ -5,6 +5,22 @@ import ConflictException from "../util/exception/ConflictException.js";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const SAFE_IDENTIFIER_PATTERN = /^[A-Za-z_]\w*$/;
+
+const quoteIdentifier = (value) => `"${String(value || "").replaceAll('"', '""')}"`;
+
+const normalizeSchemaName = (value) => {
+  if (typeof value !== "string") return "main";
+
+  const trimmed = value.trim();
+  if (!SAFE_IDENTIFIER_PATTERN.test(trimmed)) return "main";
+
+  const normalized = trimmed.toLowerCase();
+  return normalized === "public" ? "main" : normalized;
+};
+
+const qualifyTableName = (client, tableName) =>
+  `${quoteIdentifier(normalizeSchemaName(client?.options?.schema))}.${quoteIdentifier(tableName)}`;
 
 const toCalendarDateInt = (date) =>
   Number(
@@ -97,11 +113,13 @@ class PropertyRepository {
     const startDate = Math.min(...stayDates);
     const endDate = Math.max(...stayDates);
     const client = await Database.getInstance();
+    const availabilityTable = qualifyTableName(client, "property_availability");
+    const calendarOverrideTable = qualifyTableName(client, "property_calendar_override");
     const [availabilityWindows, calendarOverrides] = await Promise.all([
       client.query(
         `
           SELECT availablestartdate, availableenddate
-          FROM property_availability
+          FROM ${availabilityTable}
           WHERE property_id = $1
         `,
         [propertyId]
@@ -109,7 +127,7 @@ class PropertyRepository {
       client.query(
         `
           SELECT calendar_date, is_available
-          FROM property_calendar_override
+          FROM ${calendarOverrideTable}
           WHERE property_id = $1
             AND calendar_date >= $2
             AND calendar_date <= $3

--- a/backend/test/General-Bookings-CRUD-Bookings-develop/propertyRepository.availability.test.js
+++ b/backend/test/General-Bookings-CRUD-Bookings-develop/propertyRepository.availability.test.js
@@ -11,7 +11,8 @@ jest.mock("database", () => ({
 const PropertyRepository =
   require("../../functions/General-Bookings-CRUD-Bookings-develop/data/propertyRepository.js").default;
 
-const createClient = ({ availabilityWindows = [], calendarOverrides = [] } = {}) => ({
+const createClient = ({ availabilityWindows = [], calendarOverrides = [], schema = "main" } = {}) => ({
+  options: { schema },
   query: jest.fn().mockResolvedValueOnce(availabilityWindows).mockResolvedValueOnce(calendarOverrides),
 });
 
@@ -34,6 +35,23 @@ describe("PropertyRepository booking calendar availability guard", () => {
         departureDateMs: Date.parse("2026-06-17T00:00:00.000Z"),
       })
     ).resolves.toBe(true);
+  });
+
+  test("queries schema-qualified host availability tables", async () => {
+    const client = createClient({
+      availabilityWindows: [{ availablestartdate: 20260615, availableenddate: 20260621 }],
+    });
+    mockDatabase.getInstance.mockResolvedValue(client);
+    const repository = new PropertyRepository();
+
+    await repository.assertBookingDatesAvailable({
+      propertyId: "property-1",
+      arrivalDateMs: Date.parse("2026-06-15T00:00:00.000Z"),
+      departureDateMs: Date.parse("2026-06-17T00:00:00.000Z"),
+    });
+
+    expect(client.query.mock.calls[0][0]).toContain('FROM "main"."property_availability"');
+    expect(client.query.mock.calls[1][0]).toContain('FROM "main"."property_calendar_override"');
   });
 
   test("rejects host-unavailable calendar override dates", async () => {

--- a/frontend/web/src/features/hostdashboard/hostproperty/components/HostPropertyAvailabilityTab.test.js
+++ b/frontend/web/src/features/hostdashboard/hostproperty/components/HostPropertyAvailabilityTab.test.js
@@ -7,9 +7,15 @@ import { HostPropertyAvailabilityTab, HostPropertyTabContent } from "./HostPrope
 import { fetchPropertyAndListings } from "../services/hostPropertyApi";
 import { extractFetchedPropertyData } from "../utils/hostPropertyUtils";
 import { getAccessToken } from "../../../../services/getAccessToken";
+import getReservationsFromToken from "../../services/getReservationsFromToken";
 
 jest.mock("../../../../services/getAccessToken", () => ({
   getAccessToken: jest.fn(() => "test-token"),
+}));
+
+jest.mock("../../services/getReservationsFromToken", () => ({
+  __esModule: true,
+  default: jest.fn(() => Promise.resolve("Data not found")),
 }));
 
 const okJsonResponse = (body) => ({
@@ -54,6 +60,17 @@ const expectCalendarOverridePatch = async (expectedBody) => {
 
 const mockOverrideLoad = (overrides = []) => {
   globalThis.fetch.mockResolvedValueOnce(okJsonResponse({ overrides }));
+};
+
+const mockBookingLoad = (reservations = []) => {
+  getReservationsFromToken.mockResolvedValueOnce([
+    {
+      id: "property-1",
+      res: {
+        response: reservations,
+      },
+    },
+  ]);
 };
 
 const mockOverrideLoadThenSave = ({ savedOverrides, initialOverrides = [] }) => {
@@ -141,6 +158,7 @@ const buildTabContentProps = () => ({
 describe("HostPropertyAvailabilityTab", () => {
   beforeEach(() => {
     getAccessToken.mockReturnValue("test-token");
+    getReservationsFromToken.mockResolvedValue("Data not found");
     globalThis.fetch = jest.fn().mockResolvedValue(okJsonResponse({ overrides: [] }));
   });
 
@@ -291,6 +309,85 @@ describe("HostPropertyAvailabilityTab", () => {
       overrides: [{ date: 20260610, isAvailable: true }],
     });
     expect(await screen.findByText(/1 date marked available/i)).toBeInTheDocument();
+  });
+
+  test("shows booked dates over available overrides and excludes the checkout date", async () => {
+    mockOverrideLoad([
+      { date: 20260619, isAvailable: true },
+      { date: 20260620, isAvailable: true },
+      { date: 20260621, isAvailable: true },
+      { date: 20260622, isAvailable: true },
+    ]);
+    mockBookingLoad([
+      {
+        status: "Paid",
+        arrivaldate: "2026-06-19",
+        departuredate: "2026-06-22",
+      },
+    ]);
+
+    renderAvailabilityTab();
+
+    expect(
+      await screen.findByRole("gridcell", { name: /2026-06-19, Booked\/blocked/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("gridcell", { name: /2026-06-20, Booked\/blocked/i })).toBeInTheDocument();
+    expect(screen.getByRole("gridcell", { name: /2026-06-21, Booked\/blocked/i })).toBeInTheDocument();
+    expect(screen.getByRole("gridcell", { name: /2026-06-22, Available override/i })).toBeInTheDocument();
+  });
+
+  test("does not make a booked date appear available when marking it available", async () => {
+    mockOverrideLoad([{ date: 20260619, isAvailable: true }]);
+    mockBookingLoad([
+      {
+        status: "Paid",
+        arrivaldate: "2026-06-19",
+        departuredate: "2026-06-22",
+      },
+    ]);
+
+    renderAvailabilityTab();
+
+    await saveAvailabilityRange({
+      startDate: "2026-06-19",
+      endDate: "2026-06-19",
+      availability: "available",
+    });
+
+    expect(
+      await screen.findByText("Booked/blocked dates cannot be made available. Active bookings always block availability.")
+    ).toBeInTheDocument();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("gridcell", { name: /2026-06-19, Booked\/blocked/i })).toBeInTheDocument();
+  });
+
+  test("skips booked dates when saving availability for a mixed selected range", async () => {
+    mockOverrideLoadThenSave({
+      savedOverrides: [{ date: 20260618, isAvailable: true }],
+    });
+    mockBookingLoad([
+      {
+        status: "Paid",
+        arrivaldate: "2026-06-19",
+        departuredate: "2026-06-22",
+      },
+    ]);
+
+    renderAvailabilityTab();
+
+    await saveAvailabilityRange({
+      startDate: "2026-06-18",
+      endDate: "2026-06-20",
+      availability: "available",
+    });
+
+    await expectCalendarOverridePatch({
+      propertyId: "property-1",
+      overrides: [{ date: 20260618, isAvailable: true }],
+    });
+    expect(await screen.findByText(/1 date marked available/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 booked\/blocked dates were skipped/i)).toBeInTheDocument();
+    expect(screen.getByRole("gridcell", { name: /2026-06-19, Booked\/blocked/i })).toBeInTheDocument();
   });
 
   test("shows backend authorization errors when saving availability is denied", async () => {

--- a/frontend/web/src/features/hostdashboard/hostproperty/components/HostPropertyTabContent.js
+++ b/frontend/web/src/features/hostdashboard/hostproperty/components/HostPropertyTabContent.js
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useRef, useState, useEffect } from "react";
+import React, { useLayoutEffect, useMemo, useRef, useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import styles from "../../HostProperty.module.css";
 import arrowDownIcon from "../../../../images/arrow-down-icon.svg";
@@ -24,6 +24,7 @@ import {
   startOfMonthUTC,
   subMonthsUTC,
 } from "../../hostcalen/utils/date";
+import { useCalendarBookings } from "../../hostcalen/hooks/useCalendarBookings";
 import { usePhotoTileInteractionHandlers } from "../hooks/usePhotoTileInteractionHandlers";
 import {
   createInitialPricingForm,
@@ -135,19 +136,6 @@ const normalizeAvailabilityOverrideMap = (overrides) =>
     next[dateKey] = Boolean(override.isAvailable);
     return next;
   }, {});
-
-const resolveAvailabilityLabel = ({ dateKey, availabilityOverrides, availabilityRanges }) => {
-  if (!DATE_KEY_PATTERN.test(String(dateKey || ""))) {
-    return "Choose a date";
-  }
-  if (Object.hasOwn(availabilityOverrides, dateKey)) {
-    return availabilityOverrides[dateKey] ? "Available by override" : "Unavailable by override";
-  }
-
-  const dateNumber = keyToDateNumber(dateKey);
-  const isInBaseWindow = availabilityRanges.some((range) => dateNumber >= range.start && dateNumber <= range.end);
-  return isInBaseWindow ? "Available from listing window" : "Unavailable outside base window";
-};
 
 const buildAvailabilityOverridePayload = ({ dateKeys, available }) => ({
   overrides: (Array.isArray(dateKeys) ? dateKeys : [])
@@ -1159,8 +1147,25 @@ export function HostPropertyAvailabilityTab({ propertyId, listingTitle, availabi
   const [savingOverride, setSavingOverride] = useState(false);
   const [availabilityMessage, setAvailabilityMessage] = useState("");
   const [availabilityError, setAvailabilityError] = useState("");
+  const { bookedDateKeysByPropertyId } = useCalendarBookings();
   const availabilityRanges = normalizeAvailabilityRanges(availability);
-  const blockedDateSet = new Set(Array.isArray(blockedDateKeys) ? blockedDateKeys : []);
+  const blockedDateSet = useMemo(() => {
+    const nextBlockedDateSet = new Set();
+    const addDateKey = (dateKey) => {
+      const normalizedDateKey = String(dateKey || "");
+      if (DATE_KEY_PATTERN.test(normalizedDateKey)) {
+        nextBlockedDateSet.add(normalizedDateKey);
+      }
+    };
+
+    (Array.isArray(blockedDateKeys) ? blockedDateKeys : []).forEach(addDateKey);
+    (Array.isArray(bookedDateKeysByPropertyId?.[propertyId])
+      ? bookedDateKeysByPropertyId[propertyId]
+      : []
+    ).forEach(addDateKey);
+
+    return nextBlockedDateSet;
+  }, [blockedDateKeys, bookedDateKeysByPropertyId, propertyId]);
   const monthGrid = getMonthMatrix(calendarCursor);
   const selectedDateKeys = getKeyRangeInclusive(selectedStartDateKey, selectedEndDateKey);
   const selectedDateSet = new Set(selectedDateKeys);
@@ -1266,8 +1271,16 @@ export function HostPropertyAvailabilityTab({ propertyId, listingTitle, availabi
     setAvailabilityError("");
     setAvailabilityMessage("");
     const isAvailable = selectedAvailability === "available";
+    const editableDateKeys = selectedDateKeys.filter((dateKey) => !blockedDateSet.has(dateKey));
+    const skippedBlockedDateCount = selectedDateKeys.length - editableDateKeys.length;
+    if (!editableDateKeys.length && skippedBlockedDateCount > 0) {
+      setAvailabilityError("Booked/blocked dates cannot be made available. Active bookings always block availability.");
+      setSavingOverride(false);
+      return;
+    }
+
     const payload = buildAvailabilityOverridePayload({
-      dateKeys: selectedDateKeys,
+      dateKeys: editableDateKeys,
       available: isAvailable,
     });
     if (!payload.overrides.length) {
@@ -1299,10 +1312,17 @@ export function HostPropertyAvailabilityTab({ propertyId, listingTitle, availabi
         ...previous,
         ...confirmedOverrides,
       }));
+      const savedDateCount = editableDateKeys.length;
+      const skippedMessage =
+        skippedBlockedDateCount > 0
+          ? ` ${skippedBlockedDateCount} booked/blocked ${
+              skippedBlockedDateCount === 1 ? "date was" : "dates were"
+            } skipped because active bookings always block availability.`
+          : "";
       setAvailabilityMessage(
-        `${selectedDateKeys.length} ${selectedDateKeys.length === 1 ? "date" : "dates"} marked ${
+        `${savedDateCount} ${savedDateCount === 1 ? "date" : "dates"} marked ${
           isAvailable ? "available" : "unavailable"
-        }. Calendar & Pricing, guest bookings, and Full Sync use this same source.`
+        }.${skippedMessage} Calendar & Pricing, guest bookings, and Full Sync use this same source.`
       );
     } catch (error) {
       setAvailabilityError(error?.message || "Could not save availability override.");
@@ -1311,11 +1331,12 @@ export function HostPropertyAvailabilityTab({ propertyId, listingTitle, availabi
     }
   };
 
-  const selectedStartStatus = resolveAvailabilityLabel({
+  const selectedStartStatus = resolveAvailabilityDetails({
     dateKey: selectedStartDateKey,
     availabilityOverrides,
     availabilityRanges,
-  });
+    blockedDateSet,
+  }).label;
   const selectedRangeLabel =
     selectedDateKeys.length === 1
       ? selectedStartDateKey


### PR DESCRIPTION
## Close or Relate the Issue

* Related Issue: #

## Proposed Changes

Description:

This PR fixes two acceptance-readiness issues in the Channex/listing availability flow.

First, it fixes the Domits guest booking failure caused by the booking availability guard querying unqualified database table names. Acceptance stores availability tables under the `main` schema, so the raw SQL now safely uses schema-qualified table names for:

* `"main"."property_availability"`
* `"main"."property_calendar_override"`

This restores guest booking creation while keeping the host-calendar availability guard active.

Second, it improves the Listing Editor Availability UI so booked/imported Channex booking nights are shown as **Booked/blocked** instead of misleadingly staying green as **Available override**. Active bookings now visually take precedence over host availability overrides. Checkout dates remain unblocked.

The backend booking validation, Channex sync behavior, Full Sync behavior, polling/import behavior, Calendar & Pricing, and guest listing availability logic are preserved.

## Change Type

* [x] Bug fix
* [ ] New feature
* [ ] Optimization
* [ ] Documentation update

## Change Size

* [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [[Refactoring](https://chatgpt.com/g/g-p-697f7ff03c808191b0c04598bc66b5c0/c/6a06ea98-e38c-8386-88d5-1ccaf8a0cabb#Refactoring)](#Refactoring))
* [ ] Big change (+-max 1000)
* [x] Small change (less than 300)

## Refactoring

No refactoring-only files. The changed files contain targeted bug fixes and test coverage only.

Changed files:

* `backend/functions/General-Bookings-CRUD-Bookings-develop/data/propertyRepository.js`
* `backend/test/General-Bookings-CRUD-Bookings-develop/propertyRepository.availability.test.js`
* `frontend/web/src/features/hostdashboard/hostproperty/components/HostPropertyAvailabilityTab.test.js`
* `frontend/web/src/features/hostdashboard/hostproperty/components/HostPropertyTabContent.js`

## Evidence

* [x] Screenshots or screen recording added for UI changes
* [ ] Before/after images added when relevant
* [x] Images clearly show the implemented change
* [x] Image quality is readable (no cropped or blurry evidence)

Evidence from testing:

* External Channex booking imported into Domits through automatic polling.
* Calendar & Pricing correctly showed booked dates as blocked.
* Guest listing page correctly blocked booked dates.
* ARI Preview showed booking-aware availability:

  * `2026-06-19`, `2026-06-20`, `2026-06-21` blocked by booking.
  * `2026-06-22` available as checkout date.
* Listing Editor now has test coverage proving booked dates override green available overrides.
* Full Sync was tested after Channex booking create/modify/cancel and did not reset or break booking-aware availability.

## Responsiveness

* [ ] UI checked on mobile
* [ ] UI checked on tablet
* [x] UI checked on desktop
* [x] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages

* [ ] NPM Packages installed
* [ ] NPM Packages removed
* [ ] NPM Packages updated
* [ ] Checked for vulnerabilities using "npm audit"

No npm package changes were made in this PR.

## Checklist

* [ ] Pull request has at least 2 reviewers assigned
* [x] PR title is descriptive and includes issue number
* [x] Conventions

  * [x] No config files have been added (Amplify config, cache files)
  * [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  * [x] No global styling (see [[#1691](https://github.com/domits1/Domits/issues/1691)](https://github.com/domits1/Domits/issues/1691))
  * [x] No `console.log` left in code
  * [x] No commented-out code remains
* [x] Testing

  * [x] Code tested locally
  * [x] Jest tests are included
  * [x] Jest tests are passing

## Tests / Build

All passed:

Backend:

* `npm test -- test/General-Bookings-CRUD-Bookings-develop/propertyRepository.availability.test.js`
* `npm test -- test/General-Bookings-CRUD-Bookings-develop/bookingService.channex.test.js`
* `npm test -- functions/UnifiedMessaging/business/channexBookingAvailabilityBridge.test.js`
* `npm test -- functions/UnifiedMessaging/business/integrationService.channexAri.test.js`
* `npm test -- functions/UnifiedMessaging/business/integrationService.channexBookingRevisions.test.js`

Frontend:

* `npm test -- --runTestsByPath src/features/hostdashboard/hostproperty/components/HostPropertyAvailabilityTab.test.js --watchAll=false`
* `npm test -- --runTestsByPath src/features/hostdashboard/hostcalen/hooks/hostCalendarHelpers.test.js --watchAll=false`
* `npm test -- --runTestsByPath src/features/bookingengine/listingdetails/pages/listingDetails2.test.js --watchAll=false`
* `npm test -- --runTestsByPath src/features/bookingengine/tests/BookingOverview.test.js --watchAll=false`
* `npm run build`

Other:

* `git diff --check` passed.

## Acceptance Testing Notes

After deploy to acceptance, the main live verification should be:

1. Set an available date for `Roso Guest House`.
2. Book that date through Domits as a guest.
3. Confirm the booking is created successfully.
4. Confirm Channex availability changes to `0`.
5. Confirm Listing Editor shows the booked night as `Booked/blocked`.
6. Confirm checkout date is not blocked.
7. Confirm Full Sync preserves booking-aware availability.

## Keep or delete my branch

* [x] Delete my branch after merge
* [ ] Keep my branch