### PR TITLE
fix(booking): distinguish booked guest calendar dates

### DIFF
--- a/frontend/web/src/features/bookingengine/listingdetails/components/checkIn.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/components/checkIn.js
@@ -15,10 +15,12 @@ const CheckIn = ({
   checkInDate = "",
   setCheckInDate = () => {},
   unavailableDateKeys = [],
+  bookedDateKeys = [],
   availabilityRanges = null,
   availableDateKeys = null,
 }) => {
   const unavailableDateSet = buildUnavailableDateSet(unavailableDateKeys);
+  const bookedDateSet = buildUnavailableDateSet(bookedDateKeys);
   const minDate = normalizeDateValue(getFutureDateKey(1));
 
   return (
@@ -34,6 +36,7 @@ const CheckIn = ({
             !isUnavailableDate(date, unavailableDateSet, {
               availabilityRanges,
               availableDateKeys,
+              bookedDateKeys: bookedDateSet,
             })
           }
           dayClassName={(date) => (toDateKey(date) === toDateKey(new Date()) ? "booking-picker-day--today" : "")}
@@ -54,6 +57,7 @@ CheckIn.propTypes = {
   checkInDate: PropTypes.string,
   setCheckInDate: PropTypes.func,
   unavailableDateKeys: PropTypes.arrayOf(PropTypes.string),
+  bookedDateKeys: PropTypes.arrayOf(PropTypes.string),
   availabilityRanges: PropTypes.arrayOf(
     PropTypes.shape({
       start: PropTypes.number.isRequired,

--- a/frontend/web/src/features/bookingengine/listingdetails/components/checkOut.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/components/checkOut.js
@@ -17,12 +17,14 @@ const CheckOut = ({
   setCheckOutDate = () => {},
   checkInDate = "",
   unavailableDateKeys = [],
+  bookedDateKeys = [],
   availabilityRanges = null,
   availableDateKeys = null,
 }) => {
   const minCheckOutDate = checkInDate ? addDaysToDateKey(checkInDate, 1) : getFutureDateKey(2);
 
   const unavailableDateSet = buildUnavailableDateSet(unavailableDateKeys);
+  const bookedDateSet = buildUnavailableDateSet(bookedDateKeys);
 
   const selectedCheckOutDate = normalizeDateValue(checkOutDate);
   const selectedCheckInDate = normalizeDateValue(checkInDate);
@@ -46,6 +48,7 @@ const CheckOut = ({
             return !hasUnavailableDateInStayRange(selectedCheckInDate, date, unavailableDateSet, {
               availabilityRanges,
               availableDateKeys,
+              bookedDateKeys: bookedDateSet,
             });
           }}
           dayClassName={(date) => (toDateKey(date) === toDateKey(new Date()) ? "booking-picker-day--today" : "")}
@@ -68,6 +71,7 @@ CheckOut.propTypes = {
   setCheckOutDate: PropTypes.func,
   checkInDate: PropTypes.string,
   unavailableDateKeys: PropTypes.arrayOf(PropTypes.string),
+  bookedDateKeys: PropTypes.arrayOf(PropTypes.string),
   availabilityRanges: PropTypes.arrayOf(
     PropTypes.shape({
       start: PropTypes.number.isRequired,

--- a/frontend/web/src/features/bookingengine/listingdetails/pages/listingDetails2.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/pages/listingDetails2.js
@@ -199,24 +199,30 @@ const ListingDetails2 = () => {
   const [error, setError] = useState(null);
   const [showMessageHost, setShowMessageHost] = useState(false);
 
+  const externalBlockedDateKeys = useMemo(
+    () =>
+      Array.isArray(property?.calendarAvailability?.externalBlockedDates)
+        ? property.calendarAvailability.externalBlockedDates
+        : [],
+    [property?.calendarAvailability?.externalBlockedDates]
+  );
+  const calendarUnavailableDateKeys = useMemo(
+    () =>
+      Array.isArray(property?.calendarAvailability?.unavailableDateKeys)
+        ? property.calendarAvailability.unavailableDateKeys
+        : [],
+    [property?.calendarAvailability?.unavailableDateKeys]
+  );
   const unavailableDateKeys = useMemo(
     () =>
       Array.from(
         new Set([
-          ...(Array.isArray(property?.calendarAvailability?.externalBlockedDates)
-            ? property.calendarAvailability.externalBlockedDates
-            : []),
-          ...(Array.isArray(property?.calendarAvailability?.unavailableDateKeys)
-            ? property.calendarAvailability.unavailableDateKeys
-            : []),
+          ...externalBlockedDateKeys,
+          ...calendarUnavailableDateKeys,
           ...(Array.isArray(acceptedBookingDateKeys) ? acceptedBookingDateKeys : []),
         ])
       ),
-    [
-      acceptedBookingDateKeys,
-      property?.calendarAvailability?.externalBlockedDates,
-      property?.calendarAvailability?.unavailableDateKeys,
-    ]
+    [acceptedBookingDateKeys, calendarUnavailableDateKeys, externalBlockedDateKeys]
   );
   const availabilityRanges = useMemo(
     () => normalizeAvailabilityRanges(property?.availability),
@@ -302,7 +308,9 @@ const ListingDetails2 = () => {
               ? () => setShowMessageHost(true)
               : undefined
           }
-          unavailableDateKeys={unavailableDateKeys}
+          unavailableDateKeys={calendarUnavailableDateKeys}
+          bookedDateKeys={acceptedBookingDateKeys}
+          externalBlockedDateKeys={externalBlockedDateKeys}
           availabilityRanges={availabilityRanges}
           availableDateKeys={availableDateKeys}
           checkInDate={checkInDate}
@@ -315,6 +323,7 @@ const ListingDetails2 = () => {
             host={host}
             propertyId={id}
             unavailableDateKeys={unavailableDateKeys}
+            bookedDateKeys={acceptedBookingDateKeys}
             availabilityRanges={availabilityRanges}
             availableDateKeys={availableDateKeys}
             checkInDate={checkInDate}

--- a/frontend/web/src/features/bookingengine/listingdetails/pages/listingDetails2.test.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/pages/listingDetails2.test.js
@@ -15,11 +15,20 @@ jest.mock("../components/header", () => () => <div>Header</div>);
 jest.mock("../components/sectionTabs", () => () => <div>Tabs</div>);
 jest.mock("../views/propertyContainer", () => {
   const PropTypes = require("prop-types");
-  const MockPropertyContainer = ({ unavailableDateKeys = [], availabilityRanges = [], availableDateKeys = null, children }) => {
+  const MockPropertyContainer = ({
+    unavailableDateKeys = [],
+    bookedDateKeys = [],
+    externalBlockedDateKeys = [],
+    availabilityRanges = [],
+    availableDateKeys = null,
+    children,
+  }) => {
     const safeAvailableDateKeys = Array.isArray(availableDateKeys) ? availableDateKeys : [];
     return (
       <div>
         <div data-testid="property-unavailable-dates">{unavailableDateKeys.join("|")}</div>
+        <div data-testid="property-booked-dates">{bookedDateKeys.join("|")}</div>
+        <div data-testid="property-external-blocked-dates">{externalBlockedDateKeys.join("|")}</div>
         <div data-testid="property-availability-ranges">{JSON.stringify(availabilityRanges)}</div>
         <div data-testid="property-available-dates">{safeAvailableDateKeys.join("|")}</div>
         {children}
@@ -28,6 +37,8 @@ jest.mock("../views/propertyContainer", () => {
   };
   MockPropertyContainer.propTypes = {
     unavailableDateKeys: PropTypes.arrayOf(PropTypes.string),
+    bookedDateKeys: PropTypes.arrayOf(PropTypes.string),
+    externalBlockedDateKeys: PropTypes.arrayOf(PropTypes.string),
     availabilityRanges: PropTypes.arrayOf(PropTypes.object),
     availableDateKeys: PropTypes.arrayOf(PropTypes.string),
     children: PropTypes.node,
@@ -36,11 +47,17 @@ jest.mock("../views/propertyContainer", () => {
 });
 jest.mock("../views/bookingContainer", () => {
   const PropTypes = require("prop-types");
-  const MockBookingContainer = ({ unavailableDateKeys = [], availabilityRanges = [], availableDateKeys = null }) => {
+  const MockBookingContainer = ({
+    unavailableDateKeys = [],
+    bookedDateKeys = [],
+    availabilityRanges = [],
+    availableDateKeys = null,
+  }) => {
     const safeAvailableDateKeys = Array.isArray(availableDateKeys) ? availableDateKeys : [];
     return (
       <div>
         <div data-testid="booking-unavailable-dates">{unavailableDateKeys.join("|")}</div>
+        <div data-testid="booking-booked-dates">{bookedDateKeys.join("|")}</div>
         <div data-testid="booking-availability-ranges">{JSON.stringify(availabilityRanges)}</div>
         <div data-testid="booking-available-dates">{safeAvailableDateKeys.join("|")}</div>
       </div>
@@ -48,6 +65,7 @@ jest.mock("../views/bookingContainer", () => {
   };
   MockBookingContainer.propTypes = {
     unavailableDateKeys: PropTypes.arrayOf(PropTypes.string),
+    bookedDateKeys: PropTypes.arrayOf(PropTypes.string),
     availabilityRanges: PropTypes.arrayOf(PropTypes.object),
     availableDateKeys: PropTypes.arrayOf(PropTypes.string),
   };
@@ -128,6 +146,14 @@ describe("ListingDetails2 availability", () => {
     expect(unavailableDates).toContain("2026-06-18");
     expect(unavailableDates).toContain("2026-06-19");
     expect(unavailableDates).not.toContain("2026-06-17");
+
+    const bookedDates = screen.getByTestId("property-booked-dates").textContent;
+    expect(bookedDates).toContain("2026-06-15");
+    expect(bookedDates).toContain("2026-06-16");
+    expect(bookedDates).not.toContain("2026-06-17");
+    expect(screen.getByTestId("booking-booked-dates")).toHaveTextContent("2026-06-15");
+    expect(screen.getByTestId("property-external-blocked-dates")).toHaveTextContent("2026-06-18");
+    expect(screen.getByTestId("property-unavailable-dates")).toHaveTextContent("2026-06-19");
   });
 
   test("falls back gracefully when backend unavailable date keys are missing", async () => {
@@ -206,8 +232,25 @@ describe("RangeCalendar effective availability", () => {
     const insideWindowDate = screen.getByRole("button", { name: "June 15, 2026" });
 
     expect(outsideWindowDate).toBeDisabled();
+    expect(outsideWindowDate).toHaveClass("range-calendar__day--outside-window");
+    expect(outsideWindowDate).toHaveClass("range-calendar__day--unavailable");
     expect(within(outsideWindowDate).getByText("--")).toBeInTheDocument();
     expect(insideWindowDate).not.toBeDisabled();
+  });
+
+  test("renders booked dates with booked-specific text and style instead of the unavailable marker", () => {
+    renderRangeCalendar({
+      bookedDateKeys: ["2026-06-16"],
+      unavailableDateKeys: ["2026-06-16"],
+    });
+
+    const bookedDate = screen.getByRole("button", { name: "June 16, 2026" });
+
+    expect(bookedDate).toBeDisabled();
+    expect(bookedDate).toHaveClass("range-calendar__day--booked");
+    expect(bookedDate).not.toHaveClass("range-calendar__day--unavailable");
+    expect(within(bookedDate).getByText("Booked")).toBeInTheDocument();
+    expect(within(bookedDate).queryByText("--")).not.toBeInTheDocument();
   });
 
   test("does not mass-disable outside-window dates when available override snapshot is missing", () => {
@@ -244,18 +287,50 @@ describe("RangeCalendar effective availability", () => {
     const unavailableOverrideDate = screen.getByRole("button", { name: "June 16, 2026" });
 
     expect(unavailableOverrideDate).toBeDisabled();
+    expect(unavailableOverrideDate).toHaveClass("range-calendar__day--unavailable");
+    expect(unavailableOverrideDate).toHaveClass("range-calendar__day--unavailable-override");
     expect(within(unavailableOverrideDate).getByText("--")).toBeInTheDocument();
   });
 
-  test("blocks active booking nights and keeps checkout date selectable", () => {
+  test("booked state has visual priority over explicit available overrides", () => {
     renderRangeCalendar({
-      availabilityRanges: [{ start: 20260619, end: 20260622 }],
-      unavailableDateKeys: ["2026-06-19", "2026-06-20", "2026-06-21"],
+      availableDateKeys: ["2026-06-16"],
+      bookedDateKeys: ["2026-06-16"],
     });
 
-    expect(screen.getByRole("button", { name: "June 19, 2026" })).toBeDisabled();
+    const availableOverrideDate = screen.getByRole("button", { name: "June 16, 2026" });
+
+    expect(availableOverrideDate).toBeDisabled();
+    expect(availableOverrideDate).toHaveClass("range-calendar__day--booked");
+    expect(within(availableOverrideDate).getByText("Booked")).toBeInTheDocument();
+    expect(within(availableOverrideDate).queryByText("--")).not.toBeInTheDocument();
+  });
+
+  test("blocks active booking nights as booked and keeps checkout date selectable", () => {
+    renderRangeCalendar({
+      availabilityRanges: [{ start: 20260619, end: 20260622 }],
+      bookedDateKeys: ["2026-06-19", "2026-06-20", "2026-06-21"],
+    });
+
+    const firstBookedNight = screen.getByRole("button", { name: "June 19, 2026" });
+    const checkoutDate = screen.getByRole("button", { name: "June 22, 2026" });
+
+    expect(firstBookedNight).toBeDisabled();
+    expect(firstBookedNight).toHaveClass("range-calendar__day--booked");
     expect(screen.getByRole("button", { name: "June 20, 2026" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "June 21, 2026" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "June 22, 2026" })).not.toBeDisabled();
+    expect(checkoutDate).not.toBeDisabled();
+    expect(checkoutDate).not.toHaveClass("range-calendar__day--booked");
+    expect(within(checkoutDate).queryByText("Booked")).not.toBeInTheDocument();
+  });
+
+  test("shows booked message when selected stay includes booked nights", () => {
+    const onRangeChange = renderRangeCalendar({ bookedDateKeys: ["2026-06-16"] });
+
+    fireEvent.click(screen.getByRole("button", { name: "June 15, 2026" }));
+    fireEvent.click(screen.getByRole("button", { name: "June 18, 2026" }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent("These dates are already booked.");
+    expect(onRangeChange).toHaveBeenLastCalledWith("2026-06-18", "");
   });
 });

--- a/frontend/web/src/features/bookingengine/listingdetails/styles/RangeCalendar.scss
+++ b/frontend/web/src/features/bookingengine/listingdetails/styles/RangeCalendar.scss
@@ -148,6 +148,10 @@
   cursor: pointer;
   transition: background-color 120ms ease, color 120ms ease, border-color 120ms ease;
 
+  &:disabled {
+    opacity: 1;
+  }
+
   &:hover {
     background: #eef2f6;
   }
@@ -177,6 +181,22 @@
 
     &:hover {
       background: #757575;
+    }
+  }
+
+  &.is-booked {
+    background: #fff1e7;
+    border-color: #c2410c;
+    cursor: not-allowed;
+    flex-direction: column;
+    gap: 2px;
+
+    span {
+      color: #7c2d12;
+    }
+
+    &:hover {
+      background: #fff1e7;
     }
   }
 
@@ -215,6 +235,14 @@
     line-height: 1;
   }
 
+  .rc-cell__booked-mark {
+    color: #9a3412;
+    font-size: 0.68rem;
+    font-weight: 800;
+    line-height: 1;
+    text-transform: uppercase;
+  }
+
   &.is-start span,
   &.is-end span {
     color: var(--rc-text);
@@ -226,6 +254,16 @@
 
     span {
       color: #fff;
+    }
+  }
+
+  &.is-booked.is-today {
+    background: #fff1e7;
+    border-color: #c2410c;
+    box-shadow: inset 0 0 0 2px rgba(36, 88, 255, 0.4);
+
+    span {
+      color: #7c2d12;
     }
   }
 }

--- a/frontend/web/src/features/bookingengine/listingdetails/utils/dateAvailability.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/utils/dateAvailability.js
@@ -1,6 +1,14 @@
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
 const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
+export const DATE_AVAILABILITY_REASONS = Object.freeze({
+  AVAILABLE: "available",
+  OUTSIDE_WINDOW: "outside-window",
+  UNAVAILABLE_OVERRIDE: "unavailable-override",
+  EXTERNAL_BLOCKED: "external-blocked",
+  BOOKED: "booked",
+});
+
 const pad = (value) => String(value).padStart(2, "0");
 
 export const toDateKey = (date) =>
@@ -75,6 +83,14 @@ const normalizeAvailabilityContext = (availabilityContext = {}) => ({
     availabilityContext.availableDateKeys instanceof Set
       ? availabilityContext.availableDateKeys
       : buildUnavailableDateSet(availabilityContext.availableDateKeys),
+  bookedDateSet:
+    availabilityContext.bookedDateKeys instanceof Set
+      ? availabilityContext.bookedDateKeys
+      : buildUnavailableDateSet(availabilityContext.bookedDateKeys),
+  externalBlockedDateSet:
+    availabilityContext.externalBlockedDateKeys instanceof Set
+      ? availabilityContext.externalBlockedDateKeys
+      : buildUnavailableDateSet(availabilityContext.externalBlockedDateKeys),
   availabilityRanges: Array.isArray(availabilityContext.availabilityRanges)
     ? availabilityContext.availabilityRanges
     : null,
@@ -88,33 +104,53 @@ export const isDateAvailableFromBaseWindow = (dateKey, availabilityRanges) => {
   return availabilityRanges.some((range) => dateNumber >= range.start && dateNumber <= range.end);
 };
 
-export const isUnavailableDate = (value, unavailableValues, availabilityContext) => {
+export const getDateAvailabilityReason = (value, unavailableValues, availabilityContext) => {
   const normalizedDate = normalizeDateValue(value);
   if (!normalizedDate) {
-    return false;
+    return DATE_AVAILABILITY_REASONS.AVAILABLE;
   }
 
   const unavailableDateSet =
     unavailableValues instanceof Set ? unavailableValues : buildUnavailableDateSet(unavailableValues);
   const dateKey = toDateKey(normalizedDate);
-  if (unavailableDateSet.has(dateKey)) {
-    return true;
+  const {
+    availableDateSet,
+    availabilityRanges,
+    bookedDateSet,
+    externalBlockedDateSet,
+    hasAvailableDateKeySnapshot,
+  } = normalizeAvailabilityContext(availabilityContext);
+
+  if (bookedDateSet.has(dateKey)) {
+    return DATE_AVAILABILITY_REASONS.BOOKED;
   }
 
-  const { availableDateSet, availabilityRanges, hasAvailableDateKeySnapshot } =
-    normalizeAvailabilityContext(availabilityContext);
+  if (externalBlockedDateSet.has(dateKey)) {
+    return DATE_AVAILABILITY_REASONS.EXTERNAL_BLOCKED;
+  }
+
+  if (unavailableDateSet.has(dateKey)) {
+    return DATE_AVAILABILITY_REASONS.UNAVAILABLE_OVERRIDE;
+  }
+
   if (availableDateSet.has(dateKey)) {
-    return false;
+    return DATE_AVAILABILITY_REASONS.AVAILABLE;
   }
 
   if (hasAvailableDateKeySnapshot && Array.isArray(availabilityRanges)) {
-    return !isDateAvailableFromBaseWindow(dateKey, availabilityRanges);
+    return isDateAvailableFromBaseWindow(dateKey, availabilityRanges)
+      ? DATE_AVAILABILITY_REASONS.AVAILABLE
+      : DATE_AVAILABILITY_REASONS.OUTSIDE_WINDOW;
   }
 
-  return false;
+  return DATE_AVAILABILITY_REASONS.AVAILABLE;
 };
 
-export const hasUnavailableDateInStayRange = (
+export const isUnavailableDate = (value, unavailableValues, availabilityContext) =>
+  getDateAvailabilityReason(value, unavailableValues, availabilityContext) !==
+  DATE_AVAILABILITY_REASONS.AVAILABLE;
+
+export const getStayRangeAvailabilityIssue = (
   checkInValue,
   checkOutValue,
   unavailableValues,
@@ -123,23 +159,37 @@ export const hasUnavailableDateInStayRange = (
   const checkInDate = normalizeDateValue(checkInValue);
   const checkOutDate = normalizeDateValue(checkOutValue);
   if (!checkInDate || !checkOutDate || checkOutDate <= checkInDate) {
-    return false;
+    return null;
   }
 
   const unavailableDateSet =
     unavailableValues instanceof Set ? unavailableValues : buildUnavailableDateSet(unavailableValues);
+  let firstBlockedReason = null;
+
   for (
     let cursor = checkInDate;
     cursor < checkOutDate;
     cursor = new Date(cursor.valueOf() + DAY_IN_MS)
   ) {
-    if (isUnavailableDate(cursor, unavailableDateSet, availabilityContext)) {
-      return true;
+    const reason = getDateAvailabilityReason(cursor, unavailableDateSet, availabilityContext);
+    if (reason === DATE_AVAILABILITY_REASONS.BOOKED) {
+      return reason;
+    }
+
+    if (reason !== DATE_AVAILABILITY_REASONS.AVAILABLE && !firstBlockedReason) {
+      firstBlockedReason = reason;
     }
   }
 
-  return false;
+  return firstBlockedReason;
 };
+
+export const hasUnavailableDateInStayRange = (
+  checkInValue,
+  checkOutValue,
+  unavailableValues,
+  availabilityContext
+) => Boolean(getStayRangeAvailabilityIssue(checkInValue, checkOutValue, unavailableValues, availabilityContext));
 
 export const getFutureDateKey = (offsetDays) => toDateKey(new Date(Date.now() + offsetDays * DAY_IN_MS));
 

--- a/frontend/web/src/features/bookingengine/listingdetails/views/RangeCalendar.jsx
+++ b/frontend/web/src/features/bookingengine/listingdetails/views/RangeCalendar.jsx
@@ -3,13 +3,15 @@ import React, { useEffect, useMemo, useState } from "react";
 import { FaCalendarAlt } from "react-icons/fa";
 import {
   buildUnavailableDateSet,
-  hasUnavailableDateInStayRange,
-  isUnavailableDate,
+  DATE_AVAILABILITY_REASONS,
+  getDateAvailabilityReason,
+  getStayRangeAvailabilityIssue,
   normalizeDateValue,
   toDateKey,
 } from "../utils/dateAvailability";
 import "../styles/RangeCalendar.scss";
 
+const BOOKED_MESSAGE = "These dates are already booked.";
 const NO_AVAILABILITY_MESSAGE = "This property has no availability for the selected dates.";
 const makeDate = (year, month, day) => new Date(year, month, day);
 const addMonths = (date, offset) => makeDate(date.getFullYear(), date.getMonth() + offset, 1);
@@ -42,6 +44,8 @@ function MonthGrid({
   onPick,
   navigation = null,
   blockedDateKeys,
+  bookedDateKeys,
+  externalBlockedDateKeys,
   availabilityRanges,
   availableDateKeys,
 }) {
@@ -58,21 +62,52 @@ function MonthGrid({
       date.setDate(start.getDate() + index);
       const inMonth = date.getMonth() === month;
       const key = toDateKey(date);
-      const isUnavailable =
-        inMonth &&
-        isUnavailableDate(date, blockedDateKeys, {
-          availabilityRanges,
-          availableDateKeys,
-        });
+      const availabilityReason = inMonth
+        ? getDateAvailabilityReason(date, blockedDateKeys, {
+            availabilityRanges,
+            availableDateKeys,
+            bookedDateKeys,
+            externalBlockedDateKeys,
+          })
+        : DATE_AVAILABILITY_REASONS.AVAILABLE;
+      const isBooked = availabilityReason === DATE_AVAILABILITY_REASONS.BOOKED;
+      const isExternalBlocked = availabilityReason === DATE_AVAILABILITY_REASONS.EXTERNAL_BLOCKED;
+      const isOutsideWindow = availabilityReason === DATE_AVAILABILITY_REASONS.OUTSIDE_WINDOW;
+      const isUnavailableOverride = availabilityReason === DATE_AVAILABILITY_REASONS.UNAVAILABLE_OVERRIDE;
+      const isUnavailable = inMonth && availabilityReason !== DATE_AVAILABILITY_REASONS.AVAILABLE;
       const inRange = rangeStart && rangeEnd && date >= rangeStart && date <= rangeEnd && inMonth;
       const isStart = rangeStart && key === toDateKey(rangeStart);
       const isEnd = rangeEnd && key === toDateKey(rangeEnd);
       const isToday = inMonth && isSameDay(date, today);
-      items.push({ date, key, inMonth, inRange, isStart, isEnd, isUnavailable, isToday });
+      items.push({
+        date,
+        key,
+        inMonth,
+        inRange,
+        isStart,
+        isEnd,
+        isUnavailable,
+        isBooked,
+        isExternalBlocked,
+        isOutsideWindow,
+        isUnavailableOverride,
+        isToday,
+      });
     }
 
     return items;
-  }, [blockedDateKeys, month, rangeEnd, rangeStart, today, year]);
+  }, [
+    availabilityRanges,
+    availableDateKeys,
+    blockedDateKeys,
+    bookedDateKeys,
+    externalBlockedDateKeys,
+    month,
+    rangeEnd,
+    rangeStart,
+    today,
+    year,
+  ]);
 
   return (
     <div className="rc-month">
@@ -110,7 +145,11 @@ function MonthGrid({
               type="button"
               className={[
                 "rc-cell rc-cell--day",
-                cell.isUnavailable && "is-unavailable",
+                cell.isUnavailable && !cell.isBooked && "is-unavailable range-calendar__day--unavailable",
+                cell.isBooked && "is-booked range-calendar__day--booked",
+                cell.isExternalBlocked && "range-calendar__day--external-blocked",
+                cell.isOutsideWindow && "range-calendar__day--outside-window",
+                cell.isUnavailableOverride && "range-calendar__day--unavailable-override",
                 cell.inRange && "is-inrange",
                 cell.isStart && "is-start",
                 cell.isEnd && "is-end",
@@ -123,7 +162,10 @@ function MonthGrid({
               onClick={() => onPick(cell.date)}
             >
               <span>{cell.date.getDate()}</span>
-              {cell.isUnavailable ? <span className="rc-cell__unavailable-mark" aria-hidden="true">--</span> : null}
+              {cell.isBooked ? <span className="rc-cell__booked-mark">Booked</span> : null}
+              {cell.isUnavailable && !cell.isBooked ? (
+                <span className="rc-cell__unavailable-mark" aria-hidden="true">--</span>
+              ) : null}
             </button>
           );
         })}
@@ -145,6 +187,8 @@ MonthGrid.propTypes = {
     })
   ),
   availableDateKeys: PropTypes.instanceOf(Set),
+  bookedDateKeys: PropTypes.instanceOf(Set).isRequired,
+  externalBlockedDateKeys: PropTypes.instanceOf(Set).isRequired,
   navigation: PropTypes.shape({
     side: PropTypes.oneOf(["left", "right"]),
     onClick: PropTypes.func,
@@ -153,6 +197,8 @@ MonthGrid.propTypes = {
 
 export default function RangeCalendar({
   unavailableDateKeys = [],
+  bookedDateKeys = [],
+  externalBlockedDateKeys = [],
   availabilityRanges = null,
   availableDateKeys = null,
   checkInDate = "",
@@ -169,6 +215,11 @@ export default function RangeCalendar({
   const rangeEnd = useMemo(() => normalizeDateValue(checkOutDate), [checkOutDate]);
 
   const blockedDateKeys = useMemo(() => buildUnavailableDateSet(unavailableDateKeys), [unavailableDateKeys]);
+  const bookedDateKeySet = useMemo(() => buildUnavailableDateSet(bookedDateKeys), [bookedDateKeys]);
+  const externalBlockedDateKeySet = useMemo(
+    () => buildUnavailableDateSet(externalBlockedDateKeys),
+    [externalBlockedDateKeys]
+  );
   const availableDateKeySet = useMemo(
     () => (Array.isArray(availableDateKeys) ? buildUnavailableDateSet(availableDateKeys) : null),
     [availableDateKeys]
@@ -177,8 +228,10 @@ export default function RangeCalendar({
     () => ({
       availabilityRanges,
       availableDateKeys: availableDateKeySet,
+      bookedDateKeys: bookedDateKeySet,
+      externalBlockedDateKeys: externalBlockedDateKeySet,
     }),
-    [availabilityRanges, availableDateKeySet]
+    [availabilityRanges, availableDateKeySet, bookedDateKeySet, externalBlockedDateKeySet]
   );
 
   const rightMonth = useMemo(() => addMonths(view, 1), [view]);
@@ -192,8 +245,11 @@ export default function RangeCalendar({
 
   const handlePick = (date) => {
     const key = toDateKey(date);
-    if (isUnavailableDate(date, blockedDateKeys, availabilityContext)) {
-      setSelectionError(NO_AVAILABILITY_MESSAGE);
+    const availabilityReason = getDateAvailabilityReason(date, blockedDateKeys, availabilityContext);
+    if (availabilityReason !== DATE_AVAILABILITY_REASONS.AVAILABLE) {
+      setSelectionError(
+        availabilityReason === DATE_AVAILABILITY_REASONS.BOOKED ? BOOKED_MESSAGE : NO_AVAILABILITY_MESSAGE
+      );
       return;
     }
     setSelectionError("");
@@ -209,8 +265,9 @@ export default function RangeCalendar({
     const nextStart = anchorDate.getTime() <= date.getTime() ? anchorDate : date;
     const nextEnd = anchorDate.getTime() <= date.getTime() ? date : anchorDate;
 
-    if (hasUnavailableDateInStayRange(nextStart, nextEnd, blockedDateKeys, availabilityContext)) {
-      setSelectionError(NO_AVAILABILITY_MESSAGE);
+    const rangeIssue = getStayRangeAvailabilityIssue(nextStart, nextEnd, blockedDateKeys, availabilityContext);
+    if (rangeIssue) {
+      setSelectionError(rangeIssue === DATE_AVAILABILITY_REASONS.BOOKED ? BOOKED_MESSAGE : NO_AVAILABILITY_MESSAGE);
       setDraftStart(date);
       onRangeChange(key, "");
       return;
@@ -251,6 +308,8 @@ export default function RangeCalendar({
               rangeEnd={rangeEnd}
               onPick={handlePick}
               blockedDateKeys={blockedDateKeys}
+              bookedDateKeys={bookedDateKeySet}
+              externalBlockedDateKeys={externalBlockedDateKeySet}
               availabilityRanges={availabilityRanges}
               availableDateKeys={availableDateKeySet}
               navigation={{ side: "left", onClick: prev }}
@@ -261,6 +320,8 @@ export default function RangeCalendar({
               rangeEnd={rangeEnd}
               onPick={handlePick}
               blockedDateKeys={blockedDateKeys}
+              bookedDateKeys={bookedDateKeySet}
+              externalBlockedDateKeys={externalBlockedDateKeySet}
               availabilityRanges={availabilityRanges}
               availableDateKeys={availableDateKeySet}
               navigation={{ side: "right", onClick: next }}
@@ -274,6 +335,8 @@ export default function RangeCalendar({
 
 RangeCalendar.propTypes = {
   unavailableDateKeys: PropTypes.arrayOf(PropTypes.string),
+  bookedDateKeys: PropTypes.arrayOf(PropTypes.string),
+  externalBlockedDateKeys: PropTypes.arrayOf(PropTypes.string),
   availabilityRanges: PropTypes.arrayOf(
     PropTypes.shape({
       start: PropTypes.number.isRequired,

--- a/frontend/web/src/features/bookingengine/listingdetails/views/bookingContainer.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/views/bookingContainer.js
@@ -6,6 +6,9 @@ import Pricing from "../components/pricing";
 import useHandleReservePress from "../hooks/handleReservePress";
 import {
   buildUnavailableDateSet,
+  DATE_AVAILABILITY_REASONS,
+  getDateAvailabilityReason,
+  getStayRangeAvailabilityIssue,
   hasUnavailableDateInStayRange,
   isUnavailableDate,
 } from "../utils/dateAvailability";
@@ -23,6 +26,8 @@ import ChatScreen from "../../../../components/messages/ChatScreen";
 import "../../../../components/messages/messagesV2.scss";
 
 const UNIFIED_MESSAGING_API = "https://54s3llwby8.execute-api.eu-north-1.amazonaws.com/default";
+const BOOKED_MESSAGE = "These dates are already booked.";
+const NO_AVAILABILITY_MESSAGE = "This property has no availability for the selected dates.";
 
 const MessageHostModalInner = ({ onClose, hostId, hostName, hostImage, propertyId }) => {
   const { userId } = useAuth();
@@ -155,6 +160,7 @@ const BookingContainer = ({
   host = {},
   propertyId = null,
   unavailableDateKeys = [],
+  bookedDateKeys = [],
   availabilityRanges = null,
   availableDateKeys = null,
   checkInDate = "",
@@ -178,12 +184,14 @@ const BookingContainer = ({
     () => buildUnavailableDateSet(unavailableDateKeys),
     [unavailableDateKeys]
   );
+  const bookedDateSet = useMemo(() => buildUnavailableDateSet(bookedDateKeys), [bookedDateKeys]);
   const availabilityContext = useMemo(
     () => ({
       availabilityRanges,
       availableDateKeys,
+      bookedDateKeys: bookedDateSet,
     }),
-    [availabilityRanges, availableDateKeys]
+    [availabilityRanges, availableDateKeys, bookedDateSet]
   );
   const nights = useMemo(() => calculateNights(checkInDate, checkOutDate), [checkInDate, checkOutDate]);
 
@@ -275,8 +283,9 @@ const BookingContainer = ({
       return;
     }
 
-    if (isUnavailableDate(value, unavailableDateSet, availabilityContext)) {
-      alert("This property has no availability for the selected dates.");
+    const availabilityReason = getDateAvailabilityReason(value, unavailableDateSet, availabilityContext);
+    if (availabilityReason !== DATE_AVAILABILITY_REASONS.AVAILABLE) {
+      alert(availabilityReason === DATE_AVAILABILITY_REASONS.BOOKED ? BOOKED_MESSAGE : NO_AVAILABILITY_MESSAGE);
       return;
     }
 
@@ -285,8 +294,10 @@ const BookingContainer = ({
       return;
     }
 
-    if (checkOutDate && hasUnavailableDateInStayRange(value, checkOutDate, unavailableDateSet, availabilityContext)) {
-      alert("This property has no availability for the selected dates.");
+    const rangeIssue =
+      checkOutDate && getStayRangeAvailabilityIssue(value, checkOutDate, unavailableDateSet, availabilityContext);
+    if (rangeIssue) {
+      alert(rangeIssue === DATE_AVAILABILITY_REASONS.BOOKED ? BOOKED_MESSAGE : NO_AVAILABILITY_MESSAGE);
       return;
     }
 
@@ -309,8 +320,9 @@ const BookingContainer = ({
       return;
     }
 
-    if (hasUnavailableDateInStayRange(checkInDate, value, unavailableDateSet, availabilityContext)) {
-      alert("This property has no availability for the selected dates.");
+    const rangeIssue = getStayRangeAvailabilityIssue(checkInDate, value, unavailableDateSet, availabilityContext);
+    if (rangeIssue) {
+      alert(rangeIssue === DATE_AVAILABILITY_REASONS.BOOKED ? BOOKED_MESSAGE : NO_AVAILABILITY_MESSAGE);
       return;
     }
 
@@ -323,6 +335,7 @@ const BookingContainer = ({
     checkOutDate,
     setCheckOutDate: handleCheckOutDateChange,
     unavailableDateKeys,
+    bookedDateKeys,
     availabilityRanges,
     availableDateKeys,
     className: "date-container--mobile-sticky",
@@ -362,6 +375,7 @@ const BookingContainer = ({
         checkOutDate={checkOutDate}
         setCheckOutDate={handleCheckOutDateChange}
         unavailableDateKeys={unavailableDateKeys}
+        bookedDateKeys={bookedDateKeys}
         availabilityRanges={availabilityRanges}
         availableDateKeys={availableDateKeys}
       />
@@ -474,6 +488,7 @@ BookingContainer.propTypes = {
   }),
   propertyId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   unavailableDateKeys: PropTypes.arrayOf(PropTypes.string),
+  bookedDateKeys: PropTypes.arrayOf(PropTypes.string),
   availabilityRanges: PropTypes.arrayOf(
     PropTypes.shape({
       start: PropTypes.number.isRequired,

--- a/frontend/web/src/features/bookingengine/listingdetails/views/dateSelectionContainer.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/views/dateSelectionContainer.js
@@ -9,6 +9,7 @@ const DateSelectionContainer = ({
   checkOutDate = "",
   setCheckOutDate = () => {},
   unavailableDateKeys = [],
+  bookedDateKeys = [],
   availabilityRanges = null,
   availableDateKeys = null,
   className = "",
@@ -21,6 +22,7 @@ const DateSelectionContainer = ({
         checkInDate={checkInDate}
         setCheckInDate={setCheckInDate}
         unavailableDateKeys={unavailableDateKeys}
+        bookedDateKeys={bookedDateKeys}
         availabilityRanges={availabilityRanges}
         availableDateKeys={availableDateKeys}
       />
@@ -30,6 +32,7 @@ const DateSelectionContainer = ({
         setCheckOutDate={setCheckOutDate}
         checkInDate={checkInDate}
         unavailableDateKeys={unavailableDateKeys}
+        bookedDateKeys={bookedDateKeys}
         availabilityRanges={availabilityRanges}
         availableDateKeys={availableDateKeys}
       />
@@ -43,6 +46,7 @@ DateSelectionContainer.propTypes = {
   checkOutDate: PropTypes.string,
   setCheckOutDate: PropTypes.func,
   unavailableDateKeys: PropTypes.arrayOf(PropTypes.string),
+  bookedDateKeys: PropTypes.arrayOf(PropTypes.string),
   availabilityRanges: PropTypes.arrayOf(
     PropTypes.shape({
       start: PropTypes.number.isRequired,

--- a/frontend/web/src/features/bookingengine/listingdetails/views/propertyContainer.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/views/propertyContainer.js
@@ -35,6 +35,8 @@ const PropertyContainer = ({
   location = {},
   onContactHost,
   unavailableDateKeys = [],
+  bookedDateKeys = [],
+  externalBlockedDateKeys = [],
   availabilityRanges = null,
   availableDateKeys = [],
   checkInDate = "",
@@ -136,6 +138,8 @@ const PropertyContainer = ({
         <section id="listing-availability" className="listing-section-block">
           <RangeCalendar
             unavailableDateKeys={unavailableDateKeys}
+            bookedDateKeys={bookedDateKeys}
+            externalBlockedDateKeys={externalBlockedDateKeys}
             availabilityRanges={availabilityRanges}
             availableDateKeys={availableDateKeys}
             checkInDate={checkInDate}
@@ -222,6 +226,8 @@ PropertyContainer.propTypes = {
   onContactHost: PropTypes.func,
   children: PropTypes.node,
   unavailableDateKeys: PropTypes.arrayOf(PropTypes.string),
+  bookedDateKeys: PropTypes.arrayOf(PropTypes.string),
+  externalBlockedDateKeys: PropTypes.arrayOf(PropTypes.string),
   availabilityRanges: PropTypes.arrayOf(
     PropTypes.shape({
       start: PropTypes.number.isRequired,

--- a/frontend/web/src/features/bookingengine/tests/BookingContainer.test.js
+++ b/frontend/web/src/features/bookingengine/tests/BookingContainer.test.js
@@ -11,6 +11,12 @@ jest.mock("../listingdetails/components/pricing", () => () => <div>Pricing</div>
 jest.mock("../listingdetails/hooks/handleReservePress", () => () => mockReservePress);
 jest.mock("../listingdetails/utils/dateAvailability", () => ({
   buildUnavailableDateSet: () => new Set(),
+  DATE_AVAILABILITY_REASONS: {
+    AVAILABLE: "available",
+    BOOKED: "booked",
+  },
+  getDateAvailabilityReason: () => "available",
+  getStayRangeAvailabilityIssue: () => null,
   hasUnavailableDateInStayRange: () => false,
   isUnavailableDate: () => false,
 }));


### PR DESCRIPTION
## Close or Relate the Issue

* Related Issue: #

## Proposed Changes

Description:

This PR improves the public guest listing calendar so booked dates are visually different from outside-window/no-availability dates.

Before this change, booked nights were merged into the generic unavailable date set. Because of that, the calendar only knew whether a date was unavailable, but not why. As a result, booked dates were rendered the same way as unavailable/outside-window dates with `--`.

This PR introduces reason-based date availability handling for the guest calendar. Booked dates now render as `Booked` with a booked-specific class, while outside-window, explicit unavailable, and generic blocked dates still render as `--`.

Implemented behavior:

* Booked dates:

  * disabled
  * show `Booked`
  * use booked-specific styling
  * do not show `--`
  * selecting a booked range shows: `These dates are already booked.`

* Outside-window / no availability / unavailable override dates:

  * disabled
  * show `--`
  * use unavailable styling
  * selecting such a range shows: `This property has no availability for the selected dates.`

Checkout handling is preserved. Booking nights remain arrival-inclusive and departure-exclusive, so a departure/checkout date is not marked as booked unless it is also a booked night from another booking.

No backend booking validation, Channex sync, Full Sync, polling/import logic, database schema, or AWS configuration was changed.

## Change Type

* [x] Bug fix
* [ ] New feature
* [ ] Optimization
* [ ] Documentation update

## Change Size

* [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [[Refactoring](https://chatgpt.com/g/g-p-697f7ff03c808191b0c04598bc66b5c0/c/6a06ea98-e38c-8386-88d5-1ccaf8a0cabb#Refactoring)](#Refactoring))
* [x] Big change (+-max 1000)
* [ ] Small change (less than 300)

## Refactoring

No refactoring-only files. The changed files contain the guest calendar booked/unavailable UI fix and related test coverage.

## Evidence

* [ ] Screenshots or screen recording added for UI changes
* [ ] Before/after images added when relevant
* [ ] Images clearly show the implemented change
* [ ] Image quality is readable (no cropped or blurry evidence)

Evidence to add after deploy/test:

* Guest calendar showing a booked date rendered as `Booked`
* Guest calendar showing outside-window/unavailable dates rendered as `--`
* Guest calendar showing checkout date not marked as booked
* Error message for booked range: `These dates are already booked.`
* Error message for unavailable range: `This property has no availability for the selected dates.`

## Responsiveness

* [ ] UI checked on mobile
* [ ] UI checked on tablet
* [x] UI checked on desktop
* [x] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages

* [ ] NPM Packages installed
* [ ] NPM Packages removed
* [ ] NPM Packages updated
* [ ] Checked for vulnerabilities using "npm audit"

No npm package changes were made in this PR.

## Checklist

* [ ] Pull request has at least 2 reviewers assigned
* [x] PR title is descriptive and includes issue number
* [x] Conventions

  * [x] No config files have been added (Amplify config, cache files)
  * [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  * [x] No global styling (see [[#1691](https://github.com/domits1/Domits/issues/1691)](https://github.com/domits1/Domits/issues/1691))
  * [x] No `console.log` left in code
  * [x] No commented-out code remains
* [x] Testing

  * [x] Code tested locally
  * [x] Jest tests are included
  * [x] Jest tests are passing

## Tests / Build

Passed:

* `npm test -- --runTestsByPath src/features/bookingengine/listingdetails/pages/listingDetails2.test.js --watchAll=false`

  * PASS, 13 tests

* `npm test -- --runTestsByPath src/features/bookingengine/tests/BookingOverview.test.js --watchAll=false`

  * PASS, 5 passed, 4 skipped

* `npm test -- --runTestsByPath src/features/bookingengine/listingdetails/views/BookingContainer.test.js --watchAll=false`

  * PASS, 2 tests

* `npm run build`

  * compiled successfully
  * existing bundle-size warning only

Other:

* `git diff --check` passed


Known caveat:

If Channex dates ever arrive only as flat `externalBlockedDates`, the UI cannot safely classify those dates as booked yet. In that case, they remain generic unavailable dates. If needed later, add per-date source metadata so external blocks can be displayed as booked when appropriate.

## Keep or delete my branch

* [x] Delete my branch after merge
* [ ] Keep my branch