### PR TITLE
fix(booking): show outside-window dates unavailable to guests

### DIFF
--- a/backend/functions/PropertyHandler/business/service/propertyService.js
+++ b/backend/functions/PropertyHandler/business/service/propertyService.js
@@ -27,6 +27,7 @@ import { DatabaseException } from "../../util/exception/DatabaseException.js";
 import { NotFoundException } from "../../util/exception/NotFoundException.js";
 import { Forbidden } from "../../util/exception/Forbidden.js";
 import {
+  extractAvailableOverrideDateKeys,
   extractUnavailableOverrideDateKeys,
   normalizeBlockedDateKeys,
 } from "../../util/calendarAvailability.js";
@@ -387,6 +388,7 @@ export class PropertyService {
       externalBlockedDates: Array.isArray(availabilitySnapshot?.externalBlockedDates)
         ? availabilitySnapshot.externalBlockedDates
         : [],
+      availableDateKeys: extractAvailableOverrideDateKeys(calendarOverrides),
       unavailableDateKeys,
       hasExternalCalendarSync: availabilitySnapshot?.hasExternalCalendarSync === true,
       syncedSourceCount: Math.max(0, Number(availabilitySnapshot?.syncedSourceCount || 0)),

--- a/backend/functions/PropertyHandler/util/calendarAvailability.js
+++ b/backend/functions/PropertyHandler/util/calendarAvailability.js
@@ -91,3 +91,9 @@ export const extractUnavailableOverrideDateKeys = (overrides) =>
     (Array.isArray(overrides) ? overrides : []).filter((override) => override?.isAvailable === false),
     (override) => normalizeOverrideDateKey(override?.date)
   );
+
+export const extractAvailableOverrideDateKeys = (overrides) =>
+  collectNormalizedDateKeys(
+    (Array.isArray(overrides) ? overrides : []).filter((override) => override?.isAvailable === true),
+    (override) => normalizeOverrideDateKey(override?.date)
+  );

