### PR TITLE
fix(booking): prevent outside-window mass disabling

### DIFF
--- a/backend/test/PropertyHandler/calendar-overrides-unit.test.js
+++ b/backend/test/PropertyHandler/calendar-overrides-unit.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it, jest } from "@jest/globals";
 import { AuthManager } from "../../functions/PropertyHandler/auth/authManager.js";
 import { PropertyController } from "../../functions/PropertyHandler/controller/propertyController.js";
+import { PropertyService } from "../../functions/PropertyHandler/business/service/propertyService.js";
 
 const buildAuthManager = ({ username = "caller-user", property, membership = null }) => {
   const authManager = new AuthManager();
@@ -302,5 +303,31 @@ describe("Property calendar override authorization", () => {
     expect(response.statusCode).toBe(403);
     expect(JSON.parse(response.body)).toBe("You must be the owner or an active co-host of the property to access it.");
     expect(controller.propertyService.updatePropertyCalendarOverrides).not.toHaveBeenCalled();
+  });
+});
+
+describe("Property public calendar availability response", () => {
+  it("includes explicit available override dates for guest listing availability", async () => {
+    const service = new PropertyService();
+    service.propertyExternalCalendarRepository = {
+      getAvailabilitySnapshotByPropertyId: jest.fn().mockResolvedValue({
+        externalBlockedDates: ["2026-06-18"],
+      }),
+    };
+    service.propertyCalendarOverrideRepository = {
+      getOverridesByPropertyId: jest.fn().mockResolvedValue([
+        { date: 20260610, isAvailable: true },
+        { date: 20260619, isAvailable: false },
+      ]),
+    };
+    service.bookingRepository = {
+      getBlockedDateKeysByPropertyId: jest.fn().mockResolvedValue(["2026-06-20"]),
+    };
+
+    const response = await service.getPublicCalendarAvailability("property-1");
+
+    expect(response.availableDateKeys).toEqual(["2026-06-10"]);
+    expect(response.unavailableDateKeys).toEqual(["2026-06-19", "2026-06-20"]);
+    expect(response.externalBlockedDates).toEqual(["2026-06-18"]);
   });
 });

