### PR TITLE
fix(booking): simplify guest calendar availability states

### DIFF
--- a/frontend/web/src/features/bookingengine/listingdetails/pages/listingDetails2.test.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/pages/listingDetails2.test.js
@@ -238,7 +238,7 @@ describe("RangeCalendar effective availability", () => {
     expect(insideWindowDate).not.toBeDisabled();
   });
 
-  test("renders booked dates with booked-specific text and style instead of the unavailable marker", () => {
+  test("renders booked dates with the same unavailable marker and style as other blocked dates", () => {
     renderRangeCalendar({
       bookedDateKeys: ["2026-06-16"],
       unavailableDateKeys: ["2026-06-16"],
@@ -247,10 +247,10 @@ describe("RangeCalendar effective availability", () => {
     const bookedDate = screen.getByRole("button", { name: "June 16, 2026" });
 
     expect(bookedDate).toBeDisabled();
-    expect(bookedDate).toHaveClass("range-calendar__day--booked");
-    expect(bookedDate).not.toHaveClass("range-calendar__day--unavailable");
-    expect(within(bookedDate).getByText("Booked")).toBeInTheDocument();
-    expect(within(bookedDate).queryByText("--")).not.toBeInTheDocument();
+    expect(bookedDate).toHaveClass("range-calendar__day--unavailable");
+    expect(bookedDate).not.toHaveClass("range-calendar__day--booked");
+    expect(within(bookedDate).getByText("--")).toBeInTheDocument();
+    expect(within(bookedDate).queryByText("Booked")).not.toBeInTheDocument();
   });
 
   test("does not mass-disable outside-window dates when available override snapshot is missing", () => {
@@ -292,7 +292,7 @@ describe("RangeCalendar effective availability", () => {
     expect(within(unavailableOverrideDate).getByText("--")).toBeInTheDocument();
   });
 
-  test("booked state has visual priority over explicit available overrides", () => {
+  test("booked dates remain unavailable when an explicit available override exists", () => {
     renderRangeCalendar({
       availableDateKeys: ["2026-06-16"],
       bookedDateKeys: ["2026-06-16"],
@@ -301,12 +301,13 @@ describe("RangeCalendar effective availability", () => {
     const availableOverrideDate = screen.getByRole("button", { name: "June 16, 2026" });
 
     expect(availableOverrideDate).toBeDisabled();
-    expect(availableOverrideDate).toHaveClass("range-calendar__day--booked");
-    expect(within(availableOverrideDate).getByText("Booked")).toBeInTheDocument();
-    expect(within(availableOverrideDate).queryByText("--")).not.toBeInTheDocument();
+    expect(availableOverrideDate).toHaveClass("range-calendar__day--unavailable");
+    expect(availableOverrideDate).not.toHaveClass("range-calendar__day--booked");
+    expect(within(availableOverrideDate).getByText("--")).toBeInTheDocument();
+    expect(within(availableOverrideDate).queryByText("Booked")).not.toBeInTheDocument();
   });
 
-  test("blocks active booking nights as booked and keeps checkout date selectable", () => {
+  test("blocks active booking nights as unavailable and keeps checkout date selectable", () => {
     renderRangeCalendar({
       availabilityRanges: [{ start: 20260619, end: 20260622 }],
       bookedDateKeys: ["2026-06-19", "2026-06-20", "2026-06-21"],
@@ -316,21 +317,23 @@ describe("RangeCalendar effective availability", () => {
     const checkoutDate = screen.getByRole("button", { name: "June 22, 2026" });
 
     expect(firstBookedNight).toBeDisabled();
-    expect(firstBookedNight).toHaveClass("range-calendar__day--booked");
+    expect(firstBookedNight).toHaveClass("range-calendar__day--unavailable");
+    expect(within(firstBookedNight).getByText("--")).toBeInTheDocument();
+    expect(within(firstBookedNight).queryByText("Booked")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "June 20, 2026" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "June 21, 2026" })).toBeDisabled();
     expect(checkoutDate).not.toBeDisabled();
-    expect(checkoutDate).not.toHaveClass("range-calendar__day--booked");
+    expect(checkoutDate).not.toHaveClass("range-calendar__day--unavailable");
     expect(within(checkoutDate).queryByText("Booked")).not.toBeInTheDocument();
   });
 
-  test("shows booked message when selected stay includes booked nights", () => {
+  test("shows the generic unavailable message when selected stay includes booked nights", () => {
     const onRangeChange = renderRangeCalendar({ bookedDateKeys: ["2026-06-16"] });
 
     fireEvent.click(screen.getByRole("button", { name: "June 15, 2026" }));
     fireEvent.click(screen.getByRole("button", { name: "June 18, 2026" }));
 
-    expect(screen.getByRole("alert")).toHaveTextContent("These dates are already booked.");
+    expect(screen.getByRole("alert")).toHaveTextContent("This property has no availability for the selected dates.");
     expect(onRangeChange).toHaveBeenLastCalledWith("2026-06-18", "");
   });
 });

--- a/frontend/web/src/features/bookingengine/listingdetails/styles/RangeCalendar.scss
+++ b/frontend/web/src/features/bookingengine/listingdetails/styles/RangeCalendar.scss
@@ -184,22 +184,6 @@
     }
   }
 
-  &.is-booked {
-    background: #fff1e7;
-    border-color: #c2410c;
-    cursor: not-allowed;
-    flex-direction: column;
-    gap: 2px;
-
-    span {
-      color: #7c2d12;
-    }
-
-    &:hover {
-      background: #fff1e7;
-    }
-  }
-
   &.is-today {
     background: rgba(36, 88, 255, 0.12);
     border-color: rgba(36, 88, 255, 0.45);
@@ -235,14 +219,6 @@
     line-height: 1;
   }
 
-  .rc-cell__booked-mark {
-    color: #9a3412;
-    font-size: 0.68rem;
-    font-weight: 800;
-    line-height: 1;
-    text-transform: uppercase;
-  }
-
   &.is-start span,
   &.is-end span {
     color: var(--rc-text);
@@ -257,15 +233,6 @@
     }
   }
 
-  &.is-booked.is-today {
-    background: #fff1e7;
-    border-color: #c2410c;
-    box-shadow: inset 0 0 0 2px rgba(36, 88, 255, 0.4);
-
-    span {
-      color: #7c2d12;
-    }
-  }
 }
 
 .rc-chevron {

--- a/frontend/web/src/features/bookingengine/listingdetails/views/RangeCalendar.jsx
+++ b/frontend/web/src/features/bookingengine/listingdetails/views/RangeCalendar.jsx
@@ -11,7 +11,6 @@ import {
 } from "../utils/dateAvailability";
 import "../styles/RangeCalendar.scss";
 
-const BOOKED_MESSAGE = "These dates are already booked.";
 const NO_AVAILABILITY_MESSAGE = "This property has no availability for the selected dates.";
 const makeDate = (year, month, day) => new Date(year, month, day);
 const addMonths = (date, offset) => makeDate(date.getFullYear(), date.getMonth() + offset, 1);
@@ -70,7 +69,6 @@ function MonthGrid({
             externalBlockedDateKeys,
           })
         : DATE_AVAILABILITY_REASONS.AVAILABLE;
-      const isBooked = availabilityReason === DATE_AVAILABILITY_REASONS.BOOKED;
       const isExternalBlocked = availabilityReason === DATE_AVAILABILITY_REASONS.EXTERNAL_BLOCKED;
       const isOutsideWindow = availabilityReason === DATE_AVAILABILITY_REASONS.OUTSIDE_WINDOW;
       const isUnavailableOverride = availabilityReason === DATE_AVAILABILITY_REASONS.UNAVAILABLE_OVERRIDE;
@@ -87,7 +85,6 @@ function MonthGrid({
         isStart,
         isEnd,
         isUnavailable,
-        isBooked,
         isExternalBlocked,
         isOutsideWindow,
         isUnavailableOverride,
@@ -145,8 +142,7 @@ function MonthGrid({
               type="button"
               className={[
                 "rc-cell rc-cell--day",
-                cell.isUnavailable && !cell.isBooked && "is-unavailable range-calendar__day--unavailable",
-                cell.isBooked && "is-booked range-calendar__day--booked",
+                cell.isUnavailable && "is-unavailable range-calendar__day--unavailable",
                 cell.isExternalBlocked && "range-calendar__day--external-blocked",
                 cell.isOutsideWindow && "range-calendar__day--outside-window",
                 cell.isUnavailableOverride && "range-calendar__day--unavailable-override",
@@ -162,8 +158,7 @@ function MonthGrid({
               onClick={() => onPick(cell.date)}
             >
               <span>{cell.date.getDate()}</span>
-              {cell.isBooked ? <span className="rc-cell__booked-mark">Booked</span> : null}
-              {cell.isUnavailable && !cell.isBooked ? (
+              {cell.isUnavailable ? (
                 <span className="rc-cell__unavailable-mark" aria-hidden="true">--</span>
               ) : null}
             </button>
@@ -247,9 +242,7 @@ export default function RangeCalendar({
     const key = toDateKey(date);
     const availabilityReason = getDateAvailabilityReason(date, blockedDateKeys, availabilityContext);
     if (availabilityReason !== DATE_AVAILABILITY_REASONS.AVAILABLE) {
-      setSelectionError(
-        availabilityReason === DATE_AVAILABILITY_REASONS.BOOKED ? BOOKED_MESSAGE : NO_AVAILABILITY_MESSAGE
-      );
+      setSelectionError(NO_AVAILABILITY_MESSAGE);
       return;
     }
     setSelectionError("");
@@ -267,7 +260,7 @@ export default function RangeCalendar({
 
     const rangeIssue = getStayRangeAvailabilityIssue(nextStart, nextEnd, blockedDateKeys, availabilityContext);
     if (rangeIssue) {
-      setSelectionError(rangeIssue === DATE_AVAILABILITY_REASONS.BOOKED ? BOOKED_MESSAGE : NO_AVAILABILITY_MESSAGE);
+      setSelectionError(NO_AVAILABILITY_MESSAGE);
       setDraftStart(date);
       onRangeChange(key, "");
       return;

--- a/frontend/web/src/features/bookingengine/listingdetails/views/bookingContainer.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/views/bookingContainer.js
@@ -6,9 +6,6 @@ import Pricing from "../components/pricing";
 import useHandleReservePress from "../hooks/handleReservePress";
 import {
   buildUnavailableDateSet,
-  DATE_AVAILABILITY_REASONS,
-  getDateAvailabilityReason,
-  getStayRangeAvailabilityIssue,
   hasUnavailableDateInStayRange,
   isUnavailableDate,
 } from "../utils/dateAvailability";
@@ -26,7 +23,6 @@ import ChatScreen from "../../../../components/messages/ChatScreen";
 import "../../../../components/messages/messagesV2.scss";
 
 const UNIFIED_MESSAGING_API = "https://54s3llwby8.execute-api.eu-north-1.amazonaws.com/default";
-const BOOKED_MESSAGE = "These dates are already booked.";
 const NO_AVAILABILITY_MESSAGE = "This property has no availability for the selected dates.";
 
 const MessageHostModalInner = ({ onClose, hostId, hostName, hostImage, propertyId }) => {
@@ -283,9 +279,8 @@ const BookingContainer = ({
       return;
     }
 
-    const availabilityReason = getDateAvailabilityReason(value, unavailableDateSet, availabilityContext);
-    if (availabilityReason !== DATE_AVAILABILITY_REASONS.AVAILABLE) {
-      alert(availabilityReason === DATE_AVAILABILITY_REASONS.BOOKED ? BOOKED_MESSAGE : NO_AVAILABILITY_MESSAGE);
+    if (isUnavailableDate(value, unavailableDateSet, availabilityContext)) {
+      alert(NO_AVAILABILITY_MESSAGE);
       return;
     }
 
@@ -294,10 +289,8 @@ const BookingContainer = ({
       return;
     }
 
-    const rangeIssue =
-      checkOutDate && getStayRangeAvailabilityIssue(value, checkOutDate, unavailableDateSet, availabilityContext);
-    if (rangeIssue) {
-      alert(rangeIssue === DATE_AVAILABILITY_REASONS.BOOKED ? BOOKED_MESSAGE : NO_AVAILABILITY_MESSAGE);
+    if (checkOutDate && hasUnavailableDateInStayRange(value, checkOutDate, unavailableDateSet, availabilityContext)) {
+      alert(NO_AVAILABILITY_MESSAGE);
       return;
     }
 
@@ -320,9 +313,8 @@ const BookingContainer = ({
       return;
     }
 
-    const rangeIssue = getStayRangeAvailabilityIssue(checkInDate, value, unavailableDateSet, availabilityContext);
-    if (rangeIssue) {
-      alert(rangeIssue === DATE_AVAILABILITY_REASONS.BOOKED ? BOOKED_MESSAGE : NO_AVAILABILITY_MESSAGE);
+    if (hasUnavailableDateInStayRange(checkInDate, value, unavailableDateSet, availabilityContext)) {
+      alert(NO_AVAILABILITY_MESSAGE);
       return;
     }
 

--- a/frontend/web/src/features/bookingengine/tests/BookingContainer.test.js
+++ b/frontend/web/src/features/bookingengine/tests/BookingContainer.test.js
@@ -11,12 +11,6 @@ jest.mock("../listingdetails/components/pricing", () => () => <div>Pricing</div>
 jest.mock("../listingdetails/hooks/handleReservePress", () => () => mockReservePress);
 jest.mock("../listingdetails/utils/dateAvailability", () => ({
   buildUnavailableDateSet: () => new Set(),
-  DATE_AVAILABILITY_REASONS: {
-    AVAILABLE: "available",
-    BOOKED: "booked",
-  },
-  getDateAvailabilityReason: () => "available",
-  getStayRangeAvailabilityIssue: () => null,
   hasUnavailableDateInStayRange: () => false,
   isUnavailableDate: () => false,
 }));


### PR DESCRIPTION
## Close or Relate the Issue

* Related Issue: #

## Proposed Changes

Description:

Simplified the public guest listing calendar to use only two visible availability states:

* Available
* Unavailable / greyed out

Booked dates now use the same greyed-out unavailable UI as outside-window, unavailable override, and blocked dates. The separate `Booked` guest-calendar status was removed from the public listing page.

This change only affects the guest booking/listing calendar UI. Backend booking validation, Channex sync, Full Sync, polling/import logic, and host availability screens are unchanged.

## Change Type

* [x] Bug fix
* [ ] New feature
* [ ] Optimization
* [ ] Documentation update

## Change Size

* [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [[Refactoring](https://chatgpt.com/g/g-p-697f7ff03c808191b0c04598bc66b5c0/c/6a06ea98-e38c-8386-88d5-1ccaf8a0cabb#Refactoring)](#Refactoring))
* [ ] Big change (+-max 1000)
* [x] Small change (less than 300)

## Refactoring

No refactoring-only files.

## Evidence

* [ ] Screenshots or screen recording added for UI changes
* [ ] Before/after images added when relevant
* [ ] Images clearly show the implemented change
* [ ] Image quality is readable (no cropped or blurry evidence)

## Responsiveness

* [ ] UI checked on mobile
* [ ] UI checked on tablet
* [x] UI checked on desktop
* [x] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages

* [ ] NPM Packages installed
* [ ] NPM Packages removed
* [ ] NPM Packages updated
* [ ] Checked for vulnerabilities using "npm audit"

## Checklist

* [ ] Pull request has at least 2 reviewers assigned
* [x] PR title is descriptive and includes issue number
* [x] Conventions

  * [x] No config files have been added (Amplify config, cache files)
  * [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  * [x] No global styling (see [[#1691](https://github.com/domits1/Domits/issues/1691)](https://github.com/domits1/Domits/issues/1691))
  * [x] No `console.log` left in code
  * [x] No commented-out code remains
* [x] Testing

  * [x] Code tested locally
  * [x] Jest tests are included
  * [x] Jest tests are passing

## Keep or delete my branch

* [x] Delete my branch after merge
* [ ] Keep my branch