--- a/frontend/web/src/features/bookingengine/listingdetails/components/checkIn.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/components/checkIn.js
@@ -15,6 +15,8 @@ const CheckIn = ({
   checkInDate = "",
   setCheckInDate = () => {},
   unavailableDateKeys = [],
+  availabilityRanges = null,
+  availableDateKeys = [],
 }) => {
   const unavailableDateSet = buildUnavailableDateSet(unavailableDateKeys);
   const minDate = normalizeDateValue(getFutureDateKey(1));
@@ -28,7 +30,12 @@ const CheckIn = ({
           onChange={(date) => setCheckInDate(date ? toDateKey(date) : "")}
           className="inputField"
           minDate={minDate}
-          filterDate={(date) => !isUnavailableDate(date, unavailableDateSet)}
+          filterDate={(date) =>
+            !isUnavailableDate(date, unavailableDateSet, {
+              availabilityRanges,
+              availableDateKeys,
+            })
+          }
           dayClassName={(date) => (toDateKey(date) === toDateKey(new Date()) ? "booking-picker-day--today" : "")}
           dateFormat="yyyy-MM-dd"
           placeholderText="YYYY-MM-DD"
@@ -47,6 +54,13 @@ CheckIn.propTypes = {
   checkInDate: PropTypes.string,
   setCheckInDate: PropTypes.func,
   unavailableDateKeys: PropTypes.arrayOf(PropTypes.string),
+  availabilityRanges: PropTypes.arrayOf(
+    PropTypes.shape({
+      start: PropTypes.number.isRequired,
+      end: PropTypes.number.isRequired,
+    })
+  ),
+  availableDateKeys: PropTypes.arrayOf(PropTypes.string),
 };
 
 export default CheckIn;

--- a/frontend/web/src/features/bookingengine/listingdetails/components/checkOut.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/components/checkOut.js
@@ -12,7 +12,14 @@ import {
 
 const fixedPopperProps = { strategy: "fixed" };
 
-const CheckOut = ({ checkOutDate = "", setCheckOutDate = () => {}, checkInDate = "", unavailableDateKeys = [] }) => {
+const CheckOut = ({
+  checkOutDate = "",
+  setCheckOutDate = () => {},
+  checkInDate = "",
+  unavailableDateKeys = [],
+  availabilityRanges = null,
+  availableDateKeys = [],
+}) => {
   const minCheckOutDate = checkInDate ? addDaysToDateKey(checkInDate, 1) : getFutureDateKey(2);
 
   const unavailableDateSet = buildUnavailableDateSet(unavailableDateKeys);
@@ -36,7 +43,10 @@ const CheckOut = ({ checkOutDate = "", setCheckOutDate = () => {}, checkInDate =
               return false;
             }
 
-            return !hasUnavailableDateInStayRange(selectedCheckInDate, date, unavailableDateSet);
+            return !hasUnavailableDateInStayRange(selectedCheckInDate, date, unavailableDateSet, {
+              availabilityRanges,
+              availableDateKeys,
+            });
           }}
           dayClassName={(date) => (toDateKey(date) === toDateKey(new Date()) ? "booking-picker-day--today" : "")}
           dateFormat="yyyy-MM-dd"
@@ -58,6 +68,13 @@ CheckOut.propTypes = {
   setCheckOutDate: PropTypes.func,
   checkInDate: PropTypes.string,
   unavailableDateKeys: PropTypes.arrayOf(PropTypes.string),
+  availabilityRanges: PropTypes.arrayOf(
+    PropTypes.shape({
+      start: PropTypes.number.isRequired,
+      end: PropTypes.number.isRequired,
+    })
+  ),
+  availableDateKeys: PropTypes.arrayOf(PropTypes.string),
 };
 
 export default CheckOut;

--- a/frontend/web/src/features/bookingengine/listingdetails/pages/listingDetails2.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/pages/listingDetails2.js
@@ -7,6 +7,7 @@ import Header from "../components/header";
 import SectionTabs from "../components/sectionTabs";
 import PropertyContainer from "../views/propertyContainer";
 import BookingContainer from "../views/bookingContainer";
+import { normalizeAvailabilityRanges } from "../utils/dateAvailability";
 
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
 const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
@@ -96,6 +97,9 @@ const normalizeCalendarAvailability = (calendarAvailability) => {
   const safeCalendarAvailability = toPlainObject(calendarAvailability);
   return {
     ...safeCalendarAvailability,
+    availableDateKeys: normalizeDateKeyArray(
+      safeCalendarAvailability.availableDateKeys ?? safeCalendarAvailability.availableOverrideDateKeys
+    ),
     externalBlockedDates: normalizeDateKeyArray(safeCalendarAvailability.externalBlockedDates),
     unavailableDateKeys: normalizeDateKeyArray(safeCalendarAvailability.unavailableDateKeys),
   };
@@ -152,6 +156,7 @@ const normalizeListingProperty = (payload) => {
           })),
     property: nestedProperty,
     images: toArray(property.images),
+    availability: toArray(property.availability || nestedProperty.availability),
     pricing: toPlainObject(property.pricing),
     generalDetails: toArray(property.generalDetails),
     amenities: toArray(property.amenities),
@@ -206,6 +211,17 @@ const ListingDetails2 = () => {
       property?.calendarAvailability?.externalBlockedDates,
       property?.calendarAvailability?.unavailableDateKeys,
     ]
+  );
+  const availabilityRanges = useMemo(
+    () => normalizeAvailabilityRanges(property?.availability),
+    [property?.availability]
+  );
+  const availableDateKeys = useMemo(
+    () =>
+      Array.isArray(property?.calendarAvailability?.availableDateKeys)
+        ? property.calendarAvailability.availableDateKeys
+        : [],
+    [property?.calendarAvailability?.availableDateKeys]
   );
 
   useEffect(() => {
@@ -281,6 +297,8 @@ const ListingDetails2 = () => {
               : undefined
           }
           unavailableDateKeys={unavailableDateKeys}
+          availabilityRanges={availabilityRanges}
+          availableDateKeys={availableDateKeys}
           checkInDate={checkInDate}
           checkOutDate={checkOutDate}
           setCheckInDate={setCheckInDate}
@@ -291,6 +309,8 @@ const ListingDetails2 = () => {
             host={host}
             propertyId={id}
             unavailableDateKeys={unavailableDateKeys}
+            availabilityRanges={availabilityRanges}
+            availableDateKeys={availableDateKeys}
             checkInDate={checkInDate}
             setCheckInDate={setCheckInDate}
             checkOutDate={checkOutDate}

--- a/frontend/web/src/features/bookingengine/listingdetails/pages/listingDetails2.test.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/pages/listingDetails2.test.js
@@ -1,11 +1,12 @@
 import React from "react";
 import "@testing-library/jest-dom";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 
 import ListingDetails2 from "./listingDetails2";
 import FetchPropertyById from "../services/fetchPropertyById";
 import fetchHostInfo from "../services/fetchHostInfo";
+import RangeCalendar from "../views/RangeCalendar";
 
 jest.mock("../services/fetchPropertyById");
 jest.mock("../services/fetchHostInfo");
@@ -14,25 +15,35 @@ jest.mock("../components/header", () => () => <div>Header</div>);
 jest.mock("../components/sectionTabs", () => () => <div>Tabs</div>);
 jest.mock("../views/propertyContainer", () => {
   const PropTypes = require("prop-types");
-  const MockPropertyContainer = ({ unavailableDateKeys = [], children }) => (
+  const MockPropertyContainer = ({ unavailableDateKeys = [], availabilityRanges = [], availableDateKeys = [], children }) => (
     <div>
       <div data-testid="property-unavailable-dates">{unavailableDateKeys.join("|")}</div>
+      <div data-testid="property-availability-ranges">{JSON.stringify(availabilityRanges)}</div>
+      <div data-testid="property-available-dates">{availableDateKeys.join("|")}</div>
       {children}
     </div>
   );
   MockPropertyContainer.propTypes = {
     unavailableDateKeys: PropTypes.arrayOf(PropTypes.string),
+    availabilityRanges: PropTypes.arrayOf(PropTypes.object),
+    availableDateKeys: PropTypes.arrayOf(PropTypes.string),
     children: PropTypes.node,
   };
   return MockPropertyContainer;
 });
 jest.mock("../views/bookingContainer", () => {
   const PropTypes = require("prop-types");
-  const MockBookingContainer = ({ unavailableDateKeys = [] }) => (
-    <div data-testid="booking-unavailable-dates">{unavailableDateKeys.join("|")}</div>
+  const MockBookingContainer = ({ unavailableDateKeys = [], availabilityRanges = [], availableDateKeys = [] }) => (
+    <div>
+      <div data-testid="booking-unavailable-dates">{unavailableDateKeys.join("|")}</div>
+      <div data-testid="booking-availability-ranges">{JSON.stringify(availabilityRanges)}</div>
+      <div data-testid="booking-available-dates">{availableDateKeys.join("|")}</div>
+    </div>
   );
   MockBookingContainer.propTypes = {
     unavailableDateKeys: PropTypes.arrayOf(PropTypes.string),
+    availabilityRanges: PropTypes.arrayOf(PropTypes.object),
+    availableDateKeys: PropTypes.arrayOf(PropTypes.string),
   };
   return MockBookingContainer;
 });
@@ -44,16 +55,31 @@ const renderListingDetails = () =>
     </MemoryRouter>
   );
 
-const mockProperty = (calendarAvailability = {}) => {
+const mockProperty = (calendarAvailability = {}, options = {}) => {
   FetchPropertyById.mockResolvedValue({
     property: {
       id: "property-1",
       hostId: "host-1",
       title: "Demo listing",
     },
+    availability: options.availability || [],
     calendarAvailability,
   });
   fetchHostInfo.mockResolvedValue({ name: "Host" });
+};
+
+const renderRangeCalendar = (props = {}) => {
+  const onRangeChange = jest.fn();
+  render(
+    <RangeCalendar
+      availabilityRanges={[{ start: 20260615, end: 20260621 }]}
+      checkInDate=""
+      checkOutDate=""
+      onRangeChange={onRangeChange}
+      {...props}
+    />
+  );
+  return onRangeChange;
 };
 
 describe("ListingDetails2 availability", () => {
@@ -107,5 +133,95 @@ describe("ListingDetails2 availability", () => {
     await waitFor(() => {
       expect(screen.getByTestId("booking-unavailable-dates")).toHaveTextContent("2026-06-20");
     });
+  });
+
+  test("passes base availability and explicit available overrides to guest availability components", async () => {
+    mockProperty(
+      {
+        availableDateKeys: ["2026-06-10"],
+        unavailableDateKeys: ["2026-06-19"],
+      },
+      {
+        availability: [{ availableStartDate: 20260615, availableEndDate: 20260621 }],
+      }
+    );
+
+    renderListingDetails();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("booking-available-dates")).toHaveTextContent("2026-06-10");
+    });
+
+    expect(screen.getByTestId("booking-availability-ranges")).toHaveTextContent(
+      JSON.stringify([{ start: 20260615, end: 20260621 }])
+    );
+    expect(screen.getByTestId("property-available-dates")).toHaveTextContent("2026-06-10");
+    expect(screen.getByTestId("property-availability-ranges")).toHaveTextContent(
+      JSON.stringify([{ start: 20260615, end: 20260621 }])
+    );
+  });
+});
+
+describe("RangeCalendar effective availability", () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-06-01T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  test("renders outside-base-window dates as unavailable with a visible marker", () => {
+    renderRangeCalendar();
+
+    const outsideWindowDate = screen.getByRole("button", { name: "June 10, 2026" });
+    const insideWindowDate = screen.getByRole("button", { name: "June 15, 2026" });
+
+    expect(outsideWindowDate).toBeDisabled();
+    expect(within(outsideWindowDate).getByText("--")).toBeInTheDocument();
+    expect(insideWindowDate).not.toBeDisabled();
+  });
+
+  test("shows a clear message when selected stay includes outside-window unavailable nights", () => {
+    const onRangeChange = renderRangeCalendar({ availableDateKeys: ["2026-06-10"] });
+
+    fireEvent.click(screen.getByRole("button", { name: "June 10, 2026" }));
+    fireEvent.click(screen.getByRole("button", { name: "June 15, 2026" }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent("This property has no availability for the selected dates.");
+    expect(onRangeChange).toHaveBeenLastCalledWith("2026-06-15", "");
+  });
+
+  test("keeps explicit available override outside base window selectable", () => {
+    const onRangeChange = renderRangeCalendar({ availableDateKeys: ["2026-06-10"] });
+
+    const availableOverrideDate = screen.getByRole("button", { name: "June 10, 2026" });
+
+    expect(availableOverrideDate).not.toBeDisabled();
+    fireEvent.click(availableOverrideDate);
+
+    expect(onRangeChange).toHaveBeenCalledWith("2026-06-10", "");
+  });
+
+  test("keeps explicit unavailable override inside base window unavailable", () => {
+    renderRangeCalendar({ unavailableDateKeys: ["2026-06-16"] });
+
+    const unavailableOverrideDate = screen.getByRole("button", { name: "June 16, 2026" });
+
+    expect(unavailableOverrideDate).toBeDisabled();
+    expect(within(unavailableOverrideDate).getByText("--")).toBeInTheDocument();
+  });
+
+  test("blocks active booking nights and keeps checkout date selectable", () => {
+    renderRangeCalendar({
+      availabilityRanges: [{ start: 20260619, end: 20260622 }],
+      unavailableDateKeys: ["2026-06-19", "2026-06-20", "2026-06-21"],
+    });
+
+    expect(screen.getByRole("button", { name: "June 19, 2026" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "June 20, 2026" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "June 21, 2026" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "June 22, 2026" })).not.toBeDisabled();
   });
 });

--- a/frontend/web/src/features/bookingengine/listingdetails/styles/RangeCalendar.scss
+++ b/frontend/web/src/features/bookingengine/listingdetails/styles/RangeCalendar.scss
@@ -47,6 +47,14 @@
   line-height: 1.35;
 }
 
+.availability-section__error {
+  margin: 0;
+  color: #b42318;
+  font-size: 0.98rem;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
 .rc {
   --rc-border: #dfe4ea;
   --rc-muted: #6b7280;
@@ -160,6 +168,8 @@
     background: #757575;
     border-color: #757575;
     cursor: not-allowed;
+    flex-direction: column;
+    gap: 2px;
 
     span {
       color: #fff;
@@ -196,6 +206,13 @@
     color: #3b4048;
     font-size: 1rem;
     font-weight: 500;
+  }
+
+  .rc-cell__unavailable-mark {
+    color: #fff;
+    font-size: 0.78rem;
+    font-weight: 700;
+    line-height: 1;
   }
 
   &.is-start span,

--- a/frontend/web/src/features/bookingengine/listingdetails/utils/dateAvailability.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/utils/dateAvailability.js
@@ -27,7 +27,66 @@ export const buildUnavailableDateSet = (values) =>
       .filter((value) => DATE_KEY_PATTERN.test(value))
   );
 
-export const isUnavailableDate = (value, unavailableValues) => {
+export const normalizeAvailabilityDateNumber = (value) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return null;
+  }
+
+  const truncated = Math.trunc(numeric);
+  if (truncated >= 10000101 && truncated <= 99991231) {
+    return truncated;
+  }
+
+  const milliseconds = truncated > 1000000000000 ? truncated : truncated * 1000;
+  const date = new Date(milliseconds);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return Number(`${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}`);
+};
+
+export const normalizeAvailabilityRanges = (availability) =>
+  (Array.isArray(availability) ? availability : [])
+    .map((entry) => {
+      const start = normalizeAvailabilityDateNumber(entry?.availableStartDate ?? entry?.availablestartdate);
+      const end = normalizeAvailabilityDateNumber(entry?.availableEndDate ?? entry?.availableenddate);
+      if (!start || !end) {
+        return null;
+      }
+      return start <= end ? { start, end } : { start: end, end: start };
+    })
+    .filter(Boolean)
+    .sort((left, right) => left.start - right.start);
+
+export const dateKeyToDateNumber = (value) => {
+  const normalizedDateKey = String(value || "").trim();
+  if (!DATE_KEY_PATTERN.test(normalizedDateKey)) {
+    return null;
+  }
+  return Number(normalizedDateKey.replaceAll("-", ""));
+};
+
+const normalizeAvailabilityContext = (availabilityContext = {}) => ({
+  availableDateSet:
+    availabilityContext.availableDateKeys instanceof Set
+      ? availabilityContext.availableDateKeys
+      : buildUnavailableDateSet(availabilityContext.availableDateKeys),
+  availabilityRanges: Array.isArray(availabilityContext.availabilityRanges)
+    ? availabilityContext.availabilityRanges
+    : null,
+});
+
+export const isDateAvailableFromBaseWindow = (dateKey, availabilityRanges) => {
+  const dateNumber = dateKeyToDateNumber(dateKey);
+  if (!dateNumber || !Array.isArray(availabilityRanges)) {
+    return false;
+  }
+  return availabilityRanges.some((range) => dateNumber >= range.start && dateNumber <= range.end);
+};
+
+export const isUnavailableDate = (value, unavailableValues, availabilityContext) => {
   const normalizedDate = normalizeDateValue(value);
   if (!normalizedDate) {
     return false;
@@ -35,10 +94,29 @@ export const isUnavailableDate = (value, unavailableValues) => {
 
   const unavailableDateSet =
     unavailableValues instanceof Set ? unavailableValues : buildUnavailableDateSet(unavailableValues);
-  return unavailableDateSet.has(toDateKey(normalizedDate));
+  const dateKey = toDateKey(normalizedDate);
+  if (unavailableDateSet.has(dateKey)) {
+    return true;
+  }
+
+  const { availableDateSet, availabilityRanges } = normalizeAvailabilityContext(availabilityContext);
+  if (availableDateSet.has(dateKey)) {
+    return false;
+  }
+
+  if (Array.isArray(availabilityRanges)) {
+    return !isDateAvailableFromBaseWindow(dateKey, availabilityRanges);
+  }
+
+  return false;
 };
 
-export const hasUnavailableDateInStayRange = (checkInValue, checkOutValue, unavailableValues) => {
+export const hasUnavailableDateInStayRange = (
+  checkInValue,
+  checkOutValue,
+  unavailableValues,
+  availabilityContext
+) => {
   const checkInDate = normalizeDateValue(checkInValue);
   const checkOutDate = normalizeDateValue(checkOutValue);
   if (!checkInDate || !checkOutDate || checkOutDate <= checkInDate) {
@@ -52,7 +130,7 @@ export const hasUnavailableDateInStayRange = (checkInValue, checkOutValue, unava
     cursor < checkOutDate;
     cursor = new Date(cursor.valueOf() + DAY_IN_MS)
   ) {
-    if (unavailableDateSet.has(toDateKey(cursor))) {
+    if (isUnavailableDate(cursor, unavailableDateSet, availabilityContext)) {
       return true;
     }
   }

--- a/frontend/web/src/features/bookingengine/listingdetails/views/RangeCalendar.jsx
+++ b/frontend/web/src/features/bookingengine/listingdetails/views/RangeCalendar.jsx
@@ -4,11 +4,13 @@ import { FaCalendarAlt } from "react-icons/fa";
 import {
   buildUnavailableDateSet,
   hasUnavailableDateInStayRange,
+  isUnavailableDate,
   normalizeDateValue,
   toDateKey,
 } from "../utils/dateAvailability";
 import "../styles/RangeCalendar.scss";
 
+const NO_AVAILABILITY_MESSAGE = "This property has no availability for the selected dates.";
 const makeDate = (year, month, day) => new Date(year, month, day);
 const addMonths = (date, offset) => makeDate(date.getFullYear(), date.getMonth() + offset, 1);
 
@@ -40,6 +42,8 @@ function MonthGrid({
   onPick,
   navigation = null,
   blockedDateKeys,
+  availabilityRanges,
+  availableDateKeys,
 }) {
   const year = viewMonth.getFullYear();
   const month = viewMonth.getMonth();
@@ -54,7 +58,12 @@ function MonthGrid({
       date.setDate(start.getDate() + index);
       const inMonth = date.getMonth() === month;
       const key = toDateKey(date);
-      const isUnavailable = inMonth && blockedDateKeys.has(key);
+      const isUnavailable =
+        inMonth &&
+        isUnavailableDate(date, blockedDateKeys, {
+          availabilityRanges,
+          availableDateKeys,
+        });
       const inRange = rangeStart && rangeEnd && date >= rangeStart && date <= rangeEnd && inMonth;
       const isStart = rangeStart && key === toDateKey(rangeStart);
       const isEnd = rangeEnd && key === toDateKey(rangeEnd);
@@ -114,6 +123,7 @@ function MonthGrid({
               onClick={() => onPick(cell.date)}
             >
               <span>{cell.date.getDate()}</span>
+              {cell.isUnavailable ? <span className="rc-cell__unavailable-mark" aria-hidden="true">--</span> : null}
             </button>
           );
         })}
@@ -128,6 +138,13 @@ MonthGrid.propTypes = {
   rangeEnd: PropTypes.instanceOf(Date),
   onPick: PropTypes.func.isRequired,
   blockedDateKeys: PropTypes.instanceOf(Set).isRequired,
+  availabilityRanges: PropTypes.arrayOf(
+    PropTypes.shape({
+      start: PropTypes.number.isRequired,
+      end: PropTypes.number.isRequired,
+    })
+  ),
+  availableDateKeys: PropTypes.instanceOf(Set).isRequired,
   navigation: PropTypes.shape({
     side: PropTypes.oneOf(["left", "right"]),
     onClick: PropTypes.func,
@@ -136,6 +153,8 @@ MonthGrid.propTypes = {
 
 export default function RangeCalendar({
   unavailableDateKeys = [],
+  availabilityRanges = null,
+  availableDateKeys = [],
   checkInDate = "",
   checkOutDate = "",
   onRangeChange,
@@ -145,10 +164,19 @@ export default function RangeCalendar({
 
   const [view, setView] = useState(initialMonth);
   const [draftStart, setDraftStart] = useState(null);
+  const [selectionError, setSelectionError] = useState("");
   const rangeStart = useMemo(() => normalizeDateValue(checkInDate), [checkInDate]);
   const rangeEnd = useMemo(() => normalizeDateValue(checkOutDate), [checkOutDate]);
 
   const blockedDateKeys = useMemo(() => buildUnavailableDateSet(unavailableDateKeys), [unavailableDateKeys]);
+  const availableDateKeySet = useMemo(() => buildUnavailableDateSet(availableDateKeys), [availableDateKeys]);
+  const availabilityContext = useMemo(
+    () => ({
+      availabilityRanges,
+      availableDateKeys: availableDateKeySet,
+    }),
+    [availabilityRanges, availableDateKeySet]
+  );
 
   const rightMonth = useMemo(() => addMonths(view, 1), [view]);
 
@@ -161,9 +189,11 @@ export default function RangeCalendar({
 
   const handlePick = (date) => {
     const key = toDateKey(date);
-    if (blockedDateKeys.has(key)) {
+    if (isUnavailableDate(date, blockedDateKeys, availabilityContext)) {
+      setSelectionError(NO_AVAILABILITY_MESSAGE);
       return;
     }
+    setSelectionError("");
 
     const anchorDate = draftStart || rangeStart;
 
@@ -176,8 +206,8 @@ export default function RangeCalendar({
     const nextStart = anchorDate.getTime() <= date.getTime() ? anchorDate : date;
     const nextEnd = anchorDate.getTime() <= date.getTime() ? date : anchorDate;
 
-    if (hasUnavailableDateInStayRange(nextStart, nextEnd, blockedDateKeys)) {
-      alert("Selected stay includes unavailable dates.");
+    if (hasUnavailableDateInStayRange(nextStart, nextEnd, blockedDateKeys, availabilityContext)) {
+      setSelectionError(NO_AVAILABILITY_MESSAGE);
       setDraftStart(date);
       onRangeChange(key, "");
       return;
@@ -202,6 +232,11 @@ export default function RangeCalendar({
           <h3 className="availability-section__title">Availability</h3>
         </div>
         <p className="availability-section__range">{rangeLabel}</p>
+        {selectionError ? (
+          <p className="availability-section__error" role="alert">
+            {selectionError}
+          </p>
+        ) : null}
       </div>
 
       <div className="rc-con">
@@ -213,6 +248,8 @@ export default function RangeCalendar({
               rangeEnd={rangeEnd}
               onPick={handlePick}
               blockedDateKeys={blockedDateKeys}
+              availabilityRanges={availabilityRanges}
+              availableDateKeys={availableDateKeySet}
               navigation={{ side: "left", onClick: prev }}
             />
             <MonthGrid
@@ -221,6 +258,8 @@ export default function RangeCalendar({
               rangeEnd={rangeEnd}
               onPick={handlePick}
               blockedDateKeys={blockedDateKeys}
+              availabilityRanges={availabilityRanges}
+              availableDateKeys={availableDateKeySet}
               navigation={{ side: "right", onClick: next }}
             />
           </div>
@@ -232,8 +271,14 @@ export default function RangeCalendar({
 
 RangeCalendar.propTypes = {
   unavailableDateKeys: PropTypes.arrayOf(PropTypes.string),
+  availabilityRanges: PropTypes.arrayOf(
+    PropTypes.shape({
+      start: PropTypes.number.isRequired,
+      end: PropTypes.number.isRequired,
+    })
+  ),
+  availableDateKeys: PropTypes.arrayOf(PropTypes.string),
   checkInDate: PropTypes.string,
   checkOutDate: PropTypes.string,
   onRangeChange: PropTypes.func.isRequired,
 };
-

--- a/frontend/web/src/features/bookingengine/listingdetails/views/bookingContainer.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/views/bookingContainer.js
@@ -155,6 +155,8 @@ const BookingContainer = ({
   host = {},
   propertyId = null,
   unavailableDateKeys = [],
+  availabilityRanges = null,
+  availableDateKeys = [],
   checkInDate = "",
   setCheckInDate = () => {},
   checkOutDate = "",
@@ -175,6 +177,13 @@ const BookingContainer = ({
   const unavailableDateSet = useMemo(
     () => buildUnavailableDateSet(unavailableDateKeys),
     [unavailableDateKeys]
+  );
+  const availabilityContext = useMemo(
+    () => ({
+      availabilityRanges,
+      availableDateKeys,
+    }),
+    [availabilityRanges, availableDateKeys]
   );
   const nights = useMemo(() => calculateNights(checkInDate, checkOutDate), [checkInDate, checkOutDate]);
 
@@ -251,13 +260,13 @@ const BookingContainer = ({
     }
 
     if (
-      isUnavailableDate(checkInDate, unavailableDateSet) ||
-      (checkOutDate && hasUnavailableDateInStayRange(checkInDate, checkOutDate, unavailableDateSet))
+      isUnavailableDate(checkInDate, unavailableDateSet, availabilityContext) ||
+      (checkOutDate && hasUnavailableDateInStayRange(checkInDate, checkOutDate, unavailableDateSet, availabilityContext))
     ) {
       setCheckInDate("");
       setCheckOutDate("");
     }
-  }, [checkInDate, checkOutDate, setCheckInDate, setCheckOutDate, unavailableDateSet]);
+  }, [availabilityContext, checkInDate, checkOutDate, setCheckInDate, setCheckOutDate, unavailableDateSet]);
 
   const handleCheckInDateChange = (value) => {
     if (!value) {
@@ -266,8 +275,8 @@ const BookingContainer = ({
       return;
     }
 
-    if (isUnavailableDate(value, unavailableDateSet)) {
-      alert("Check in date is unavailable.");
+    if (isUnavailableDate(value, unavailableDateSet, availabilityContext)) {
+      alert("This property has no availability for the selected dates.");
       return;
     }
 
@@ -276,8 +285,8 @@ const BookingContainer = ({
       return;
     }
 
-    if (checkOutDate && hasUnavailableDateInStayRange(value, checkOutDate, unavailableDateSet)) {
-      alert("Selected stay includes unavailable dates.");
+    if (checkOutDate && hasUnavailableDateInStayRange(value, checkOutDate, unavailableDateSet, availabilityContext)) {
+      alert("This property has no availability for the selected dates.");
       return;
     }
 
@@ -300,8 +309,8 @@ const BookingContainer = ({
       return;
     }
 
-    if (hasUnavailableDateInStayRange(checkInDate, value, unavailableDateSet)) {
-      alert("Selected stay includes unavailable dates.");
+    if (hasUnavailableDateInStayRange(checkInDate, value, unavailableDateSet, availabilityContext)) {
+      alert("This property has no availability for the selected dates.");
       return;
     }
 
@@ -314,6 +323,8 @@ const BookingContainer = ({
     checkOutDate,
     setCheckOutDate: handleCheckOutDateChange,
     unavailableDateKeys,
+    availabilityRanges,
+    availableDateKeys,
     className: "date-container--mobile-sticky",
   };
 
@@ -351,6 +362,8 @@ const BookingContainer = ({
         checkOutDate={checkOutDate}
         setCheckOutDate={handleCheckOutDateChange}
         unavailableDateKeys={unavailableDateKeys}
+        availabilityRanges={availabilityRanges}
+        availableDateKeys={availableDateKeys}
       />
 
       <GuestSelectionContainer setAdultsParent={setAdults} setKidsParent={setKids} maxGuests={maxGuests} />
@@ -461,6 +474,13 @@ BookingContainer.propTypes = {
   }),
   propertyId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   unavailableDateKeys: PropTypes.arrayOf(PropTypes.string),
+  availabilityRanges: PropTypes.arrayOf(
+    PropTypes.shape({
+      start: PropTypes.number.isRequired,
+      end: PropTypes.number.isRequired,
+    })
+  ),
+  availableDateKeys: PropTypes.arrayOf(PropTypes.string),
   checkInDate: PropTypes.string,
   setCheckInDate: PropTypes.func,
   checkOutDate: PropTypes.string,

--- a/frontend/web/src/features/bookingengine/listingdetails/views/dateSelectionContainer.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/views/dateSelectionContainer.js
@@ -9,6 +9,8 @@ const DateSelectionContainer = ({
   checkOutDate = "",
   setCheckOutDate = () => {},
   unavailableDateKeys = [],
+  availabilityRanges = null,
+  availableDateKeys = [],
   className = "",
 }) => {
   const containerClassName = className ? `date-container ${className}` : "date-container";
@@ -19,6 +21,8 @@ const DateSelectionContainer = ({
         checkInDate={checkInDate}
         setCheckInDate={setCheckInDate}
         unavailableDateKeys={unavailableDateKeys}
+        availabilityRanges={availabilityRanges}
+        availableDateKeys={availableDateKeys}
       />
 
       <CheckOut
@@ -26,6 +30,8 @@ const DateSelectionContainer = ({
         setCheckOutDate={setCheckOutDate}
         checkInDate={checkInDate}
         unavailableDateKeys={unavailableDateKeys}
+        availabilityRanges={availabilityRanges}
+        availableDateKeys={availableDateKeys}
       />
     </div>
   );
@@ -37,6 +43,13 @@ DateSelectionContainer.propTypes = {
   checkOutDate: PropTypes.string,
   setCheckOutDate: PropTypes.func,
   unavailableDateKeys: PropTypes.arrayOf(PropTypes.string),
+  availabilityRanges: PropTypes.arrayOf(
+    PropTypes.shape({
+      start: PropTypes.number.isRequired,
+      end: PropTypes.number.isRequired,
+    })
+  ),
+  availableDateKeys: PropTypes.arrayOf(PropTypes.string),
   className: PropTypes.string,
 };
 

--- a/frontend/web/src/features/bookingengine/listingdetails/views/propertyContainer.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/views/propertyContainer.js
@@ -35,6 +35,8 @@ const PropertyContainer = ({
   location = {},
   onContactHost,
   unavailableDateKeys = [],
+  availabilityRanges = null,
+  availableDateKeys = [],
   checkInDate = "",
   checkOutDate = "",
   setCheckInDate,
@@ -134,6 +136,8 @@ const PropertyContainer = ({
         <section id="listing-availability" className="listing-section-block">
           <RangeCalendar
             unavailableDateKeys={unavailableDateKeys}
+            availabilityRanges={availabilityRanges}
+            availableDateKeys={availableDateKeys}
             checkInDate={checkInDate}
             checkOutDate={checkOutDate}
             onRangeChange={(nextCheckInDate, nextCheckOutDate) => {
@@ -218,6 +222,13 @@ PropertyContainer.propTypes = {
   onContactHost: PropTypes.func,
   children: PropTypes.node,
   unavailableDateKeys: PropTypes.arrayOf(PropTypes.string),
+  availabilityRanges: PropTypes.arrayOf(
+    PropTypes.shape({
+      start: PropTypes.number.isRequired,
+      end: PropTypes.number.isRequired,
+    })
+  ),
+  availableDateKeys: PropTypes.arrayOf(PropTypes.string),
   checkInDate: PropTypes.string,
   checkOutDate: PropTypes.string,
   setCheckInDate: PropTypes.func.isRequired,


### PR DESCRIPTION
## Close or Relate the Issue

* Related Issue: #

## Proposed Changes

Description:

This PR improves the public guest listing availability calendar so dates outside the listing’s base availability window are clearly shown as unavailable to guests.

Before this change, outside-base-window dates were correctly treated as unavailable by backend/Channex logic, but the guest-facing listing calendar did not clearly show that state. This could make dates look selectable even though the property could not actually be booked for those dates.

The guest calendar now evaluates the listing’s base availability window and marks unavailable dates clearly with disabled styling and `--` under the date. If a guest selects a range containing outside-window or otherwise unavailable nights, the UI shows:

`This property has no availability for the selected dates.`

The fix also preserves the correct availability precedence:

1. Active/imported booking or external blocked night = unavailable
2. Explicit unavailable override = unavailable
3. Explicit available override = available, even outside the base window
4. Inside base availability window = available
5. Outside base availability window with no available override = unavailable

Checkout-date behavior remains correct: booking nights are arrival-inclusive and checkout-exclusive, so the checkout date itself is not blocked as an occupied night.

No Channex sync, Full Sync, polling/import, or booking validation behavior was changed.

## Change Type

* [x] Bug fix
* [ ] New feature
* [ ] Optimization
* [ ] Documentation update

## Change Size

* [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [[Refactoring](https://chatgpt.com/g/g-p-697f7ff03c808191b0c04598bc66b5c0/c/6a06ea98-e38c-8386-88d5-1ccaf8a0cabb#Refactoring)](#Refactoring))
* [x] Big change (+-max 1000)
* [ ] Small change (less than 300)

## Refactoring

No refactoring-only files. The changed files contain targeted guest availability UX fixes and test coverage.

Changed files:

* `backend/functions/PropertyHandler/business/service/propertyService.js`
* `backend/functions/PropertyHandler/util/calendarAvailability.js`
* `frontend/web/src/features/bookingengine/listingdetails/components/checkIn.js`
* `frontend/web/src/features/bookingengine/listingdetails/components/checkOut.js`
* `frontend/web/src/features/bookingengine/listingdetails/pages/listingDetails2.js`
* `frontend/web/src/features/bookingengine/listingdetails/pages/listingDetails2.test.js`
* `frontend/web/src/features/bookingengine/listingdetails/styles/RangeCalendar.scss`
* `frontend/web/src/features/bookingengine/listingdetails/utils/dateAvailability.js`
* `frontend/web/src/features/bookingengine/listingdetails/views/RangeCalendar.jsx`
* `frontend/web/src/features/bookingengine/listingdetails/views/bookingContainer.js`
* `frontend/web/src/features/bookingengine/listingdetails/views/dateSelectionContainer.js`
* `frontend/web/src/features/bookingengine/listingdetails/views/propertyContainer.js`

## Evidence

* [x] Screenshots or screen recording added for UI changes
* [ ] Before/after images added when relevant
* [x] Images clearly show the implemented change
* [x] Image quality is readable (no cropped or blurry evidence)

Evidence from testing:

* Outside-base-window dates now render as disabled/unavailable on the guest listing calendar.
* Unavailable dates show `--` under the date number.
* Selecting a range with unavailable/outside-window nights shows the no-availability message.
* Explicit available overrides outside the base window remain selectable/bookable.
* Active booking nights still block availability.
* Checkout dates remain selectable when they are only checkout dates.

## Responsiveness

* [ ] UI checked on mobile
* [ ] UI checked on tablet
* [x] UI checked on desktop
* [x] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages

* [ ] NPM Packages installed
* [ ] NPM Packages removed
* [ ] NPM Packages updated
* [ ] Checked for vulnerabilities using "npm audit"

No npm package changes were made in this PR.

## Checklist

* [ ] Pull request has at least 2 reviewers assigned
* [x] PR title is descriptive and includes issue number
* [x] Conventions

  * [x] No config files have been added (Amplify config, cache files)
  * [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  * [x] No global styling (see [[#1691](https://github.com/domits1/Domits/issues/1691)](https://github.com/domits1/Domits/issues/1691))
  * [x] No `console.log` left in code
  * [x] No commented-out code remains
* [x] Testing

  * [x] Code tested locally
  * [x] Jest tests are included
  * [x] Jest tests are passing

## Tests / Build

Passed:

Frontend:

* `npm test -- --runTestsByPath src/features/bookingengine/listingdetails/pages/listingDetails2.test.js --watchAll=false`
* `npm test -- --runTestsByPath src/features/bookingengine/tests/BookingOverview.test.js --watchAll=false`
* `npm test -- --runTestsByPath src/features/hostdashboard/hostproperty/components/HostPropertyAvailabilityTab.test.js --watchAll=false`
* `npm test -- --runTestsByPath src/features/hostdashboard/hostcalen/hooks/hostCalendarHelpers.test.js --watchAll=false`
* `npm run build`

Backend smoke:

* `npm test -- test/PropertyHandler/calendar-overrides-unit.test.js`

Other:

* `git diff --check` passed.

## Acceptance Testing Notes

After deploy to acceptance, verify visually with a real listing that has a narrow base availability window:

1. Open the public guest listing calendar.
2. Confirm outside-base-window dates show as unavailable/disabled with `--`.
3. Try selecting a range containing outside-window dates.
4. Confirm the message appears: `This property has no availability for the selected dates.`
5. Confirm explicit available override dates outside the base window remain selectable.
6. Confirm booked/imported blocked dates remain unavailable.
7. Confirm checkout date behavior is still correct.

## Keep or delete my branch

* [x] Delete my branch after merge
* [ ] Keep my branch