### PR TITLE
Feat/direct booking website templates

### DIFF
--- a/backend/functions/PropertyHandler/controller/propertyController.js
+++ b/backend/functions/PropertyHandler/controller/propertyController.js
@@ -1763,7 +1763,11 @@ export class PropertyController {
     }
 
     isPublicDirectBookingWebsiteReachable(site, domain) {
-        return Boolean(site) && site.status === "PUBLISHED" && domain?.status === "ACTIVE";
+        return (
+            Boolean(site) &&
+            site.status === "PUBLISHED" &&
+            resolveDirectBookingWebsiteFallbackDomainStatus(domain) === "ACTIVE"
+        );
     }
 
     async getDirectBookingWebsiteSummaryByPropertyId(propertyId, hostId) {

--- a/backend/functions/PropertyHandler/controller/propertyController.js
+++ b/backend/functions/PropertyHandler/controller/propertyController.js
@@ -1836,7 +1836,12 @@ export class PropertyController {
             },
         });
 
-        return this.buildDirectBookingWebsiteSummary(site, [liveDomain]);
+        const persistedSiteSummary = await this.getDirectBookingWebsiteSummaryByPropertyId(propertyId, hostId);
+        if (persistedSiteSummary) {
+            return persistedSiteSummary;
+        }
+
+        return this.buildDirectBookingWebsiteSummary(site, liveDomain ? [liveDomain] : []);
     }
 
     async unpublishDirectBookingWebsiteSummary({ site, draft, hostId, propertyId }) {

--- a/backend/functions/PropertyHandler/data/repository/propertyImageRepository.js
+++ b/backend/functions/PropertyHandler/data/repository/propertyImageRepository.js
@@ -100,8 +100,14 @@ export class PropertyImageRepository {
                     status: image.status,
                     key: web?.key || original?.key || "",
                     web_key: web?.key || null,
+                    web_width: web?.width || null,
+                    web_height: web?.height || null,
                     thumb_key: thumb?.key || null,
+                    thumb_width: thumb?.width || null,
+                    thumb_height: thumb?.height || null,
                     original_key: original?.key || null,
+                    original_width: original?.width || null,
+                    original_height: original?.height || null,
                 };
             });
         }