--- a/frontend/web/src/features/bookingengine/listingdetails/components/checkIn.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/components/checkIn.js
@@ -16,7 +16,7 @@ const CheckIn = ({
   setCheckInDate = () => {},
   unavailableDateKeys = [],
   availabilityRanges = null,
-  availableDateKeys = [],
+  availableDateKeys = null,
 }) => {
   const unavailableDateSet = buildUnavailableDateSet(unavailableDateKeys);
   const minDate = normalizeDateValue(getFutureDateKey(1));

--- a/frontend/web/src/features/bookingengine/listingdetails/components/checkOut.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/components/checkOut.js
@@ -18,7 +18,7 @@ const CheckOut = ({
   checkInDate = "",
   unavailableDateKeys = [],
   availabilityRanges = null,
-  availableDateKeys = [],
+  availableDateKeys = null,
 }) => {
   const minCheckOutDate = checkInDate ? addDaysToDateKey(checkInDate, 1) : getFutureDateKey(2);
 

--- a/frontend/web/src/features/bookingengine/listingdetails/pages/listingDetails2.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/pages/listingDetails2.js
@@ -85,6 +85,11 @@ const normalizeDateKey = (value) => {
 
 const normalizeDateKeyArray = (value) => toArray(value).map(normalizeDateKey).filter(Boolean);
 
+const normalizeOptionalDateKeyArray = (...values) => {
+  const providedValue = values.find((value) => Array.isArray(value));
+  return Array.isArray(providedValue) ? normalizeDateKeyArray(providedValue) : null;
+};
+
 const normalizeCheckInSection = (checkIn) => {
   const safeCheckIn = toPlainObject(checkIn);
   return {
@@ -97,8 +102,9 @@ const normalizeCalendarAvailability = (calendarAvailability) => {
   const safeCalendarAvailability = toPlainObject(calendarAvailability);
   return {
     ...safeCalendarAvailability,
-    availableDateKeys: normalizeDateKeyArray(
-      safeCalendarAvailability.availableDateKeys ?? safeCalendarAvailability.availableOverrideDateKeys
+    availableDateKeys: normalizeOptionalDateKeyArray(
+      safeCalendarAvailability.availableDateKeys,
+      safeCalendarAvailability.availableOverrideDateKeys
     ),
     externalBlockedDates: normalizeDateKeyArray(safeCalendarAvailability.externalBlockedDates),
     unavailableDateKeys: normalizeDateKeyArray(safeCalendarAvailability.unavailableDateKeys),
@@ -220,7 +226,7 @@ const ListingDetails2 = () => {
     () =>
       Array.isArray(property?.calendarAvailability?.availableDateKeys)
         ? property.calendarAvailability.availableDateKeys
-        : [],
+        : null,
     [property?.calendarAvailability?.availableDateKeys]
   );
 

--- a/frontend/web/src/features/bookingengine/listingdetails/pages/listingDetails2.test.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/pages/listingDetails2.test.js
@@ -15,14 +15,17 @@ jest.mock("../components/header", () => () => <div>Header</div>);
 jest.mock("../components/sectionTabs", () => () => <div>Tabs</div>);
 jest.mock("../views/propertyContainer", () => {
   const PropTypes = require("prop-types");
-  const MockPropertyContainer = ({ unavailableDateKeys = [], availabilityRanges = [], availableDateKeys = [], children }) => (
-    <div>
-      <div data-testid="property-unavailable-dates">{unavailableDateKeys.join("|")}</div>
-      <div data-testid="property-availability-ranges">{JSON.stringify(availabilityRanges)}</div>
-      <div data-testid="property-available-dates">{availableDateKeys.join("|")}</div>
-      {children}
-    </div>
-  );
+  const MockPropertyContainer = ({ unavailableDateKeys = [], availabilityRanges = [], availableDateKeys = null, children }) => {
+    const safeAvailableDateKeys = Array.isArray(availableDateKeys) ? availableDateKeys : [];
+    return (
+      <div>
+        <div data-testid="property-unavailable-dates">{unavailableDateKeys.join("|")}</div>
+        <div data-testid="property-availability-ranges">{JSON.stringify(availabilityRanges)}</div>
+        <div data-testid="property-available-dates">{safeAvailableDateKeys.join("|")}</div>
+        {children}
+      </div>
+    );
+  };
   MockPropertyContainer.propTypes = {
     unavailableDateKeys: PropTypes.arrayOf(PropTypes.string),
     availabilityRanges: PropTypes.arrayOf(PropTypes.object),
@@ -33,13 +36,16 @@ jest.mock("../views/propertyContainer", () => {
 });
 jest.mock("../views/bookingContainer", () => {
   const PropTypes = require("prop-types");
-  const MockBookingContainer = ({ unavailableDateKeys = [], availabilityRanges = [], availableDateKeys = [] }) => (
-    <div>
-      <div data-testid="booking-unavailable-dates">{unavailableDateKeys.join("|")}</div>
-      <div data-testid="booking-availability-ranges">{JSON.stringify(availabilityRanges)}</div>
-      <div data-testid="booking-available-dates">{availableDateKeys.join("|")}</div>
-    </div>
-  );
+  const MockBookingContainer = ({ unavailableDateKeys = [], availabilityRanges = [], availableDateKeys = null }) => {
+    const safeAvailableDateKeys = Array.isArray(availableDateKeys) ? availableDateKeys : [];
+    return (
+      <div>
+        <div data-testid="booking-unavailable-dates">{unavailableDateKeys.join("|")}</div>
+        <div data-testid="booking-availability-ranges">{JSON.stringify(availabilityRanges)}</div>
+        <div data-testid="booking-available-dates">{safeAvailableDateKeys.join("|")}</div>
+      </div>
+    );
+  };
   MockBookingContainer.propTypes = {
     unavailableDateKeys: PropTypes.arrayOf(PropTypes.string),
     availabilityRanges: PropTypes.arrayOf(PropTypes.object),
@@ -73,6 +79,7 @@ const renderRangeCalendar = (props = {}) => {
   render(
     <RangeCalendar
       availabilityRanges={[{ start: 20260615, end: 20260621 }]}
+      availableDateKeys={[]}
       checkInDate=""
       checkOutDate=""
       onRangeChange={onRangeChange}
@@ -160,6 +167,26 @@ describe("ListingDetails2 availability", () => {
       JSON.stringify([{ start: 20260615, end: 20260621 }])
     );
   });
+
+  test("keeps missing availableDateKeys as unknown instead of an empty allowlist", async () => {
+    mockProperty(
+      {
+        unavailableDateKeys: ["2026-06-19"],
+      },
+      {
+        availability: [{ availableStartDate: 20260615, availableEndDate: 20260621 }],
+      }
+    );
+
+    renderListingDetails();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("booking-available-dates")).toHaveTextContent("");
+    });
+    expect(screen.getByTestId("booking-availability-ranges")).toHaveTextContent(
+      JSON.stringify([{ start: 20260615, end: 20260621 }])
+    );
+  });
 });
 
 describe("RangeCalendar effective availability", () => {
@@ -181,6 +208,13 @@ describe("RangeCalendar effective availability", () => {
     expect(outsideWindowDate).toBeDisabled();
     expect(within(outsideWindowDate).getByText("--")).toBeInTheDocument();
     expect(insideWindowDate).not.toBeDisabled();
+  });
+
+  test("does not mass-disable outside-window dates when available override snapshot is missing", () => {
+    renderRangeCalendar({ availableDateKeys: null });
+
+    expect(screen.getByRole("button", { name: "June 10, 2026" })).not.toBeDisabled();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
   test("shows a clear message when selected stay includes outside-window unavailable nights", () => {

--- a/frontend/web/src/features/bookingengine/listingdetails/utils/dateAvailability.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/utils/dateAvailability.js
@@ -69,6 +69,8 @@ export const dateKeyToDateNumber = (value) => {
 };
 
 const normalizeAvailabilityContext = (availabilityContext = {}) => ({
+  hasAvailableDateKeySnapshot:
+    availabilityContext.availableDateKeys instanceof Set || Array.isArray(availabilityContext.availableDateKeys),
   availableDateSet:
     availabilityContext.availableDateKeys instanceof Set
       ? availabilityContext.availableDateKeys
@@ -99,12 +101,13 @@ export const isUnavailableDate = (value, unavailableValues, availabilityContext)
     return true;
   }
 
-  const { availableDateSet, availabilityRanges } = normalizeAvailabilityContext(availabilityContext);
+  const { availableDateSet, availabilityRanges, hasAvailableDateKeySnapshot } =
+    normalizeAvailabilityContext(availabilityContext);
   if (availableDateSet.has(dateKey)) {
     return false;
   }
 
-  if (Array.isArray(availabilityRanges)) {
+  if (hasAvailableDateKeySnapshot && Array.isArray(availabilityRanges)) {
     return !isDateAvailableFromBaseWindow(dateKey, availabilityRanges);
   }
 

--- a/frontend/web/src/features/bookingengine/listingdetails/views/RangeCalendar.jsx
+++ b/frontend/web/src/features/bookingengine/listingdetails/views/RangeCalendar.jsx
@@ -144,7 +144,7 @@ MonthGrid.propTypes = {
       end: PropTypes.number.isRequired,
     })
   ),
-  availableDateKeys: PropTypes.instanceOf(Set).isRequired,
+  availableDateKeys: PropTypes.instanceOf(Set),
   navigation: PropTypes.shape({
     side: PropTypes.oneOf(["left", "right"]),
     onClick: PropTypes.func,
@@ -154,7 +154,7 @@ MonthGrid.propTypes = {
 export default function RangeCalendar({
   unavailableDateKeys = [],
   availabilityRanges = null,
-  availableDateKeys = [],
+  availableDateKeys = null,
   checkInDate = "",
   checkOutDate = "",
   onRangeChange,
@@ -169,7 +169,10 @@ export default function RangeCalendar({
   const rangeEnd = useMemo(() => normalizeDateValue(checkOutDate), [checkOutDate]);
 
   const blockedDateKeys = useMemo(() => buildUnavailableDateSet(unavailableDateKeys), [unavailableDateKeys]);
-  const availableDateKeySet = useMemo(() => buildUnavailableDateSet(availableDateKeys), [availableDateKeys]);
+  const availableDateKeySet = useMemo(
+    () => (Array.isArray(availableDateKeys) ? buildUnavailableDateSet(availableDateKeys) : null),
+    [availableDateKeys]
+  );
   const availabilityContext = useMemo(
     () => ({
       availabilityRanges,

--- a/frontend/web/src/features/bookingengine/listingdetails/views/bookingContainer.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/views/bookingContainer.js
@@ -156,7 +156,7 @@ const BookingContainer = ({
   propertyId = null,
   unavailableDateKeys = [],
   availabilityRanges = null,
-  availableDateKeys = [],
+  availableDateKeys = null,
   checkInDate = "",
   setCheckInDate = () => {},
   checkOutDate = "",

--- a/frontend/web/src/features/bookingengine/listingdetails/views/dateSelectionContainer.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/views/dateSelectionContainer.js
@@ -10,7 +10,7 @@ const DateSelectionContainer = ({
   setCheckOutDate = () => {},
   unavailableDateKeys = [],
   availabilityRanges = null,
-  availableDateKeys = [],
+  availableDateKeys = null,
   className = "",
 }) => {
   const containerClassName = className ? `date-container ${className}` : "date-container";


### PR DESCRIPTION
## Close or Relate the Issue

* Related Issue: #

## Proposed Changes

Description:

This PR is a hotfix for the guest listing outside-window availability UI.

After the previous outside-window availability change, the public guest calendar could mass-disable dates with `--` when `calendarAvailability.availableDateKeys` was missing from the API response. On acceptance, this caused June/July dates to appear fully blocked even though some dates were explicitly available overrides in Domits.

Root cause:

The frontend normalized missing `calendarAvailability.availableDateKeys` into an empty array. It then treated that empty array as a complete snapshot of explicit available overrides. Because of that, dates outside the base availability window were blocked even when the API had not provided enough information to safely distinguish unavailable outside-window dates from explicit available override dates.

This hotfix changes the frontend behavior so missing `availableDateKeys` is treated as unknown, not as an empty allowlist.

New behavior:

* If `availableDateKeys` is present:

  * Outside base window + no explicit available override = unavailable / disabled / `--`
  * Outside base window + explicit available override = selectable/bookable
* If `availableDateKeys` is missing:

  * Do not mass-disable outside-window dates
  * Fall back to blocking only known unavailable keys, external blocks, and active booking nights

The backend production logic already includes support for returning `calendarAvailability.availableDateKeys` from explicit available override rows, and this PR adds regression coverage for that response.

No Channex sync, Full Sync, polling/import, or booking validation behavior was changed.

## Change Type

* [x] Bug fix
* [ ] New feature
* [ ] Optimization
* [ ] Documentation update

## Change Size

* [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [[Refactoring](https://chatgpt.com/g/g-p-697f7ff03c808191b0c04598bc66b5c0/c/6a06ea98-e38c-8386-88d5-1ccaf8a0cabb#Refactoring)](#Refactoring))
* [ ] Big change (+-max 1000)
* [x] Small change (less than 300)

## Refactoring

No refactoring-only files. This is a targeted hotfix for guest listing availability fallback behavior and regression coverage.

Changed files:

* `backend/test/PropertyHandler/calendar-overrides-unit.test.js`
* `frontend/web/src/features/bookingengine/listingdetails/components/checkIn.js`
* `frontend/web/src/features/bookingengine/listingdetails/components/checkOut.js`
* `frontend/web/src/features/bookingengine/listingdetails/pages/listingDetails2.js`
* `frontend/web/src/features/bookingengine/listingdetails/pages/listingDetails2.test.js`
* `frontend/web/src/features/bookingengine/listingdetails/utils/dateAvailability.js`
* `frontend/web/src/features/bookingengine/listingdetails/views/RangeCalendar.jsx`
* `frontend/web/src/features/bookingengine/listingdetails/views/bookingContainer.js`
* `frontend/web/src/features/bookingengine/listingdetails/views/dateSelectionContainer.js`

## Evidence

* [x] Screenshots or screen recording added for UI changes
* [ ] Before/after images added when relevant
* [x] Images clearly show the issue/fix context
* [x] Image quality is readable (no cropped or blurry evidence)

Evidence from acceptance before this hotfix:

* Public listing calendar showed all June/July dates as disabled with `--`.
* API response contained base `availability`.
* API response did not include `calendarAvailability.availableDateKeys`.
* Because `availableDateKeys` was missing, frontend should not have treated outside-window dates as definitely unavailable.

Expected after this hotfix:

* June/July should no longer be mass-disabled when `availableDateKeys` is absent.
* Known unavailable dates, external blocked dates, and active booking nights should still show unavailable.
* When `availableDateKeys` is present, outside-window dates without explicit available override should still show as unavailable.

## Responsiveness

* [ ] UI checked on mobile
* [ ] UI checked on tablet
* [x] UI checked on desktop
* [x] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages

* [ ] NPM Packages installed
* [ ] NPM Packages removed
* [ ] NPM Packages updated
* [ ] Checked for vulnerabilities using "npm audit"

No npm package changes were made in this PR.

## Checklist

* [ ] Pull request has at least 2 reviewers assigned
* [x] PR title is descriptive and includes issue number
* [x] Conventions

  * [x] No config files have been added (Amplify config, cache files)
  * [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  * [x] No global styling (see [[#1691](https://github.com/domits1/Domits/issues/1691)](https://github.com/domits1/Domits/issues/1691))
  * [x] No `console.log` left in code
  * [x] No commented-out code remains
* [x] Testing

  * [x] Code tested locally
  * [x] Jest tests are included
  * [x] Jest tests are passing

## Tests / Build

Passed:

Backend:

* `npm test -- test/PropertyHandler/calendar-overrides-unit.test.js`

Frontend:

* `npm test -- --runTestsByPath src/features/bookingengine/listingdetails/pages/listingDetails2.test.js --watchAll=false`
* `npm test -- --runTestsByPath src/features/bookingengine/tests/BookingOverview.test.js --watchAll=false`
* `npm run build`

Other:

* `git diff --check` passed.


## Keep or delete my branch

* [x] Delete my branch after merge
* [ ] Keep my branch