--- a/frontend/web/src/features/hostdashboard/website/WebsitePublicPreviewPage.jsx
+++ b/frontend/web/src/features/hostdashboard/website/WebsitePublicPreviewPage.jsx
@@ -64,21 +64,30 @@ function WebsitePublicPreviewPage() {
 
       try {
         const nextPayload = await fetchWebsitePreviewByDraftId(draftId);
-        const nextPropertyDetails = nextPayload?.propertyDetails
-          ? await enrichWebsitePropertyDetails(nextPayload.propertyDetails)
-          : nextPayload?.propertyDetails;
 
         if (!isMounted) {
           return;
         }
 
-        setPayload(
-          nextPropertyDetails === nextPayload?.propertyDetails
-            ? nextPayload
-            : {
-                ...nextPayload,
+        setPayload(nextPayload);
+        setIsLoading(false);
+
+        if (!nextPayload?.propertyDetails) {
+          return;
+        }
+
+        const nextPropertyDetails = await enrichWebsitePropertyDetails(nextPayload.propertyDetails);
+        if (!isMounted || nextPropertyDetails === nextPayload.propertyDetails) {
+          return;
+        }
+
+        setPayload((currentPayload) =>
+          currentPayload
+            ? {
+                ...currentPayload,
                 propertyDetails: nextPropertyDetails,
               }
+            : currentPayload
         );
       } catch (error) {
         if (!isMounted) {
@@ -87,10 +96,7 @@ function WebsitePublicPreviewPage() {
 
         setPayload(null);
         setLoadError(error?.message || "We could not load this website preview.");
-      } finally {
-        if (isMounted) {
-          setIsLoading(false);
-        }
+        setIsLoading(false);
       }
     };
 

--- a/frontend/web/src/features/hostdashboard/website/WebsitePublicSitePage.jsx
+++ b/frontend/web/src/features/hostdashboard/website/WebsitePublicSitePage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 import { recordPublicWebsiteAnalyticsEventSafely } from "./analytics/websiteAnalyticsService";
 import {
@@ -21,7 +21,6 @@ import { applyWebsiteDraftThemeOverrides, resolveWebsiteBackgroundColor } from "
 import { enrichWebsitePropertyDetails } from "./services/websitePropertyService";
 import {
   fetchPublicWebsiteRenderModel,
-  fetchPublicWebsiteSiteResolution,
 } from "./services/websitePublicSiteService";
 import {
   subscribeToWebsiteLiveSiteUpdates,
@@ -111,10 +110,7 @@ function WebsitePublicSitePage() {
 
     return normalizeWebsiteDomain(globalThis.location?.host || "");
   }, [routeDomain]);
-  const requestedSiteId = useMemo(() => {
-    const searchParameters = new URLSearchParams(globalThis.location?.search || "");
-    return String(searchParameters.get("siteId") || "").trim();
-  }, [routeDomain]);
+  const requestedSiteId = String(new URLSearchParams(globalThis.location?.search || "").get("siteId") || "").trim();
 
   useEffect(() => {
     let isMounted = true;
@@ -124,29 +120,11 @@ function WebsitePublicSitePage() {
       setLoadError("");
 
       try {
-        let nextResolution = null;
-        let nextRenderPayload = null;
-
-        if (requestedSiteId) {
-          nextRenderPayload = await fetchPublicWebsiteRenderModel({
-            siteId: requestedSiteId,
-            domain: requestedDomain,
-          });
-          nextResolution = nextRenderPayload?.resolution || null;
-        } else {
-          nextResolution = await fetchPublicWebsiteSiteResolution(requestedDomain);
-          nextRenderPayload = await fetchPublicWebsiteRenderModel({
-            siteId: nextResolution?.siteId,
-            domain: requestedDomain,
-          });
-        }
-
-        if (nextRenderPayload?.propertySnapshot) {
-          nextRenderPayload = {
-            ...nextRenderPayload,
-            propertySnapshot: await enrichWebsitePropertyDetails(nextRenderPayload.propertySnapshot),
-          };
-        }
+        const nextRenderPayload = await fetchPublicWebsiteRenderModel({
+          siteId: requestedSiteId,
+          domain: requestedDomain,
+        });
+        const nextResolution = nextRenderPayload?.resolution || null;
 
         if (!isMounted) {
           return;
@@ -154,6 +132,25 @@ function WebsitePublicSitePage() {
 
         setResolution(nextResolution);
         setRenderPayload(nextRenderPayload);
+        setIsLoading(false);
+
+        if (!nextRenderPayload?.propertySnapshot) {
+          return;
+        }
+
+        const nextPropertySnapshot = await enrichWebsitePropertyDetails(nextRenderPayload.propertySnapshot);
+        if (!isMounted || nextPropertySnapshot === nextRenderPayload.propertySnapshot) {
+          return;
+        }
+
+        setRenderPayload((currentPayload) =>
+          currentPayload
+            ? {
+                ...currentPayload,
+                propertySnapshot: nextPropertySnapshot,
+              }
+            : currentPayload
+        );
       } catch (error) {
         if (!isMounted) {
           return;
@@ -162,10 +159,7 @@ function WebsitePublicSitePage() {
         setResolution(null);
         setRenderPayload(null);
         setLoadError(error?.message || "We could not load this published website.");
-      } finally {
-        if (isMounted) {
-          setIsLoading(false);
-        }
+        setIsLoading(false);
       }
     };
 
@@ -218,7 +212,7 @@ function WebsitePublicSitePage() {
     requestedDomain: resolvedDomain || requestedDomain,
   });
 
-  const clearRefreshRetryWindow = () => {
+  const clearRefreshRetryWindow = useCallback(() => {
     if (refreshRetryIntervalRef.current) {
       globalThis.clearInterval(refreshRetryIntervalRef.current);
       refreshRetryIntervalRef.current = null;
@@ -228,13 +222,13 @@ function WebsitePublicSitePage() {
       globalThis.clearTimeout(refreshRetryTimeoutRef.current);
       refreshRetryTimeoutRef.current = null;
     }
-  };
+  }, []);
 
-  const triggerPublishedSiteRefresh = () => {
+  const triggerPublishedSiteRefresh = useCallback(() => {
     setRefreshVersion((currentVersion) => currentVersion + 1);
-  };
+  }, []);
 
-  const startRefreshRetryWindow = () => {
+  const startRefreshRetryWindow = useCallback(() => {
     clearRefreshRetryWindow();
 
     if (globalThis.document?.visibilityState === "hidden") {
@@ -252,7 +246,7 @@ function WebsitePublicSitePage() {
     refreshRetryTimeoutRef.current = globalThis.setTimeout(() => {
       clearRefreshRetryWindow();
     }, LIVE_SITE_REFRESH_WINDOW_MS);
-  };
+  }, [clearRefreshRetryWindow, triggerPublishedSiteRefresh]);
 
   useEffect(() => {
     const unsubscribeStorage = subscribeToWebsiteLiveSiteUpdates(
@@ -297,13 +291,13 @@ function WebsitePublicSitePage() {
       globalThis.removeEventListener("message", handleMessage);
       globalThis.document?.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, [resolvedDomain, resolvedSiteId]);
+  }, [resolvedDomain, resolvedSiteId, startRefreshRetryWindow, clearRefreshRetryWindow]);
 
   useEffect(() => {
     return () => {
       clearRefreshRetryWindow();
     };
-  }, []);
+  }, [clearRefreshRetryWindow]);
 
   useEffect(() => {
     if (!publicModel?.site?.title) {

--- a/frontend/web/src/features/hostdashboard/website/_websiteBuilder.layout.scss
+++ b/frontend/web/src/features/hostdashboard/website/_websiteBuilder.layout.scss
@@ -381,6 +381,47 @@
   margin: 0;
 }
 
+.surfaceKpiViewportGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 14px;
+}
+
+.surfaceKpiViewportPanel {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(31, 78, 121, 0.1);
+  background: rgba(255, 255, 255, 0.76);
+}
+
+.surfaceKpiViewportHeader {
+  display: grid;
+  gap: 6px;
+}
+
+.surfaceKpiViewportHeader h4,
+.surfaceKpiViewportHeader p {
+  margin: 0;
+}
+
+.surfaceKpiViewportHeader h4 {
+  color: #153e64;
+  font-size: 0.98rem;
+}
+
+.surfaceKpiViewportHeader p {
+  color: #64748b;
+  line-height: 1.5;
+}
+
+.surfaceKpiViewportMetricGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 14px;
+}
+
 .surfaceKpiGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/frontend/web/src/features/hostdashboard/website/editor/WebsiteEditorFields.jsx
+++ b/frontend/web/src/features/hostdashboard/website/editor/WebsiteEditorFields.jsx
@@ -26,6 +26,8 @@ export function TextField({
   onFocus = undefined,
   onBlur = undefined,
 }) {
+  const normalizedValue = typeof value === "string" ? value : "";
+
   if (field.component === "textarea") {
     return (
       <div
@@ -38,7 +40,7 @@ export function TextField({
         <textarea
           id={`website-editor-${field.key}`}
           className={styles.textArea}
-          value={value}
+          value={normalizedValue}
           onChange={onChange}
           onKeyDown={onKeyDown}
           onFocus={onFocus}
@@ -59,7 +61,7 @@ export function TextField({
       <input
         id={`website-editor-${field.key}`}
         className={styles.textInput}
-        value={value}
+        value={normalizedValue}
         onChange={onChange}
         onKeyDown={onKeyDown}
         onFocus={onFocus}

--- a/frontend/web/src/features/hostdashboard/website/kpis/WebsiteKpiDashboardPage.js
+++ b/frontend/web/src/features/hostdashboard/website/kpis/WebsiteKpiDashboardPage.js
@@ -14,7 +14,6 @@ import {
   buildWebsiteMetricGroups,
   buildWebsiteMetricDeltaMap,
   EMPTY_WEBSITE_KPIS,
-  PERFORMANCE_VIEWPORT_TAB_MOBILE,
   PERFORMANCE_VIEWPORT_TAB_OPTIONS,
 } from "./websiteKpiConfig";
 import styles from "../WebsiteBuilderPage.module.scss";
@@ -32,6 +31,7 @@ const KPI_VIEW_TAB_OPTIONS = Object.freeze([
 ]);
 const WEBSITE_KPI_POLL_INTERVAL_MS = 60000;
 const WEBSITE_KPI_HIGHLIGHT_DURATION_MS = 4200;
+
 const formatWebsiteKpiSyncTime = (timestamp) =>
   new Intl.DateTimeFormat("en-GB", {
     hour: "2-digit",
@@ -168,7 +168,6 @@ function WebsiteKpiDashboardPage() {
   const [websiteKpisError, setWebsiteKpisError] = useState("");
   const [websiteKpisRefreshError, setWebsiteKpisRefreshError] = useState("");
   const [lastWebsiteKpiRefreshAt, setLastWebsiteKpiRefreshAt] = useState(0);
-  const [performanceViewportTab, setPerformanceViewportTab] = useState(PERFORMANCE_VIEWPORT_TAB_MOBILE);
   const [kpiViewTab, setKpiViewTab] = useState(KPI_VIEW_TAB_OVERVIEW);
   const [highlightedMetricIds, setHighlightedMetricIds] = useState([]);
   const [metricDeltaMap, setMetricDeltaMap] = useState({});
@@ -287,7 +286,19 @@ function WebsiteKpiDashboardPage() {
   }, []);
 
   const metricGroups = buildWebsiteMetricGroups(websiteKpis);
-  const performanceCards = buildPerformanceCards(websiteKpis, performanceViewportTab);
+  const performanceViewportCards = useMemo(
+    () =>
+      PERFORMANCE_VIEWPORT_TAB_OPTIONS.map((viewportOption) => ({
+        ...viewportOption,
+        ...buildPerformanceCards(websiteKpis, viewportOption.id),
+      })),
+    [websiteKpis]
+  );
+  const performanceCards = performanceViewportCards[0] || {
+    title: "Website performance",
+    description: "",
+    metrics: [],
+  };
   const researchKpiCards = buildResearchKpiCards(websiteKpis);
   const deletionReasonRows = useMemo(
     () => buildDeletionReasonRows(websiteKpis.deletionReasonBreakdown),
@@ -389,43 +400,29 @@ function WebsiteKpiDashboardPage() {
       </div>
 
       <div className={styles.surfaceKpiBody}>
-        <div className={styles.surfaceKpiViewportSection}>
-          <div className={styles.surfaceKpiTabRow} role="tablist" aria-label="Website viewport KPI tabs">
-            {PERFORMANCE_VIEWPORT_TAB_OPTIONS.map(({ id, label }) => {
-              const isActiveTab = performanceViewportTab === id;
-              return (
-                <button
-                  key={id}
-                  type="button"
-                  role="tab"
-                  aria-selected={isActiveTab}
-                  className={`${styles.surfaceKpiTabButton} ${
-                    isActiveTab ? styles.surfaceKpiTabButtonActive : ""
-                  }`.trim()}
-                  onClick={() => setPerformanceViewportTab(id)}
-                >
-                  {label}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-        <p className={styles.surfaceKpiDescription}>
-          {performanceCards.viewportDescription}
-        </p>
-        <div className={styles.surfaceKpiGrid}>
-          {performanceCards.metrics.map((surfaceMetric) => (
-            <WebsiteKpiMetricCard
-              key={surfaceMetric.id}
-              title={surfaceMetric.title}
-              value={surfaceMetric.value}
-              meta={surfaceMetric.meta}
-              isLoading={isInitialKpiLoad}
-              loadingMeta="Loading surface performance metrics..."
-              isHighlighted={highlightedMetricIds.includes(surfaceMetric.id)}
-              sampleLabel={surfaceMetric.sampleLabel}
-              deltaLabel={metricDeltaMap[surfaceMetric.id] || ""}
-            />
+        <div className={styles.surfaceKpiViewportGrid}>
+          {performanceViewportCards.map((viewportCard) => (
+            <section key={viewportCard.id} className={styles.surfaceKpiViewportPanel}>
+              <div className={styles.surfaceKpiViewportHeader}>
+                <h4>{viewportCard.label}</h4>
+              </div>
+
+              <div className={styles.surfaceKpiViewportMetricGrid}>
+                {viewportCard.metrics.map((surfaceMetric) => (
+                  <WebsiteKpiMetricCard
+                    key={surfaceMetric.id}
+                    title={surfaceMetric.title}
+                    value={surfaceMetric.value}
+                    meta={surfaceMetric.meta}
+                    isLoading={isInitialKpiLoad}
+                    loadingMeta="Loading surface performance metrics..."
+                    isHighlighted={highlightedMetricIds.includes(surfaceMetric.id)}
+                    sampleLabel={surfaceMetric.sampleLabel}
+                    deltaLabel={metricDeltaMap[surfaceMetric.id] || ""}
+                  />
+                ))}
+              </div>
+            </section>
           ))}
         </div>
       </div>

--- a/frontend/web/src/features/hostdashboard/website/rendering/WebsiteTemplatePreview.module.scss
+++ b/frontend/web/src/features/hostdashboard/website/rendering/WebsiteTemplatePreview.module.scss
@@ -560,6 +560,15 @@
   border-radius: 24px;
 }
 
+.availabilityCalendarDeferredFallback {
+  min-height: 360px;
+  border-radius: 24px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(248, 250, 252, 0.94)),
+    #ffffff;
+  box-shadow: inset 0 0 0 1px rgba(203, 213, 225, 0.42);
+}
+
 .previewUnsupported {
   padding: 22px;
   border-radius: 22px;
@@ -1211,6 +1220,13 @@
   gap: 14px;
   width: min(100%, 1080px);
   justify-self: center;
+}
+
+.panoramaDeferredRenderSection {
+  @supports (content-visibility: auto) {
+    content-visibility: auto;
+    contain-intrinsic-size: 1px 720px;
+  }
 }
 
 .sectionHeadingTitle {

--- a/frontend/web/src/features/hostdashboard/website/rendering/buildWebsiteTemplateModel.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/buildWebsiteTemplateModel.js
@@ -1,5 +1,9 @@
 import amenitiesCatalog from "../../../../store/amenities";
-import { placeholderImage, resolveAccommodationImageUrls } from "../../../../utils/accommodationImage";
+import {
+  buildAccommodationImageAssetFromUrl,
+  buildAccommodationImageAssets,
+  placeholderImage,
+} from "../../../../utils/accommodationImage";
 import { AMENITY_CATEGORY_ORDER, POLICY_RULE_CONFIG } from "../../hostproperty/constants";
 import {
   DEFAULT_WEBSITE_CONTACT_ACCENT_COLOR,
@@ -256,14 +260,20 @@ const buildPolicyHighlights = (rules) => {
   return [...configuredRules, ...fallbackRules];
 };
 
-const buildGalleryImages = (propertyDetails, summaryProperty, imageVariant) => {
-  const detailImages = resolveAccommodationImageUrls(propertyDetails?.images, imageVariant);
-  if (detailImages.length > 0) {
-    return detailImages;
+const buildGalleryImageAssets = (propertyDetails, summaryProperty, imageVariant) => {
+  const detailImageAssets = buildAccommodationImageAssets(propertyDetails?.images, imageVariant);
+  if (detailImageAssets.length > 0) {
+    return detailImageAssets;
   }
 
-  const summaryImages = Array.isArray(summaryProperty?.galleryImages) ? summaryProperty.galleryImages : [];
-  return summaryImages.length > 0 ? summaryImages : [placeholderImage];
+  const summaryImageAssets = (Array.isArray(summaryProperty?.galleryImages) ? summaryProperty.galleryImages : [])
+    .map((imageUrl) => buildAccommodationImageAssetFromUrl(imageUrl))
+    .filter(Boolean);
+  if (summaryImageAssets.length > 0) {
+    return summaryImageAssets;
+  }
+
+  return [buildAccommodationImageAssetFromUrl(placeholderImage)];
 };
 
 const buildHeroDescription = ({ title, description, propertyTypeLabel, locationLabel, guestsLabel }) => {
@@ -503,7 +513,8 @@ export const buildWebsiteTemplateModel = ({ propertyDetails, summaryProperty = n
   const property = propertyDetails?.property || {};
   const generalDetails = Array.isArray(propertyDetails?.generalDetails) ? propertyDetails.generalDetails : [];
   const availabilityRestrictions = buildRestrictionValueMap(propertyDetails?.availabilityRestrictions);
-  const galleryImages = buildGalleryImages(propertyDetails, summaryProperty, imageVariant);
+  const galleryImageAssets = buildGalleryImageAssets(propertyDetails, summaryProperty, imageVariant).filter(Boolean);
+  const galleryImages = galleryImageAssets.map((imageAsset) => imageAsset.src).filter(Boolean);
   const previewImages = galleryImages.slice(0, 3);
   const featuredGalleryImages = galleryImages.slice(0, MAX_FEATURED_GALLERY_IMAGES);
   const locationLabel = buildLocationLabel(propertyDetails?.location, summaryProperty);
@@ -561,8 +572,14 @@ export const buildWebsiteTemplateModel = ({ propertyDetails, summaryProperty = n
     },
     media: {
       heroImage: galleryImages[0] || placeholderImage,
+      heroImageAsset: galleryImageAssets[0] || buildAccommodationImageAssetFromUrl(placeholderImage),
       residenceImage: galleryImages[1] || galleryImages[0] || placeholderImage,
+      residenceImageAsset:
+        galleryImageAssets[1] ||
+        galleryImageAssets[0] ||
+        buildAccommodationImageAssetFromUrl(placeholderImage),
       galleryImages,
+      galleryImageAssets,
       imageRotation: normalizeWebsiteImageRotationSettings(),
       previewImages,
       featuredGalleryImages,

--- a/frontend/web/src/features/hostdashboard/website/rendering/templates/PanoramaLandingTemplate.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/templates/PanoramaLandingTemplate.jsx
@@ -1,9 +1,8 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { Suspense, lazy, useEffect, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { createPortal } from "react-dom";
 import MenuRoundedIcon from "@mui/icons-material/MenuRounded";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
-import PhotoBrowserOverlay from "../../../../../components/gallery/PhotoBrowserOverlay";
 import styles from "../WebsiteTemplatePreview.module.scss";
 import { getScrollRevealProps } from "../animations/scrollRevealProps";
 import { getAmenityIconNode } from "../amenityIconRegistry";
@@ -63,6 +62,8 @@ const PANORAMA_AMENITY_CATEGORY_LABELS = Object.freeze({
 });
 const PANORAMA_RESIDENCE_SECTION_LABEL = "The residence";
 const PANORAMA_JOURNEY_SECTION_LABEL = "The stay";
+const loadPhotoBrowserOverlay = () => import("../../../../../components/gallery/PhotoBrowserOverlay");
+const LazyPhotoBrowserOverlay = lazy(loadPhotoBrowserOverlay);
 
 const hexToRgbChannels = (hexColor) => {
   const normalizedHexColor = resolveWebsiteContactAccentColor(hexColor).slice(1);
@@ -154,6 +155,8 @@ const formatPanoramaAmenityCategory = (value) => {
 };
 
 const resolvePanoramaNavLabel = (value, fallbackLabel) => String(value || "").trim() || fallbackLabel;
+const buildPanoramaDeferredSectionClassName = (baseClassName, shouldDeferContent = false) =>
+  `${baseClassName} ${shouldDeferContent ? styles.panoramaDeferredRenderSection : ""}`.trim();
 
 const getAmenityMatchKey = (amenity) => {
   const normalizedId = String(amenity?.id || "").trim();
@@ -765,6 +768,7 @@ const renderPanoramaGallerySection = ({
   onSelectTarget,
   activeTargetId,
   onOpenGalleryBrowser,
+  shouldDeferContent = false,
 }) => {
   if (gallerySlots.length < 1) {
     return null;
@@ -791,9 +795,12 @@ const renderPanoramaGallerySection = ({
     <section
       id="gallery"
       {...getInteractiveTargetProps(
-        `${styles.panoramaGallerySection} ${
-          showGalleryPanel ? styles.panoramaGallerySectionPanel : ""
-        }`.trim(),
+        buildPanoramaDeferredSectionClassName(
+          `${styles.panoramaGallerySection} ${
+            showGalleryPanel ? styles.panoramaGallerySectionPanel : ""
+          }`.trim(),
+          shouldDeferContent
+        ),
         onSelectTarget,
         {
           sectionId: "gallery",
@@ -867,6 +874,7 @@ const renderPanoramaDetailsSection = ({
   onSelectTarget,
   activeTargetId,
   onShowAllAmenities,
+  shouldDeferContent = false,
 }) => {
   if (!showAmenitiesPanel || featuredAmenities.length < 1) {
     return null;
@@ -875,10 +883,15 @@ const renderPanoramaDetailsSection = ({
   return (
     <section
       id="features"
-      {...getInteractiveTargetProps(styles.panoramaAmenitiesSection, onSelectTarget, {
-        sectionId: "amenities",
-        targetId: "visibility.amenitiesPanel",
-      }, activeTargetId)}
+      {...getInteractiveTargetProps(
+        buildPanoramaDeferredSectionClassName(styles.panoramaAmenitiesSection, shouldDeferContent),
+        onSelectTarget,
+        {
+          sectionId: "amenities",
+          targetId: "visibility.amenitiesPanel",
+        },
+        activeTargetId
+      )}
       {...getScrollRevealProps(120)}
     >
       <div className={styles.panoramaAmenityIntro}>
@@ -951,13 +964,22 @@ const renderPanoramaDetailsSection = ({
   );
 };
 
-const renderPanoramaJourneySection = ({ featuredJourneyStops, onSelectTarget, activeTargetId }) => {
+const renderPanoramaJourneySection = ({
+  featuredJourneyStops,
+  onSelectTarget,
+  activeTargetId,
+  shouldDeferContent = false,
+}) => {
   if (featuredJourneyStops.length < 1) {
     return null;
   }
 
   return (
-    <section id="lifestyle" className={styles.sectionCard} {...getScrollRevealProps(140)}>
+    <section
+      id="lifestyle"
+      className={buildPanoramaDeferredSectionClassName(styles.sectionCard, shouldDeferContent)}
+      {...getScrollRevealProps(140)}
+    >
       <div className={styles.sectionHeading}>
         <p className={styles.sectionEyebrow}>The stay</p>
         <h2>From first impression to arrival, the flow stays easy to follow</h2>
@@ -988,6 +1010,7 @@ const renderPanoramaContactSection = ({
   model,
   onSelectTarget,
   activeTargetId,
+  shouldDeferContent = false,
 }) => {
   const resolvedContactSectionCopy = resolveWebsiteContactSectionCopy(model.contactSection);
   const contactTitle =
@@ -1023,7 +1046,11 @@ const renderPanoramaContactSection = ({
   };
 
   return (
-    <section id="contact" className={styles.panoramaContactShell} {...getScrollRevealProps(180)}>
+    <section
+      id="contact"
+      className={buildPanoramaDeferredSectionClassName(styles.panoramaContactShell, shouldDeferContent)}
+      {...getScrollRevealProps(180)}
+    >
       <div
         {...getPreviewTargetMarkerProps(
           styles.panoramaContactSection,
@@ -1090,6 +1117,8 @@ export default function PanoramaLandingTemplate({ model, onSelectTarget, activeT
   const [isGalleryBrowserOpen, setIsGalleryBrowserOpen] = useState(false);
   const [galleryBrowserInitialIndex, setGalleryBrowserInitialIndex] = useState(0);
   const [isNavDrawerOpen, setIsNavDrawerOpen] = useState(false);
+  const isInteractivePreview = Boolean(onSelectTarget);
+  const shouldDeferBelowFoldSections = !isInteractivePreview;
   const { heroSectionRef, isTopBarSolid } = usePanoramaTopBarSolidState(viewState.showTopBar);
   const navItems = buildPanoramaNavItems(model, viewState);
   const handleOpenGalleryBrowser = (imageIndex = 0) => {
@@ -1099,6 +1128,7 @@ export default function PanoramaLandingTemplate({ model, onSelectTarget, activeT
     const maxGalleryIndex = Math.max(normalizedGalleryImages.length - 1, 0);
     const nextGalleryIndex = Number.isInteger(imageIndex) ? imageIndex : 0;
 
+    void loadPhotoBrowserOverlay();
     setGalleryBrowserInitialIndex(Math.max(0, Math.min(nextGalleryIndex, maxGalleryIndex)));
     setIsGalleryBrowserOpen(true);
   };
@@ -1171,6 +1201,7 @@ export default function PanoramaLandingTemplate({ model, onSelectTarget, activeT
               onSelectTarget,
               activeTargetId,
               onOpenGalleryBrowser: handleOpenGalleryBrowser,
+              shouldDeferContent: shouldDeferBelowFoldSections,
             })
           : null}
         {renderPanoramaDetailsSection({
@@ -1182,16 +1213,25 @@ export default function PanoramaLandingTemplate({ model, onSelectTarget, activeT
           onSelectTarget,
           activeTargetId,
           onShowAllAmenities: () => setShowAmenitiesModal(true),
+          shouldDeferContent: shouldDeferBelowFoldSections,
         })}
         {viewState.showJourneyStops
           ? renderPanoramaJourneySection({
               featuredJourneyStops: viewState.featuredJourneyStops,
               onSelectTarget,
               activeTargetId,
+              shouldDeferContent: shouldDeferBelowFoldSections,
             })
           : null}
         {viewState.showAvailabilityCalendar ? (
-          <section id="availability" className={styles.panoramaAvailabilityShell} {...getScrollRevealProps(160)}>
+          <section
+            id="availability"
+            className={buildPanoramaDeferredSectionClassName(
+              styles.panoramaAvailabilityShell,
+              shouldDeferBelowFoldSections
+            )}
+            {...getScrollRevealProps(160)}
+          >
             <TemplateAvailabilityCalendar
               model={model}
               variant="panorama"
@@ -1208,19 +1248,24 @@ export default function PanoramaLandingTemplate({ model, onSelectTarget, activeT
               model,
               onSelectTarget,
               activeTargetId,
+              shouldDeferContent: shouldDeferBelowFoldSections,
             })
           : null}
       </article>
 
-      <PhotoBrowserOverlay
-        images={Array.isArray(model.media?.galleryImages) ? model.media.galleryImages : []}
-        initialIndex={galleryBrowserInitialIndex}
-        isOpen={isGalleryBrowserOpen}
-        onClose={() => setIsGalleryBrowserOpen(false)}
-        showSideZones={true}
-        alwaysShowSideZoneArrows={true}
-        resolveImageAlt={(index) => `${model.hero.title} gallery image ${index + 1}`}
-      />
+      {isGalleryBrowserOpen ? (
+        <Suspense fallback={null}>
+          <LazyPhotoBrowserOverlay
+            images={Array.isArray(model.media?.galleryImages) ? model.media.galleryImages : []}
+            initialIndex={galleryBrowserInitialIndex}
+            isOpen={isGalleryBrowserOpen}
+            onClose={() => setIsGalleryBrowserOpen(false)}
+            showSideZones={true}
+            alwaysShowSideZoneArrows={true}
+            resolveImageAlt={(index) => `${model.hero.title} gallery image ${index + 1}`}
+          />
+        </Suspense>
+      ) : null}
 
       {showAmenitiesModal && viewState.allAmenities.length > 0 ? (
         <PanoramaAmenitiesModal

--- a/frontend/web/src/features/hostdashboard/website/rendering/templates/PanoramaLandingTemplate.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/templates/PanoramaLandingTemplate.jsx
@@ -613,7 +613,6 @@ const renderPanoramaHeroSection = ({
     className={`${styles.panoramaEditorialHero} ${
       showTopBar ? styles.panoramaEditorialHeroWithTopBar : ""
     }`.trim()}
-    {...getScrollRevealProps(60)}
   >
     <div className={styles.panoramaHeroBackdropShell}>
       <TemplateImageSlotVisual

--- a/frontend/web/src/features/hostdashboard/website/rendering/templates/templatePropTypes.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/templates/templatePropTypes.js
@@ -1,5 +1,14 @@
 import PropTypes from "prop-types";
 
+const responsiveImageAssetPropType = PropTypes.shape({
+  src: PropTypes.string.isRequired,
+  thumbSrc: PropTypes.string,
+  webSrc: PropTypes.string,
+  originalSrc: PropTypes.string,
+  srcSet: PropTypes.string,
+  sizes: PropTypes.string,
+});
+
 export const sitePropType = PropTypes.shape({
   title: PropTypes.string,
 });
@@ -12,8 +21,11 @@ export const heroPropType = PropTypes.shape({
 
 export const mediaPropType = PropTypes.shape({
   heroImage: PropTypes.string,
+  heroImageAsset: responsiveImageAssetPropType,
   residenceImage: PropTypes.string,
+  residenceImageAsset: responsiveImageAssetPropType,
   galleryImages: PropTypes.arrayOf(PropTypes.string),
+  galleryImageAssets: PropTypes.arrayOf(responsiveImageAssetPropType),
   imageRotation: PropTypes.shape({
     hero: PropTypes.bool,
     residence: PropTypes.bool,

--- a/frontend/web/src/features/hostdashboard/website/rendering/templates/templateSharedSections.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/templates/templateSharedSections.jsx
@@ -22,6 +22,23 @@ const buildImageSlotFrameClassName = ({
 const buildImageSlotImageClassName = (imageClassName, enableHoverEffect = false) =>
   `${imageClassName} ${enableHoverEffect ? styles.templateImageHoverImage : ""}`.trim();
 
+const buildImageLoadingProps = ({ slot, imageIndex = 0, isRotationEnabled = false, isInteractivePreview = false }) => {
+  if (isInteractivePreview) {
+    return {
+      decoding: "async",
+    };
+  }
+
+  const isHeroSlot = slot?.kind === "hero";
+  const isLeadHeroImage = isHeroSlot && (!isRotationEnabled || imageIndex === 0);
+
+  return {
+    loading: isLeadHeroImage ? "eager" : "lazy",
+    fetchPriority: isLeadHeroImage ? "high" : "low",
+    decoding: "async",
+  };
+};
+
 export const getInteractiveTargetProps = (
   className,
   onSelectTarget,
@@ -219,6 +236,7 @@ export function TemplateImageSlotVisual({
     imageSequence,
     isRotationEnabled,
   } = useWebsiteImageSlotRotation(slot, model?.media, rotationIntervalMs);
+  const isInteractivePreview = Boolean(onSelectTarget);
   const buildInteractiveProps = (className) =>
     getInteractiveTargetProps(
       className,
@@ -242,6 +260,12 @@ export function TemplateImageSlotVisual({
         {...buildInteractiveProps(imageClassName)}
         src={imageSequence[0]}
         alt={alt}
+        {...buildImageLoadingProps({
+          slot,
+          imageIndex: 0,
+          isRotationEnabled: false,
+          isInteractivePreview,
+        })}
       />
     );
   }
@@ -261,6 +285,12 @@ export function TemplateImageSlotVisual({
           src={imageSequence[0]}
           alt={alt}
           className={buildImageSlotImageClassName(imageClassName, enableHoverEffect)}
+          {...buildImageLoadingProps({
+            slot,
+            imageIndex: 0,
+            isRotationEnabled: false,
+            isInteractivePreview,
+          })}
         />
       </div>
     );
@@ -285,6 +315,12 @@ export function TemplateImageSlotVisual({
           src={imageUrl}
           alt={index === activeImageIndex ? alt : ""}
           aria-hidden={index === activeImageIndex ? undefined : "true"}
+          {...buildImageLoadingProps({
+            slot,
+            imageIndex: index,
+            isRotationEnabled,
+            isInteractivePreview,
+          })}
           className={`${styles.templateRotatingImageLayer} ${buildImageSlotImageClassName(
             "",
             enableHoverEffect

--- a/frontend/web/src/features/hostdashboard/website/rendering/templates/templateSharedSections.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/templates/templateSharedSections.jsx
@@ -39,6 +39,31 @@ const buildImageLoadingProps = ({ slot, imageIndex = 0, isRotationEnabled = fals
   };
 };
 
+const buildResponsiveImageProps = ({
+  slot,
+  model,
+  isRotationEnabled = false,
+  isInteractivePreview = false,
+}) => {
+  if (isInteractivePreview || isRotationEnabled || slot?.kind !== "hero") {
+    return {};
+  }
+
+  const heroImageAsset =
+    model?.media?.heroImageAsset && typeof model.media.heroImageAsset === "object"
+      ? model.media.heroImageAsset
+      : null;
+  const responsiveSrcSet = String(heroImageAsset?.srcSet || "").trim();
+  if (!responsiveSrcSet) {
+    return {};
+  }
+
+  return {
+    srcSet: responsiveSrcSet,
+    sizes: String(heroImageAsset?.sizes || "100vw").trim() || "100vw",
+  };
+};
+
 export const getInteractiveTargetProps = (
   className,
   onSelectTarget,
@@ -260,6 +285,12 @@ export function TemplateImageSlotVisual({
         {...buildInteractiveProps(imageClassName)}
         src={imageSequence[0]}
         alt={alt}
+        {...buildResponsiveImageProps({
+          slot,
+          model,
+          isRotationEnabled: false,
+          isInteractivePreview,
+        })}
         {...buildImageLoadingProps({
           slot,
           imageIndex: 0,
@@ -285,6 +316,12 @@ export function TemplateImageSlotVisual({
           src={imageSequence[0]}
           alt={alt}
           className={buildImageSlotImageClassName(imageClassName, enableHoverEffect)}
+          {...buildResponsiveImageProps({
+            slot,
+            model,
+            isRotationEnabled: false,
+            isInteractivePreview,
+          })}
           {...buildImageLoadingProps({
             slot,
             imageIndex: 0,

--- a/frontend/web/src/features/hostdashboard/website/rendering/templates/templateSharedSections.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/templates/templateSharedSections.jsx
@@ -1,7 +1,6 @@
-import React from "react";
+import React, { Suspense, lazy } from "react";
 import PropTypes from "prop-types";
 import styles from "../WebsiteTemplatePreview.module.scss";
-import AvailabilityCalendarPreview from "../AvailabilityCalendarPreview";
 import {
   buildWebsiteImageSlotTarget,
   useWebsiteImageSlotRotation,
@@ -9,6 +8,7 @@ import {
 
 const DEFAULT_IMAGE_SLOT_ROTATION_INTERVAL_MS = 3600;
 const DEFAULT_IMAGE_SLOT_FADE_DURATION_MS = 720;
+const LazyAvailabilityCalendarPreview = lazy(() => import("../AvailabilityCalendarPreview"));
 
 const buildImageSlotFrameClassName = ({
   frameClassName = "",
@@ -214,19 +214,28 @@ export function TemplateAvailabilityCalendar({
   }, activeTargetId);
 
   return (
-    <AvailabilityCalendarPreview
-      availability={model.availability}
-      calendarSection={model.calendarSection}
-      titleInteractiveTargetProps={titleInteractiveTargetProps}
-      descriptionInteractiveTargetProps={descriptionInteractiveTargetProps}
-      templateKey={templateKey}
-      variant={variant}
-      propertyTitle={propertyTitle}
-      interactiveTargetProps={getInteractiveTargetProps(styles.availabilityCalendarTarget, onSelectTarget, {
-        sectionId: "calendar",
-        targetId: "calendar.visibility",
-      }, activeTargetId)}
-    />
+    <Suspense
+      fallback={
+        <div
+          className={styles.availabilityCalendarDeferredFallback}
+          aria-hidden="true"
+        />
+      }
+    >
+      <LazyAvailabilityCalendarPreview
+        availability={model.availability}
+        calendarSection={model.calendarSection}
+        titleInteractiveTargetProps={titleInteractiveTargetProps}
+        descriptionInteractiveTargetProps={descriptionInteractiveTargetProps}
+        templateKey={templateKey}
+        variant={variant}
+        propertyTitle={propertyTitle}
+        interactiveTargetProps={getInteractiveTargetProps(styles.availabilityCalendarTarget, onSelectTarget, {
+          sectionId: "calendar",
+          targetId: "calendar.visibility",
+        }, activeTargetId)}
+      />
+    </Suspense>
   );
 }
 

--- a/frontend/web/src/features/hostdashboard/website/rendering/websiteDraftContentOverrides.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/websiteDraftContentOverrides.js
@@ -355,6 +355,7 @@ export const createEmptyWebsiteDraftEditorValues = (templateKey = "") => ({
   },
   contact: {
     title: "",
+    caption: "",
     description: "",
     avatarMode: WEBSITE_CONTACT_AVATAR_MODE_HOST,
     avatarImage: "",

--- a/frontend/web/src/features/hostdashboard/website/rendering/websiteDraftContentOverrides.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/websiteDraftContentOverrides.js
@@ -39,6 +39,7 @@ import {
   DEFAULT_WEBSITE_GALLERY_SLOT_COUNT,
   normalizeWebsiteImageRotationSettings,
 } from "./websiteImageSlotUtils";
+import { buildAccommodationImageAssetFromUrl } from "../../../../utils/accommodationImage";
 
 const MANAGED_OVERRIDE_KEYS = Object.freeze([
   "siteTitle",
@@ -133,6 +134,42 @@ const mergeGalleryImages = (baseImages = [], overrideImages = []) => {
     const overrideImage = cleanText(normalizedOverrideImages[index]);
     return overrideImage || baseImage;
   });
+};
+
+const buildMediaImageAssetLookup = (media = {}) => {
+  const imageAssetLookup = new Map();
+  const imageAssets = [
+    media?.heroImageAsset,
+    media?.residenceImageAsset,
+    ...(Array.isArray(media?.galleryImageAssets) ? media.galleryImageAssets : []),
+  ].filter(Boolean);
+
+  imageAssets.forEach((imageAsset) => {
+    [
+      imageAsset?.src,
+      imageAsset?.thumbSrc,
+      imageAsset?.webSrc,
+      imageAsset?.originalSrc,
+    ]
+      .map((value) => cleanText(value))
+      .filter(Boolean)
+      .forEach((imageUrl) => {
+        if (!imageAssetLookup.has(imageUrl)) {
+          imageAssetLookup.set(imageUrl, imageAsset);
+        }
+      });
+  });
+
+  return imageAssetLookup;
+};
+
+const resolveMediaImageAsset = (imageAssetLookup, imageUrl) => {
+  const normalizedImageUrl = cleanText(imageUrl);
+  if (!normalizedImageUrl) {
+    return null;
+  }
+
+  return imageAssetLookup.get(normalizedImageUrl) || buildAccommodationImageAssetFromUrl(normalizedImageUrl);
 };
 
 const mergeImageRotationSettings = (
@@ -434,6 +471,12 @@ export const applyWebsiteDraftContentOverrides = (model, overrides = {}, templat
   const mergedVisibility = mergeVisibility(model?.visibility, overrides.visibility);
   const mergedTrustCards = mergeCopyItems(model?.trustCards, overrides.trustCards);
   const mergedJourneyStops = mergeCopyItems(model?.journeyStops, overrides.journeyStops);
+  const mediaImageAssetLookup = buildMediaImageAssetLookup(model?.media);
+  const nextHeroImage = heroImage || model.media.heroImage;
+  const nextResidenceImage = residenceImage || model?.media?.residenceImage || nextHeroImage;
+  const mergedGalleryImageAssets = mergedGalleryImages
+    .map((imageUrl) => resolveMediaImageAsset(mediaImageAssetLookup, imageUrl))
+    .filter(Boolean);
   const resolvedContactSectionCopy = resolveWebsiteContactSectionCopy(model?.contactSection);
   const modelContactAvatarImage = cleanText(model?.contactSection?.avatarImage);
   const modelContactAvatarMode = resolveWebsiteContactAvatarMode(
@@ -468,9 +511,12 @@ export const applyWebsiteDraftContentOverrides = (model, overrides = {}, templat
     },
     media: {
       ...model.media,
-      heroImage: heroImage || model.media.heroImage,
-      residenceImage: residenceImage || model?.media?.residenceImage || model?.media?.heroImage,
-      galleryImages: mergeGalleryImages(model?.media?.galleryImages, overrides.galleryImages),
+      heroImage: nextHeroImage,
+      heroImageAsset: resolveMediaImageAsset(mediaImageAssetLookup, nextHeroImage),
+      residenceImage: nextResidenceImage,
+      residenceImageAsset: resolveMediaImageAsset(mediaImageAssetLookup, nextResidenceImage),
+      galleryImages: mergedGalleryImages,
+      galleryImageAssets: mergedGalleryImageAssets,
       imageRotation: mergedImageRotation,
       featuredGalleryImages: mergedGalleryImages,
       previewImages: mergedGalleryImages.slice(0, 3),

--- a/frontend/web/src/features/hostdashboard/website/services/websiteSiteService.js
+++ b/frontend/web/src/features/hostdashboard/website/services/websiteSiteService.js
@@ -46,6 +46,19 @@ const normalizeWebsiteSiteSummary = (payload) => {
   };
 };
 
+const tryRecoverPublishedWebsiteSiteSummary = async (propertyId) => {
+  try {
+    const siteSummary = await fetchWebsiteSiteByPropertyId(propertyId);
+    if (siteSummary?.site?.status === "PUBLISHED") {
+      return siteSummary;
+    }
+  } catch {
+    // Fall back to the original publish error when recovery is not possible.
+  }
+
+  return null;
+};
+
 export const fetchWebsiteSiteByPropertyId = async (propertyId) => {
   const normalizedPropertyId = String(propertyId || "").trim();
   if (!normalizedPropertyId) {
@@ -89,6 +102,11 @@ export const publishWebsiteSite = async (propertyId) => {
   });
 
   if (!response.ok) {
+    const recoveredSiteSummary = await tryRecoverPublishedWebsiteSiteSummary(normalizedPropertyId);
+    if (recoveredSiteSummary) {
+      return recoveredSiteSummary;
+    }
+
     const errorMessage = await getApiErrorMessage(
       response,
       "We could not publish the direct booking website for this listing."

--- a/frontend/web/src/utils/accommodationImage.js
+++ b/frontend/web/src/utils/accommodationImage.js
@@ -1,4 +1,6 @@
 export const S3_ACCOMMODATION_URL = "https://accommodation.s3.eu-north-1.amazonaws.com/";
+export const THUMB_ACCOMMODATION_IMAGE_MAX_WIDTH = 600;
+export const WEB_ACCOMMODATION_IMAGE_MAX_WIDTH = 1920;
 
 export const placeholderImage =
   "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='640' height='360'><rect width='100%' height='100%' fill='%23eee'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='%23999' font-family='Arial' font-size='20'>No image</text></svg>";
@@ -15,6 +17,17 @@ const getVariantValue = (image, keys) => {
     }
   }
   return "";
+};
+
+const getVariantWidth = (image, keys, fallbackWidth = null) => {
+  for (const key of keys) {
+    const widthValue = Number(image?.[key]);
+    if (Number.isFinite(widthValue) && widthValue > 0) {
+      return Math.trunc(widthValue);
+    }
+  }
+
+  return fallbackWidth;
 };
 
 export const normalizeImageUrl = (maybeKeyOrUrl) => {
@@ -74,6 +87,76 @@ export const resolveAccommodationImageUrls = (images, preferredVariant = "web") 
     .filter(Boolean)
     .map((imageKey) => normalizeImageUrl(imageKey));
 };
+
+export const buildAccommodationImageAssetFromUrl = (imageUrl) => {
+  const normalizedImageUrl = normalizeKey(imageUrl);
+  if (!normalizedImageUrl) {
+    return null;
+  }
+
+  const src = normalizeImageUrl(normalizedImageUrl);
+  return {
+    src,
+    thumbSrc: "",
+    webSrc: "",
+    originalSrc: src,
+    srcSet: "",
+    sizes: "",
+  };
+};
+
+export const buildAccommodationImageAsset = (image, preferredVariant = "web") => {
+  if (!image) {
+    return null;
+  }
+
+  if (typeof image === "string") {
+    return buildAccommodationImageAssetFromUrl(image);
+  }
+
+  const resolvedImageKey = resolveAccommodationImageKey(image, preferredVariant);
+  if (!resolvedImageKey) {
+    return null;
+  }
+
+  const src = normalizeImageUrl(resolvedImageKey);
+  const thumbKey = getVariantValue(image, ["thumb_key", "thumbKey"]);
+  const webKey = getVariantValue(image, ["web_key", "webKey"]);
+  const originalKey = getVariantValue(image, ["original_key", "originalKey"]);
+  const thumbSrc = thumbKey ? normalizeImageUrl(thumbKey) : "";
+  const webSrc = webKey ? normalizeImageUrl(webKey) : "";
+  const originalSrc = originalKey ? normalizeImageUrl(originalKey) : "";
+  const thumbWidth = getVariantWidth(
+    image,
+    ["thumb_width", "thumbWidth"],
+    thumbSrc ? THUMB_ACCOMMODATION_IMAGE_MAX_WIDTH : null
+  );
+  const webWidth = getVariantWidth(
+    image,
+    ["web_width", "webWidth"],
+    webSrc ? WEB_ACCOMMODATION_IMAGE_MAX_WIDTH : null
+  );
+  const originalWidth = getVariantWidth(image, ["original_width", "originalWidth"]);
+  const srcSetCandidates = [
+    thumbSrc && thumbWidth ? `${thumbSrc} ${thumbWidth}w` : "",
+    webSrc && webWidth ? `${webSrc} ${webWidth}w` : "",
+    originalSrc && originalWidth ? `${originalSrc} ${originalWidth}w` : "",
+  ].filter(Boolean);
+
+  return {
+    src,
+    thumbSrc,
+    webSrc,
+    originalSrc,
+    srcSet: Array.from(new Set(srcSetCandidates)).join(", "),
+    sizes: "100vw",
+  };
+};
+
+export const buildAccommodationImageAssets = (images, preferredVariant = "web") =>
+  (Array.isArray(images) ? images : [])
+    .map((image) => buildAccommodationImageAsset(image, preferredVariant))
+    .filter(Boolean);
 
 export const resolvePrimaryAccommodationImageUrl = (images, preferredVariant = "thumb") => {
   const safeImages = Array.isArray(images) ? images : [];


### PR DESCRIPTION
**Whats new?**

- Increased website performance with priority loading, lazy loading
- Ensured website loading doesnt overlap with header, like it used to do, decreasing the loading time speed
- The public website now renders from the saved snapshot first instead of waiting on all enrichment calls.
- Host profile, WhatsApp, and availability enrichment are deferred until after first paint.
- The Panorama hero is treated as the LCP-critical element with eager, high-priority loading.
- The hero can now use responsive thumb, web, and original image variants when metadata exists.
- Gallery overlay and availability calendar code are lazy-loaded instead of inflating the first bundle.
- Below-the-fold Panorama sections now use deferred rendering on the public runtime.
- Fallback routing for public live-site reachability. Fixes direct link of DBW 

