### PR TITLE
feat(#2297): PriceLabs apply/ignore price suggestions with calendar badges and persisted state

### DIFF
--- a/backend/ORM/migrations/20260609_property_calendar_override_pricelabs_ignored.js
+++ b/backend/ORM/migrations/20260609_property_calendar_override_pricelabs_ignored.js
@@ -1,9 +1,25 @@
-export const up = `
-  ALTER TABLE main.property_calendar_override
-    ADD COLUMN IF NOT EXISTS pricelabs_ignored BOOLEAN NOT NULL DEFAULT FALSE;
-`;
+export class PropertyCalendarOverridePriceLabsIgnored20260609 {
+  async up(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE main.property_calendar_override
+      ADD COLUMN IF NOT EXISTS pricelabs_ignored BOOLEAN;
+    `);
 
-export const down = `
-  ALTER TABLE main.property_calendar_override
-    DROP COLUMN IF EXISTS pricelabs_ignored;
-`;
+    await queryRunner.query(`
+      ALTER TABLE test.property_calendar_override
+      ADD COLUMN IF NOT EXISTS pricelabs_ignored BOOLEAN;
+    `);
+  }
+
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE main.property_calendar_override
+      DROP COLUMN IF EXISTS pricelabs_ignored;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE test.property_calendar_override
+      DROP COLUMN IF EXISTS pricelabs_ignored;
+    `);
+  }
+}

--- a/backend/ORM/models/Property_Calendar_Override.js
+++ b/backend/ORM/models/Property_Calendar_Override.js
@@ -33,8 +33,7 @@ export const Property_Calendar_Override = new EntitySchema({
     },
     pricelabs_ignored: {
       type: "boolean",
-      nullable: false,
-      default: false,
+      nullable: true,
     },
     stop_sell: {
       type: "boolean",

--- a/backend/functions/PriceLabs-Integration/business/service/priceLabsService.js
+++ b/backend/functions/PriceLabs-Integration/business/service/priceLabsService.js
@@ -122,7 +122,7 @@ export class PriceLabsService {
           currency: "EUR",
         },
       },
-      ota_listing_ids: {},
+      ota_listing_ids: otaMap[p.id] || {},
     }));
 
     await api.pushListings(token, name, listings);

--- a/backend/functions/PriceLabs-Integration/business/service/priceLabsService.js
+++ b/backend/functions/PriceLabs-Integration/business/service/priceLabsService.js
@@ -291,16 +291,16 @@ export class PriceLabsService {
       const parts = listing_id.split("_");
       const propertyId = parts.slice(5).join("-");
 
-      for (const entry of entries) {
-        await this.repo.applyPriceRecommendation({
-          property_id:         propertyId,
+      await this.repo.applyPriceRecommendations(
+        propertyId,
+        entries.map((entry) => ({
           date:                entry.date,
           nightly_price:       entry.price,
           min_stay:            entry.min_stay,
           closed_to_arrival:   entry.check_in  === false,
           closed_to_departure: entry.check_out === false,
-        });
-      }
+        }))
+      );
     }
 
     return { success: true };

--- a/backend/functions/PriceLabs-Integration/data/repository.js
+++ b/backend/functions/PriceLabs-Integration/data/repository.js
@@ -118,39 +118,70 @@ export class Repository {
   }
 
 
-  async applyPriceRecommendation({ property_id, date, nightly_price, min_stay, closed_to_arrival, closed_to_departure }) {
+  /**
+   * Batch variant of the old applyPriceRecommendation. The PriceLabs sync webhook
+   * pushes 12-18 months of prices per listing; writing those one date at a time
+   * (SELECT + UPDATE per date) exceeded the Lambda timeout. This writes them with
+   * one SELECT and chunked multi-row upserts instead.
+   */
+  async applyPriceRecommendations(property_id, items) {
     const ds = await this._ds();
     const repo = ds.getRepository(Property_Calendar_Override);
 
-    const calendarDate = Number(String(date ?? "").replaceAll("-", ""));
-    if (!calendarDate || calendarDate < 10000101 || calendarDate > 99991231) {
-      return;
+    const normalized = [];
+    for (const item of Array.isArray(items) ? items : []) {
+      const calendarDate = Number(String(item.date ?? "").replaceAll("-", ""));
+      if (!calendarDate || calendarDate < 10000101 || calendarDate > 99991231) {
+        continue;
+      }
+      normalized.push({ ...item, calendar_date: calendarDate });
     }
+    if (!normalized.length) return;
 
-    const existing = await repo.findOne({
-      where: { property_id, calendar_date: calendarDate },
+    const dates = normalized.map((n) => n.calendar_date);
+    const existingRows = await repo.createQueryBuilder("cal")
+      .where("cal.property_id = :property_id", { property_id })
+      .andWhere("cal.calendar_date IN (:...dates)", { dates })
+      .getMany();
+    const existingByDate = new Map(existingRows.map((row) => [Number(row.calendar_date), row]));
+
+    const now = Date.now();
+    const rows = normalized.map((n) => {
+      const existing = existingByDate.get(n.calendar_date);
+      if (existing) {
+        return {
+          property_id,
+          calendar_date:       n.calendar_date,
+          pricelabs_price:     n.nightly_price ?? existing.pricelabs_price,
+          pricelabs_ignored:   false,
+          min_stay:            n.min_stay ?? existing.min_stay,
+          closed_to_arrival:   n.closed_to_arrival   ?? existing.closed_to_arrival,
+          closed_to_departure: n.closed_to_departure ?? existing.closed_to_departure,
+          updated_at:          now,
+        };
+      }
+      return {
+        property_id,
+        calendar_date:       n.calendar_date,
+        pricelabs_price:     n.nightly_price,
+        pricelabs_ignored:   false,
+        min_stay:            n.min_stay || 1,
+        closed_to_arrival:   n.closed_to_arrival   || false,
+        closed_to_departure: n.closed_to_departure || false,
+        updated_at:          now,
+      };
     });
 
-    if (existing) {
-      await repo.update({ property_id, calendar_date: calendarDate }, {
-        pricelabs_price:     nightly_price ?? existing.pricelabs_price,
-        pricelabs_ignored:   false,
-        min_stay:            min_stay       ?? existing.min_stay,
-        closed_to_arrival:   closed_to_arrival   ?? existing.closed_to_arrival,
-        closed_to_departure: closed_to_departure ?? existing.closed_to_departure,
-        updated_at:          Date.now(),
-      });
-    } else {
-      await repo.save(repo.create({
-        property_id,
-        calendar_date:       calendarDate,
-        pricelabs_price:     nightly_price,
-        pricelabs_ignored:   false,
-        min_stay:            min_stay || 1,
-        closed_to_arrival:   closed_to_arrival   || false,
-        closed_to_departure: closed_to_departure || false,
-        updated_at:          Date.now(),
-      }));
+    const CHUNK_SIZE = 250;
+    for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
+      await repo.createQueryBuilder()
+        .insert()
+        .values(rows.slice(i, i + CHUNK_SIZE))
+        .orUpdate(
+          ["pricelabs_price", "pricelabs_ignored", "min_stay", "closed_to_arrival", "closed_to_departure", "updated_at"],
+          ["property_id", "calendar_date"]
+        )
+        .execute();
     }
   }
 

--- a/backend/functions/PriceLabs-Integration/data/repository.js
+++ b/backend/functions/PriceLabs-Integration/data/repository.js
@@ -55,7 +55,9 @@ export class Repository {
       await repo.createQueryBuilder()
         .update()
         .set({
+          nightly_price:       () => "CASE WHEN nightly_price = pricelabs_price THEN NULL ELSE nightly_price END",
           pricelabs_price:     null,
+          pricelabs_ignored:   false,
           min_stay:            null,
           closed_to_arrival:   null,
           closed_to_departure: null,
@@ -132,6 +134,7 @@ export class Repository {
     if (existing) {
       await repo.update({ property_id, calendar_date: calendarDate }, {
         pricelabs_price:     nightly_price ?? existing.pricelabs_price,
+        pricelabs_ignored:   false,
         min_stay:            min_stay       ?? existing.min_stay,
         closed_to_arrival:   closed_to_arrival   ?? existing.closed_to_arrival,
         closed_to_departure: closed_to_departure ?? existing.closed_to_departure,
@@ -142,6 +145,7 @@ export class Repository {
         property_id,
         calendar_date:       calendarDate,
         pricelabs_price:     nightly_price,
+        pricelabs_ignored:   false,
         min_stay:            min_stay || 1,
         closed_to_arrival:   closed_to_arrival   || false,
         closed_to_departure: closed_to_departure || false,

--- a/backend/functions/PriceLabs-Integration/data/repository.js
+++ b/backend/functions/PriceLabs-Integration/data/repository.js
@@ -5,6 +5,7 @@ import { Property_Location } from "database/models/Property_Location";
 import { Property_Calendar_Override } from "database/models/Property_Calendar_Override";
 import { Booking } from "database/models/Booking";
 import { ChannelIntegrationProperty } from "database/models/unified/integrations/ChannelIntegrationProperty";
+import { ChannelIntegrationAccount } from "database/models/unified/integrations/ChannelIntegrationAccount";
 import { ChannelReservationLink } from "database/models/unified/integrations/ChannelReservationLink";
 
 export class Repository {
@@ -186,6 +187,10 @@ export class Repository {
   }
 
 
+  /**
+   * Returns a map of propertyId → ota_listing_ids in the shape PriceLabs expects:
+   * { airbnb: { id }, bookingcom: { id }, vrbo: { id }, other: { <channel>: { id } } }
+   */
   async getOtaListingIdsByHost(hostId) {
     const ds = await this._ds();
 
@@ -196,17 +201,31 @@ export class Repository {
     const propertyIds = properties.map((p) => p.id);
     if (!propertyIds.length) return {};
 
-    const links = await ds
+    const rows = await ds
       .getRepository(ChannelIntegrationProperty)
       .createQueryBuilder("cip")
+      .innerJoin(ChannelIntegrationAccount, "acc", "acc.id = cip.integrationAccountId")
+      .select("cip.domitsPropertyId", "domitsPropertyId")
+      .addSelect("cip.externalPropertyId", "externalPropertyId")
+      .addSelect("acc.channel", "channel")
       .where("cip.domitsPropertyId IN (:...ids)", { ids: propertyIds })
       .andWhere("cip.status = :status", { status: "active" })
-      .getMany();
+      .getRawMany();
+
+    const KNOWN_CHANNELS = { airbnb: "airbnb", bookingcom: "bookingcom", vrbo: "vrbo" };
 
     const map = {};
-    for (const link of links) {
-      if (!map[link.domitsPropertyId]) map[link.domitsPropertyId] = [];
-      map[link.domitsPropertyId].push(link.externalPropertyId);
+    for (const row of rows) {
+      const normalized = String(row.channel || "").toLowerCase().replaceAll(/[^a-z]/g, "");
+      const key = KNOWN_CHANNELS[normalized];
+      if (!map[row.domitsPropertyId]) map[row.domitsPropertyId] = {};
+      const entry = { id: String(row.externalPropertyId) };
+      if (key) {
+        map[row.domitsPropertyId][key] = entry;
+      } else {
+        if (!map[row.domitsPropertyId].other) map[row.domitsPropertyId].other = {};
+        map[row.domitsPropertyId].other[normalized || "unknown"] = entry;
+      }
     }
     return map;
   }

--- a/backend/functions/PropertyHandler/controller/propertyController.js
+++ b/backend/functions/PropertyHandler/controller/propertyController.js
@@ -1139,12 +1139,17 @@ export class PropertyController {
                             "maxStay"
                         );
 
+                        const priceLabsIgnoredRaw = entry.priceLabsIgnored ?? entry.pricelabs_ignored;
+                        const priceLabsIgnored = priceLabsIgnoredRaw === null || priceLabsIgnoredRaw === undefined
+                            ? null : Boolean(priceLabsIgnoredRaw);
+
                         return [
                             calendarDate,
                             {
                                 calendarDate,
                                 isAvailable,
                                 nightlyPrice,
+                                priceLabsIgnored,
                                 stopSell,
                                 closedToArrival,
                                 closedToDeparture,

--- a/backend/functions/PropertyHandler/data/repository/propertyCalendarOverrideRepository.js
+++ b/backend/functions/PropertyHandler/data/repository/propertyCalendarOverrideRepository.js
@@ -108,6 +108,7 @@ const mapRowToOverride = (row) => ({
     row?.pricelabs_price === null || row?.pricelabs_price === undefined
       ? null
       : toInteger(row.pricelabs_price),
+  priceLabsIgnored: Boolean(row?.pricelabs_ignored ?? false),
   stopSell:
     row?.stop_sell === null || row?.stop_sell === undefined
       ? null
@@ -164,6 +165,7 @@ export class PropertyCalendarOverrideRepository {
             is_available,
             nightly_price,
             pricelabs_price,
+            pricelabs_ignored,
             stop_sell,
             closed_to_arrival,
             closed_to_departure,
@@ -226,6 +228,7 @@ export class PropertyCalendarOverrideRepository {
                 calendarDate,
                 isAvailable: normalizeOptionalAvailability(override?.isAvailable),
                 nightlyPrice: normalizeOptionalPrice(override?.nightlyPrice),
+                priceLabsIgnored: override?.priceLabsIgnored ?? override?.pricelabs_ignored ?? null,
                 stopSell: normalizeOptionalAvailability(override?.stopSell),
                 closedToArrival: normalizeOptionalAvailability(override?.closedToArrival),
                 closedToDeparture: normalizeOptionalAvailability(override?.closedToDeparture),
@@ -255,6 +258,7 @@ export class PropertyCalendarOverrideRepository {
           if (
             override.isAvailable === null &&
             override.nightlyPrice === null &&
+            override.priceLabsIgnored === null &&
             override.stopSell === null &&
             override.closedToArrival === null &&
             override.closedToDeparture === null &&
@@ -279,6 +283,7 @@ export class PropertyCalendarOverrideRepository {
                   calendar_date,
                   is_available,
                   nightly_price,
+                  pricelabs_ignored,
                   stop_sell,
                   closed_to_arrival,
                   closed_to_departure,
@@ -287,11 +292,12 @@ export class PropertyCalendarOverrideRepository {
                   updated_at
                 )
               VALUES
-                ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+                ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
               ON CONFLICT (property_id, calendar_date)
               DO UPDATE SET
                 is_available = EXCLUDED.is_available,
                 nightly_price = EXCLUDED.nightly_price,
+                pricelabs_ignored = COALESCE(EXCLUDED.pricelabs_ignored, "property_calendar_override".pricelabs_ignored),
                 stop_sell = EXCLUDED.stop_sell,
                 closed_to_arrival = EXCLUDED.closed_to_arrival,
                 closed_to_departure = EXCLUDED.closed_to_departure,
@@ -304,6 +310,7 @@ export class PropertyCalendarOverrideRepository {
               override.calendarDate,
               override.isAvailable,
               override.nightlyPrice,
+              override.priceLabsIgnored ?? null,
               override.stopSell,
               override.closedToArrival,
               override.closedToDeparture,

--- a/backend/test/PropertyHandler/calendar-overrides-unit.test.js
+++ b/backend/test/PropertyHandler/calendar-overrides-unit.test.js
@@ -70,6 +70,7 @@ describe("PropertyController calendar override normalization", () => {
       calendarDate: 20260501,
       isAvailable: false,
       nightlyPrice: 125,
+      priceLabsIgnored: null,
       stopSell: true,
       closedToArrival: true,
       closedToDeparture: false,

--- a/frontend/web/src/features/hostdashboard/hostcalen/HostCalendar.jsx
+++ b/frontend/web/src/features/hostdashboard/hostcalen/HostCalendar.jsx
@@ -209,6 +209,8 @@ function HostCalendarSidebar({
   priceLabsSyncAll,
   priceOverrides,
   priceLabsOverrides,
+  priceLabsApplied,
+  priceLabsIgnored,
   onApplyPriceLabsPrice,
   onIgnorePriceLabsPrice,
   selectedDateKeys,
@@ -292,6 +294,17 @@ function HostCalendarSidebar({
     );
   }
 
+  if (sidebarMode === "pricelabs" && !priceLabsConnected) {
+    return (
+      <PriceLabsConnect
+        onConnect={async (email) => { await priceLabsConnect(email); setSidebarMode("summary"); }}
+        isLoading={false}
+        error={null}
+        successMessage={null}
+      />
+    );
+  }
+
   if (selectedDateKeys.length > 0) {
     return (
       <>
@@ -315,6 +328,8 @@ function HostCalendarSidebar({
           isConnected={priceLabsConnected}
           selectedDateKeys={selectedDateKeys}
           priceLabsOverrides={priceLabsOverrides}
+          priceLabsApplied={priceLabsApplied}
+          priceLabsIgnored={priceLabsIgnored}
           onApplyPrice={onApplyPriceLabsPrice}
           onIgnorePrice={onIgnorePriceLabsPrice}
           onOpenSettings={() => setSidebarMode("pricelabs")}
@@ -497,6 +512,8 @@ function HostCalendarSidebar({
         isConnected={priceLabsConnected}
         selectedDateKeys={selectedDateKeys}
         priceLabsOverrides={priceLabsOverrides}
+        priceLabsApplied={priceLabsApplied}
+        priceLabsIgnored={priceLabsIgnored}
         onApplyPrice={onApplyPriceLabsPrice}
         onIgnorePrice={onIgnorePriceLabsPrice}
         onOpenSettings={() => setSidebarMode("pricelabs")}
@@ -515,6 +532,8 @@ HostCalendarSidebar.propTypes = {
   priceLabsSyncAll: PropTypes.func,
   priceOverrides: PropTypes.objectOf(PropTypes.number),
   priceLabsOverrides: PropTypes.objectOf(PropTypes.number),
+  priceLabsApplied: PropTypes.object,
+  priceLabsIgnored: PropTypes.object,
   onApplyPriceLabsPrice: PropTypes.func,
   onIgnorePriceLabsPrice: PropTypes.func,
   selectedDateKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -670,6 +689,8 @@ export default function HostCalendar() {
     restrictionOverrides,
     selectedPropertyPriceOverrides,
     selectedPropertyPriceLabsOverrides,
+    selectedPropertyPriceLabsApplied,
+    selectedPropertyPriceLabsIgnored,
     selectedDateKeys,
     pendingSelectionStartKey,
     bookedDateKeys,
@@ -848,7 +869,9 @@ export default function HostCalendar() {
             availabilityOverrides={availabilityOverrides}
             restrictionOverrides={restrictionOverrides}
             priceOverrides={selectedPropertyPriceOverrides}
-            priceLabsOverrides={selectedPropertyPriceLabsOverrides}
+            priceLabsOverrides={priceLabsConnected ? selectedPropertyPriceLabsOverrides : {}}
+            priceLabsApplied={priceLabsConnected ? selectedPropertyPriceLabsApplied : {}}
+            priceLabsIgnored={priceLabsConnected ? selectedPropertyPriceLabsIgnored : {}}
             bookedDateKeys={bookedDateKeys}
             onDateSelect={handleCalendarDateSelect}
           />
@@ -865,6 +888,8 @@ export default function HostCalendar() {
             priceLabsSyncAll={priceLabsSyncAll}
             priceOverrides={selectedPropertyPriceOverrides}
             priceLabsOverrides={selectedPropertyPriceLabsOverrides}
+            priceLabsApplied={selectedPropertyPriceLabsApplied}
+            priceLabsIgnored={selectedPropertyPriceLabsIgnored}
             onApplyPriceLabsPrice={handleApplyPriceLabsPrice}
             onIgnorePriceLabsPrice={handleIgnorePriceLabsPrice}
             selectedDateKeys={selectedDateKeys}

--- a/frontend/web/src/features/hostdashboard/hostcalen/HostCalendar.jsx
+++ b/frontend/web/src/features/hostdashboard/hostcalen/HostCalendar.jsx
@@ -213,6 +213,7 @@ function HostCalendarSidebar({
   priceLabsIgnored,
   onApplyPriceLabsPrice,
   onIgnorePriceLabsPrice,
+  onUndoPriceLabsPrice,
   selectedDateKeys,
   selectedAvailabilityStats,
   handleToggleAvailability,
@@ -287,7 +288,7 @@ function HostCalendarSidebar({
       <PriceLabsStatusCard
         status={priceLabsStatus}
         onSync={priceLabsSyncAll}
-        onDisconnect={() => { priceLabsDisconnect(); setSidebarMode("summary"); }}
+        onDisconnect={async () => { await priceLabsDisconnect(); setSidebarMode("summary"); }}
         isSyncing={false}
         isLoading={false}
       />
@@ -332,6 +333,7 @@ function HostCalendarSidebar({
           priceLabsIgnored={priceLabsIgnored}
           onApplyPrice={onApplyPriceLabsPrice}
           onIgnorePrice={onIgnorePriceLabsPrice}
+          onUndoPrice={onUndoPriceLabsPrice}
           onOpenSettings={() => setSidebarMode("pricelabs")}
         />
       </>
@@ -516,6 +518,7 @@ function HostCalendarSidebar({
         priceLabsIgnored={priceLabsIgnored}
         onApplyPrice={onApplyPriceLabsPrice}
         onIgnorePrice={onIgnorePriceLabsPrice}
+        onUndoPrice={onUndoPriceLabsPrice}
         onOpenSettings={() => setSidebarMode("pricelabs")}
       />
     </>
@@ -536,6 +539,7 @@ HostCalendarSidebar.propTypes = {
   priceLabsIgnored: PropTypes.object,
   onApplyPriceLabsPrice: PropTypes.func,
   onIgnorePriceLabsPrice: PropTypes.func,
+  onUndoPriceLabsPrice: PropTypes.func,
   selectedDateKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
   selectedAvailabilityStats: selectedAvailabilityStatsShape.isRequired,
   handleToggleAvailability: PropTypes.func.isRequired,
@@ -708,6 +712,7 @@ export default function HostCalendar() {
     handleSaveSelectionPrice,
     handleApplyPriceLabsSuggestion,
     handleIgnorePriceLabsSuggestion,
+    handleUndoPriceLabsSuggestion,
     handleSelectionRestrictionChange,
     handleSaveSelectionRestrictions,
     reloadOverrides,
@@ -793,6 +798,10 @@ export default function HostCalendar() {
 
   const handleIgnorePriceLabsPrice = (dateKeys) => {
     handleIgnorePriceLabsSuggestion(dateKeys);
+  };
+
+  const handleUndoPriceLabsPrice = (dateKeys) => {
+    handleUndoPriceLabsSuggestion(dateKeys);
   };
 
   const handlePriceLabsDisconnect = async () => {
@@ -892,6 +901,7 @@ export default function HostCalendar() {
             priceLabsIgnored={selectedPropertyPriceLabsIgnored}
             onApplyPriceLabsPrice={handleApplyPriceLabsPrice}
             onIgnorePriceLabsPrice={handleIgnorePriceLabsPrice}
+            onUndoPriceLabsPrice={handleUndoPriceLabsPrice}
             selectedDateKeys={selectedDateKeys}
             selectedAvailabilityStats={selectedAvailabilityStats}
             handleToggleAvailability={handleToggleAvailability}

--- a/frontend/web/src/features/hostdashboard/hostcalen/HostCalendar.scss
+++ b/frontend/web/src/features/hostdashboard/hostcalen/HostCalendar.scss
@@ -752,6 +752,48 @@ $accent: #2f6fed;
   white-space: nowrap;
 }
 
+.hc-cell-pricelabs-applied {
+  position: relative;
+  z-index: 2;
+  display: inline-block;
+  margin-top: 3px;
+  border: 1px solid #166534;
+  border-radius: 4px;
+  background: #166534;
+  color: #fff;
+  padding: 2px 4px;
+  font-size: 10px;
+  line-height: 1.05;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.hc-cell-pricelabs-ignored {
+  position: relative;
+  z-index: 2;
+  display: inline-block;
+  margin-top: 3px;
+  border: 1px solid #9ca3af;
+  border-radius: 4px;
+  background: #f3f4f6;
+  color: #6b7280;
+  padding: 2px 4px;
+  font-size: 10px;
+  line-height: 1.05;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.hc-info-card-line--applied {
+  color: #166534;
+  font-weight: 600;
+}
+
+.hc-info-card-line--ignored {
+  color: #b71c1c;
+  font-weight: 600;
+}
+
 .hc-cell-badge {
   position: absolute;
   top: 6px;

--- a/frontend/web/src/features/hostdashboard/hostcalen/HostCalendar.scss
+++ b/frontend/web/src/features/hostdashboard/hostcalen/HostCalendar.scss
@@ -2391,3 +2391,22 @@ $accent: #2f6fed;
   background: #f3f4f6;
   color: #374151;
 }
+
+.hc-dynamic-pricing-undo-btn {
+  margin-top: 6px;
+  padding: 0.6rem 0.9rem;
+  background: transparent;
+  color: #374151;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+  white-space: nowrap;
+}
+
+.hc-dynamic-pricing-undo-btn:hover {
+  background: #f3f4f6;
+  color: #111827;
+}

--- a/frontend/web/src/features/hostdashboard/hostcalen/HostCalendar.scss
+++ b/frontend/web/src/features/hostdashboard/hostcalen/HostCalendar.scss
@@ -776,7 +776,7 @@ $accent: #2f6fed;
   border: 1px solid #9ca3af;
   border-radius: 4px;
   background: #f3f4f6;
-  color: #6b7280;
+  color: #374151;
   padding: 2px 4px;
   font-size: 10px;
   line-height: 1.05;

--- a/frontend/web/src/features/hostdashboard/hostcalen/components/CalendarGrid.jsx
+++ b/frontend/web/src/features/hostdashboard/hostcalen/components/CalendarGrid.jsx
@@ -314,6 +314,8 @@ export default function CalendarGrid({
   restrictionOverrides = EMPTY_OBJECT,
   priceOverrides = EMPTY_OBJECT,
   priceLabsOverrides = EMPTY_OBJECT,
+  priceLabsApplied = EMPTY_OBJECT,
+  priceLabsIgnored = EMPTY_OBJECT,
   bookedDateKeys = EMPTY_SET,
   onDateSelect = null,
   loadingMessage = "",
@@ -452,11 +454,30 @@ export default function CalendarGrid({
 
                   {(() => {
                     const plPrice = priceLabsOverrides?.[dayPresentation.key];
-                    return plPrice > 0 ? (
-                      <span className="hc-cell-pricelabs-suggestion" title="PriceLabs suggested price">
-                        PL {formatEuroAmount(plPrice)}
-                      </span>
-                    ) : null;
+                    const isApplied = Boolean(priceLabsApplied?.[dayPresentation.key]);
+                    const isIgnored = Boolean(priceLabsIgnored?.[dayPresentation.key]);
+                    if (plPrice > 0) {
+                      return (
+                        <span className="hc-cell-pricelabs-suggestion" title="PriceLabs suggested price">
+                          PL {formatEuroAmount(plPrice)}
+                        </span>
+                      );
+                    }
+                    if (isApplied) {
+                      return (
+                        <span className="hc-cell-pricelabs-applied" title="PriceLabs price applied">
+                          ✓ PL
+                        </span>
+                      );
+                    }
+                    if (isIgnored) {
+                      return (
+                        <span className="hc-cell-pricelabs-ignored" title="PriceLabs suggestion ignored">
+                          ✗ PL
+                        </span>
+                      );
+                    }
+                    return null;
                   })()}
 
                   {restrictionIndicators.length > 0 ? (
@@ -599,6 +620,8 @@ CalendarGrid.propTypes = {
   ),
   priceOverrides: PropTypes.objectOf(PropTypes.number),
   priceLabsOverrides: PropTypes.objectOf(PropTypes.number),
+  priceLabsApplied: PropTypes.object,
+  priceLabsIgnored: PropTypes.object,
   bookedDateKeys: PropTypes.instanceOf(Set),
   onDateSelect: PropTypes.func,
   loadingMessage: PropTypes.string,

--- a/frontend/web/src/features/hostdashboard/hostcalen/components/Sidebar/DynamicPricingCard.jsx
+++ b/frontend/web/src/features/hostdashboard/hostcalen/components/Sidebar/DynamicPricingCard.jsx
@@ -22,6 +22,19 @@ const actionButtons = (label, dateKeys, onApplyPrice, onIgnorePrice) => (
   </div>
 );
 
+const undoButton = (dateKeys, onUndoPrice) => (
+  <div className="hc-dynamic-pricing-actions" style={{ position: "relative", zIndex: 4, display: "flex" }}>
+    <button
+      type="button"
+      className="hc-dynamic-pricing-undo-btn"
+      style={{ flex: 1 }}
+      onClick={(e) => { e.stopPropagation(); onUndoPrice?.(dateKeys); }}
+    >
+      Undo
+    </button>
+  </div>
+);
+
 const renderPricingContent = ({
   hasAnySuggestion,
   recommendedPrice,
@@ -30,6 +43,7 @@ const renderPricingContent = ({
   selectedDateKeys,
   onApplyPrice,
   onIgnorePrice,
+  onUndoPrice,
 }) => {
   // 1. Active suggestion takes priority
   if (hasAnySuggestion) {
@@ -57,6 +71,7 @@ const renderPricingContent = ({
         <p className="hc-info-card-line" style={{ fontSize: "0.78rem", color: "#aaa" }}>
           PriceLabs price is active
         </p>
+        {undoButton(selectedDateKeys, onUndoPrice)}
       </>
     );
   }
@@ -68,6 +83,7 @@ const renderPricingContent = ({
         <p className="hc-info-card-line" style={{ fontSize: "0.78rem", color: "#aaa" }}>
           Your own price is active
         </p>
+        {undoButton(selectedDateKeys, onUndoPrice)}
       </>
     );
   }
@@ -90,6 +106,7 @@ export default function DynamicPricingCard({
   priceLabsIgnored,
   onApplyPrice,
   onIgnorePrice,
+  onUndoPrice,
   onOpenSettings,
 }) {
   const firstDateKey = selectedDateKeys?.[0];
@@ -159,6 +176,7 @@ export default function DynamicPricingCard({
           selectedDateKeys,
           onApplyPrice,
           onIgnorePrice,
+          onUndoPrice,
         })}
       </section>
     );
@@ -192,6 +210,7 @@ DynamicPricingCard.propTypes = {
   priceLabsIgnored: PropTypes.object,
   onApplyPrice: PropTypes.func,
   onIgnorePrice: PropTypes.func,
+  onUndoPrice: PropTypes.func,
   onOpenSettings: PropTypes.func,
 };
 
@@ -202,5 +221,6 @@ DynamicPricingCard.defaultProps = {
   priceLabsIgnored: {},
   onApplyPrice: () => {},
   onIgnorePrice: () => {},
+  onUndoPrice: () => {},
   onOpenSettings: () => {},
 };

--- a/frontend/web/src/features/hostdashboard/hostcalen/components/Sidebar/DynamicPricingCard.jsx
+++ b/frontend/web/src/features/hostdashboard/hostcalen/components/Sidebar/DynamicPricingCard.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import arrowRightIcon from "../../../../../images/arrow-right-icon.svg";
 
 const actionButtons = (label, dateKeys, onApplyPrice, onIgnorePrice) => (
-  <div className="hc-dynamic-pricing-actions" style={{ position: "relative", zIndex: 1, display: "flex", gap: "8px" }}>
+  <div className="hc-dynamic-pricing-actions" style={{ position: "relative", zIndex: 4, display: "flex", gap: "8px" }}>
     <button
       type="button"
       className="hc-dynamic-pricing-apply-btn"
@@ -22,7 +22,16 @@ const actionButtons = (label, dateKeys, onApplyPrice, onIgnorePrice) => (
   </div>
 );
 
-const renderPricingContent = ({ hasAnySuggestion, recommendedPrice, selectedDateKeys, onApplyPrice, onIgnorePrice }) => {
+const renderPricingContent = ({
+  hasAnySuggestion,
+  recommendedPrice,
+  hasAnyApplied,
+  hasAnyIgnored,
+  selectedDateKeys,
+  onApplyPrice,
+  onIgnorePrice,
+}) => {
+  // 1. Active suggestion takes priority
   if (hasAnySuggestion) {
     return (
       <>
@@ -40,6 +49,29 @@ const renderPricingContent = ({ hasAnySuggestion, recommendedPrice, selectedDate
       </>
     );
   }
+  // 2. Applied state
+  if (hasAnyApplied) {
+    return (
+      <>
+        <p className="hc-info-card-line hc-info-card-line--applied">Price applied</p>
+        <p className="hc-info-card-line" style={{ fontSize: "0.78rem", color: "#aaa" }}>
+          PriceLabs price is active
+        </p>
+      </>
+    );
+  }
+  // 3. Ignored state
+  if (hasAnyIgnored) {
+    return (
+      <>
+        <p className="hc-info-card-line hc-info-card-line--ignored">Suggestion ignored</p>
+        <p className="hc-info-card-line" style={{ fontSize: "0.78rem", color: "#aaa" }}>
+          Your own price is active
+        </p>
+      </>
+    );
+  }
+  // 4. No suggestion
   return (
     <>
       <p className="hc-info-card-line">No suggestion for this day</p>
@@ -54,6 +86,8 @@ export default function DynamicPricingCard({
   isConnected,
   selectedDateKeys,
   priceLabsOverrides,
+  priceLabsApplied,
+  priceLabsIgnored,
   onApplyPrice,
   onIgnorePrice,
   onOpenSettings,
@@ -70,6 +104,14 @@ export default function DynamicPricingCard({
     multipleSelected &&
     Array.isArray(selectedDateKeys) &&
     selectedDateKeys.some((key) => Number(priceLabsOverrides?.[key]) > 0);
+
+  const hasAnyApplied =
+    Array.isArray(selectedDateKeys) &&
+    selectedDateKeys.some((key) => priceLabsApplied?.[key]);
+
+  const hasAnyIgnored =
+    Array.isArray(selectedDateKeys) &&
+    selectedDateKeys.some((key) => priceLabsIgnored?.[key]);
 
   if (!isConnected) {
     return (
@@ -112,6 +154,8 @@ export default function DynamicPricingCard({
         {renderPricingContent({
           hasAnySuggestion,
           recommendedPrice,
+          hasAnyApplied,
+          hasAnyIgnored,
           selectedDateKeys,
           onApplyPrice,
           onIgnorePrice,
@@ -144,6 +188,8 @@ DynamicPricingCard.propTypes = {
   isConnected: PropTypes.bool.isRequired,
   selectedDateKeys: PropTypes.arrayOf(PropTypes.string),
   priceLabsOverrides: PropTypes.object,
+  priceLabsApplied: PropTypes.object,
+  priceLabsIgnored: PropTypes.object,
   onApplyPrice: PropTypes.func,
   onIgnorePrice: PropTypes.func,
   onOpenSettings: PropTypes.func,
@@ -152,6 +198,8 @@ DynamicPricingCard.propTypes = {
 DynamicPricingCard.defaultProps = {
   selectedDateKeys: [],
   priceLabsOverrides: {},
+  priceLabsApplied: {},
+  priceLabsIgnored: {},
   onApplyPrice: () => {},
   onIgnorePrice: () => {},
   onOpenSettings: () => {},

--- a/frontend/web/src/features/hostdashboard/hostcalen/hooks/useCalendarSelection.js
+++ b/frontend/web/src/features/hostdashboard/hostcalen/hooks/useCalendarSelection.js
@@ -140,7 +140,7 @@ const getRestrictionForKey = (restrictionsByKey, key) => {
   return normalizeRestrictionOverride(restrictionsByKey[key]);
 };
 
-const buildOverridePayload = (dateKeys, availabilityByKey, priceByKey, restrictionsByKey) =>
+const buildOverridePayload = (dateKeys, availabilityByKey, priceByKey, restrictionsByKey, priceLabsIgnoredByKey = {}) =>
   (Array.isArray(dateKeys) ? dateKeys : [])
     .map((key) => {
       const date = keyToDateNumber(key);
@@ -150,10 +150,12 @@ const buildOverridePayload = (dateKeys, availabilityByKey, priceByKey, restricti
       const nightlyPriceRaw = Number(priceByKey?.[key]);
       const nightlyPrice =
         Number.isFinite(nightlyPriceRaw) && nightlyPriceRaw > 0 ? Math.trunc(nightlyPriceRaw) : null;
+      const priceLabsIgnored = Object.hasOwn(priceLabsIgnoredByKey, key) ? priceLabsIgnoredByKey[key] : null;
       return {
         date,
         isAvailable: Object.hasOwn(availabilityByKey, key) ? Boolean(availabilityByKey[key]) : null,
         nightlyPrice,
+        priceLabsIgnored,
         ...getRestrictionForKey(restrictionsByKey, key),
       };
     })
@@ -163,6 +165,8 @@ const parseOverrideResponse = (overrides) => {
   const availabilityByKey = {};
   const priceByKey = {};
   const priceLabsByKey = {};
+  const appliedByKey = {};
+  const ignoredByKey = {};
   const restrictionsByKey = {};
   (Array.isArray(overrides) ? overrides : []).forEach((override) => {
     const key = dateNumberToKey(
@@ -181,7 +185,21 @@ const parseOverrideResponse = (overrides) => {
     }
     // PriceLabs price suggestion (set by webhook, requires host approval)
     const priceLabsPrice = Number(readOverrideField(override, "priceLabsPrice", "pricelabs_price"));
-    if (Number.isFinite(priceLabsPrice) && priceLabsPrice > 0) {
+    const isIgnored = Boolean(readOverrideField(override, "priceLabsIgnored", "pricelabs_ignored"));
+    const isApplied =
+      Number.isFinite(priceLabsPrice) && priceLabsPrice > 0 &&
+      Number.isFinite(nightlyPrice) && nightlyPrice > 0 &&
+      Math.trunc(nightlyPrice) === Math.trunc(priceLabsPrice) &&
+      !isIgnored;
+
+    if (isApplied) {
+      appliedByKey[key] = Math.trunc(priceLabsPrice);
+    }
+    if (isIgnored) {
+      ignoredByKey[key] = true;
+    }
+    // Only show as active suggestion if: pl price exists, not applied, not ignored
+    if (Number.isFinite(priceLabsPrice) && priceLabsPrice > 0 && !isApplied && !isIgnored) {
       priceLabsByKey[key] = Math.trunc(priceLabsPrice);
     }
     const restriction = normalizeRestrictionOverride(override);
@@ -189,7 +207,7 @@ const parseOverrideResponse = (overrides) => {
       restrictionsByKey[key] = restriction;
     }
   });
-  return { availabilityByKey, priceByKey, priceLabsByKey, restrictionsByKey };
+  return { availabilityByKey, priceByKey, priceLabsByKey, appliedByKey, ignoredByKey, restrictionsByKey };
 };
 
 const valuesAreEqual = (left, right) => left === right;
@@ -294,6 +312,8 @@ export const useCalendarSelection = ({
   const [availabilityOverrides, setAvailabilityOverrides] = useState({});
   const [priceOverridesByPropertyId, setPriceOverridesByPropertyId] = useState({});
   const [priceLabsOverridesByPropertyId, setPriceLabsOverridesByPropertyId] = useState({});
+  const [priceLabsAppliedByPropertyId, setPriceLabsAppliedByPropertyId] = useState({});
+  const [priceLabsIgnoredByPropertyId, setPriceLabsIgnoredByPropertyId] = useState({});
   const [restrictionOverrides, setRestrictionOverrides] = useState({});
   const [reloadKey, setReloadKey] = useState(0);
   const [selectionPriceInput, setSelectionPriceInput] = useState("");
@@ -321,14 +341,15 @@ export const useCalendarSelection = ({
     dateKeys,
     availabilityByKey,
     priceByKey,
-    restrictionsByKey
+    restrictionsByKey,
+    priceLabsIgnoredByKey = {}
   ) => {
     const token = getAccessToken();
     if (!token || !propertyId) {
       return false;
     }
 
-    const overrides = buildOverridePayload(dateKeys, availabilityByKey, priceByKey, restrictionsByKey);
+    const overrides = buildOverridePayload(dateKeys, availabilityByKey, priceByKey, restrictionsByKey, priceLabsIgnoredByKey);
     if (!overrides.length) {
       return false;
     }
@@ -354,6 +375,8 @@ export const useCalendarSelection = ({
       availabilityByKey: confirmedAvailability,
       priceByKey: confirmedPrice,
       priceLabsByKey: confirmedPriceLabs,
+      appliedByKey: confirmedApplied,
+      ignoredByKey: confirmedIgnored,
       restrictionsByKey: confirmedRestrictions,
     } = parseOverrideResponse(body?.overrides);
 
@@ -389,11 +412,48 @@ export const useCalendarSelection = ({
     setPriceLabsOverridesByPropertyId((previous) => {
       const next = { ...previous };
       const existing = next[propertyId];
-      const propertyPriceLabs = existing && typeof existing === "object" ? { ...existing } : {};
-      Object.entries(confirmedPriceLabs).forEach(([key, value]) => {
-        propertyPriceLabs[key] = value;
+      const propertyLabsPrices = existing && typeof existing === "object" ? { ...existing } : {};
+      dateKeys.forEach((key) => {
+        if (Object.hasOwn(propertyLabsPrices, key)) {
+          delete propertyLabsPrices[key];
+        }
       });
-      next[propertyId] = propertyPriceLabs;
+      Object.entries(confirmedPriceLabs).forEach(([key, value]) => {
+        propertyLabsPrices[key] = value;
+      });
+      next[propertyId] = propertyLabsPrices;
+      return next;
+    });
+
+    setPriceLabsAppliedByPropertyId((previous) => {
+      const next = { ...previous };
+      const existing = next[propertyId];
+      const propertyApplied = existing && typeof existing === "object" ? { ...existing } : {};
+      dateKeys.forEach((key) => {
+        if (Object.hasOwn(propertyApplied, key)) {
+          delete propertyApplied[key];
+        }
+      });
+      Object.entries(confirmedApplied).forEach(([key, value]) => {
+        propertyApplied[key] = value;
+      });
+      next[propertyId] = propertyApplied;
+      return next;
+    });
+
+    setPriceLabsIgnoredByPropertyId((previous) => {
+      const next = { ...previous };
+      const existing = next[propertyId];
+      const propertyIgnored = existing && typeof existing === "object" ? { ...existing } : {};
+      dateKeys.forEach((key) => {
+        if (Object.hasOwn(propertyIgnored, key)) {
+          delete propertyIgnored[key];
+        }
+      });
+      Object.entries(confirmedIgnored).forEach(([key, value]) => {
+        propertyIgnored[key] = value;
+      });
+      next[propertyId] = propertyIgnored;
       return next;
     });
 
@@ -438,6 +498,16 @@ export const useCalendarSelection = ({
   const selectedPropertyPriceLabsOverrides = useMemo(
     () => priceLabsOverridesByPropertyId?.[selectedPropertyId] || EMPTY_PRICE_OVERRIDES,
     [priceLabsOverridesByPropertyId, selectedPropertyId]
+  );
+
+  const selectedPropertyPriceLabsApplied = useMemo(
+    () => priceLabsAppliedByPropertyId?.[selectedPropertyId] || EMPTY_PRICE_OVERRIDES,
+    [priceLabsAppliedByPropertyId, selectedPropertyId]
+  );
+
+  const selectedPropertyPriceLabsIgnored = useMemo(
+    () => priceLabsIgnoredByPropertyId?.[selectedPropertyId] || EMPTY_PRICE_OVERRIDES,
+    [priceLabsIgnoredByPropertyId, selectedPropertyId]
   );
 
   const getBasePriceForDateKey = (key) => {
@@ -573,7 +643,7 @@ export const useCalendarSelection = ({
         if (!mounted) {
           return;
         }
-        const { availabilityByKey, priceByKey, priceLabsByKey, restrictionsByKey } = parseOverrideResponse(body?.overrides);
+        const { availabilityByKey, priceByKey, priceLabsByKey, appliedByKey, ignoredByKey, restrictionsByKey } = parseOverrideResponse(body?.overrides);
         const localOverridesChangedDuringRequest =
           localOverrideVersionRef.current !== requestStartedAtLocalVersion;
         const selectedKeysToPreserve = localOverridesChangedDuringRequest
@@ -604,6 +674,14 @@ export const useCalendarSelection = ({
           ...previous,
           [selectedPropertyId]: priceLabsByKey,
         }));
+        setPriceLabsAppliedByPropertyId((previous) => ({
+          ...previous,
+          [selectedPropertyId]: appliedByKey,
+        }));
+        setPriceLabsIgnoredByPropertyId((previous) => ({
+          ...previous,
+          [selectedPropertyId]: ignoredByKey,
+        }));
       } catch (error) {
         console.error(error?.message || error);
       }
@@ -620,6 +698,8 @@ export const useCalendarSelection = ({
     setAvailabilityOverrides({});
     setRestrictionOverrides({});
     setPriceLabsOverridesByPropertyId({});
+    setPriceLabsAppliedByPropertyId({});
+    setPriceLabsIgnoredByPropertyId({});
     setSelectionPriceInput("");
     setSelectionPriceDirty(false);
     setSelectionRestrictionsForm(createSelectionRestrictionsForm());
@@ -735,20 +815,42 @@ export const useCalendarSelection = ({
     });
   };
 
-  const handleIgnorePriceLabsSuggestion = (dateKeys) => {
-    if (!selectedPropertyId || !dateKeys?.length) {
-      return;
-    }
-    // Remove the PriceLabs suggestion from local state for these dates.
-    // The suggestion will reappear only after the next PriceLabs sync.
+  const removePriceLabsKeysAfterIgnore = (ignoredKeys) => {
     setPriceLabsOverridesByPropertyId((previous) => {
       const existing = previous?.[selectedPropertyId];
       if (!existing) return previous;
       const next = { ...existing };
-      dateKeys.forEach((key) => {
+      for (const key of ignoredKeys) {
         delete next[key];
-      });
+      }
       return { ...previous, [selectedPropertyId]: next };
+    });
+    setPriceLabsIgnoredByPropertyId((previous) => {
+      const next = { ...(previous?.[selectedPropertyId] ?? {}) };
+      for (const key of ignoredKeys) {
+        next[key] = true;
+      }
+      return { ...previous, [selectedPropertyId]: next };
+    });
+  };
+
+  const handleIgnorePriceLabsSuggestion = (dateKeys) => {
+    if (!selectedPropertyId || !dateKeys?.length) {
+      return;
+    }
+    // Optimistically update local state immediately so the user sees feedback right away
+    removePriceLabsKeysAfterIgnore(dateKeys);
+    // Persist to DB in the background
+    const priceLabsIgnoredByKey = Object.fromEntries(dateKeys.map((k) => [k, true]));
+    void persistOverrides(
+      selectedPropertyId,
+      dateKeys,
+      availabilityOverrides,
+      selectedPropertyPriceOverrides,
+      restrictionOverrides,
+      priceLabsIgnoredByKey
+    ).catch((error) => {
+      console.error(error?.message || error);
     });
   };
 
@@ -780,14 +882,27 @@ export const useCalendarSelection = ({
       ...previous,
       [selectedPropertyId]: nextPropertyPriceOverrides,
     }));
+    // Optimistically remove suggestions and mark as applied
+    setPriceLabsOverridesByPropertyId((previous) => {
+      const next = { ...(previous?.[selectedPropertyId] ?? {}) };
+      for (const key of keysToApply) { delete next[key]; }
+      return { ...previous, [selectedPropertyId]: next };
+    });
+    setPriceLabsAppliedByPropertyId((previous) => {
+      const next = { ...(previous?.[selectedPropertyId] ?? {}) };
+      for (const key of keysToApply) { next[key] = nextPropertyPriceOverrides[key]; }
+      return { ...previous, [selectedPropertyId]: next };
+    });
     markLocalOverrideTouched();
 
+    const priceLabsIgnoredByKey = Object.fromEntries(keysToApply.map((k) => [k, false]));
     void persistOverrides(
       selectedPropertyId,
       keysToApply,
       availabilityOverrides,
       nextPropertyPriceOverrides,
-      restrictionOverrides
+      restrictionOverrides,
+      priceLabsIgnoredByKey
     ).catch((error) => {
       console.error(error?.message || error);
     });
@@ -870,6 +985,8 @@ export const useCalendarSelection = ({
     restrictionOverrides,
     selectedPropertyPriceOverrides,
     selectedPropertyPriceLabsOverrides,
+    selectedPropertyPriceLabsApplied,
+    selectedPropertyPriceLabsIgnored,
     selectedDateKeys,
     pendingSelectionStartKey,
     bookedDateKeys,

--- a/frontend/web/src/features/hostdashboard/hostcalen/hooks/useCalendarSelection.js
+++ b/frontend/web/src/features/hostdashboard/hostcalen/hooks/useCalendarSelection.js
@@ -196,7 +196,9 @@ const parseOverrideResponse = (overrides) => {
       appliedByKey[key] = Math.trunc(priceLabsPrice);
     }
     if (isIgnored) {
-      ignoredByKey[key] = true;
+      // Store the suggested price (when known) so an undo can restore the suggestion instantly.
+      ignoredByKey[key] =
+        Number.isFinite(priceLabsPrice) && priceLabsPrice > 0 ? Math.trunc(priceLabsPrice) : true;
     }
     // Only show as active suggestion if: pl price exists, not applied, not ignored
     if (Number.isFinite(priceLabsPrice) && priceLabsPrice > 0 && !isApplied && !isIgnored) {
@@ -828,7 +830,8 @@ export const useCalendarSelection = ({
     setPriceLabsIgnoredByPropertyId((previous) => {
       const next = { ...previous?.[selectedPropertyId] };
       for (const key of ignoredKeys) {
-        next[key] = true;
+        const price = Number(selectedPropertyPriceLabsOverrides?.[key]);
+        next[key] = Number.isFinite(price) && price > 0 ? Math.trunc(price) : true;
       }
       return { ...previous, [selectedPropertyId]: next };
     });
@@ -840,6 +843,7 @@ export const useCalendarSelection = ({
     }
     // Optimistically update local state immediately so the user sees feedback right away
     removePriceLabsKeysAfterIgnore(dateKeys);
+    markLocalOverrideTouched();
     // Persist to DB in the background
     const priceLabsIgnoredByKey = Object.fromEntries(dateKeys.map((k) => [k, true]));
     void persistOverrides(
@@ -899,6 +903,71 @@ export const useCalendarSelection = ({
     void persistOverrides(
       selectedPropertyId,
       keysToApply,
+      availabilityOverrides,
+      nextPropertyPriceOverrides,
+      restrictionOverrides,
+      priceLabsIgnoredByKey
+    ).catch((error) => {
+      console.error(error?.message || error);
+    });
+  };
+
+  const handleUndoPriceLabsSuggestion = (dateKeys) => {
+    if (!selectedPropertyId || !dateKeys?.length) {
+      return;
+    }
+    const appliedMap = selectedPropertyPriceLabsApplied;
+    const ignoredMap = selectedPropertyPriceLabsIgnored;
+    const keysToUndo = dateKeys.filter((key) => appliedMap?.[key] || ignoredMap?.[key]);
+    if (!keysToUndo.length) {
+      return;
+    }
+
+    // For applied dates: remove the copied nightly price so the host's base price applies again.
+    const nextPropertyPriceOverrides = { ...selectedPropertyPriceOverrides };
+    for (const key of keysToUndo) {
+      if (appliedMap?.[key]) {
+        delete nextPropertyPriceOverrides[key];
+      }
+    }
+
+    // Optimistically restore the suggestion and clear applied/ignored state.
+    setPriceOverridesByPropertyId((previous) => ({
+      ...previous,
+      [selectedPropertyId]: nextPropertyPriceOverrides,
+    }));
+    setPriceLabsOverridesByPropertyId((previous) => {
+      const next = { ...previous?.[selectedPropertyId] };
+      for (const key of keysToUndo) {
+        const restored = Number(appliedMap?.[key] ?? ignoredMap?.[key]);
+        if (Number.isFinite(restored) && restored > 0) {
+          next[key] = Math.trunc(restored);
+        }
+      }
+      return { ...previous, [selectedPropertyId]: next };
+    });
+    setPriceLabsAppliedByPropertyId((previous) => {
+      const next = { ...previous?.[selectedPropertyId] };
+      for (const key of keysToUndo) {
+        delete next[key];
+      }
+      return { ...previous, [selectedPropertyId]: next };
+    });
+    setPriceLabsIgnoredByPropertyId((previous) => {
+      const next = { ...previous?.[selectedPropertyId] };
+      for (const key of keysToUndo) {
+        delete next[key];
+      }
+      return { ...previous, [selectedPropertyId]: next };
+    });
+    markLocalOverrideTouched();
+
+    // Persist: pricelabs_ignored = false; for applied dates the nightly price is cleared,
+    // so the row keeps its pricelabs_price and the suggestion becomes active again after reload.
+    const priceLabsIgnoredByKey = Object.fromEntries(keysToUndo.map((key) => [key, false]));
+    void persistOverrides(
+      selectedPropertyId,
+      keysToUndo,
       availabilityOverrides,
       nextPropertyPriceOverrides,
       restrictionOverrides,
@@ -1004,6 +1073,7 @@ export const useCalendarSelection = ({
     handleSaveSelectionPrice,
     handleApplyPriceLabsSuggestion,
     handleIgnorePriceLabsSuggestion,
+    handleUndoPriceLabsSuggestion,
     handleSelectionRestrictionChange,
     handleSaveSelectionRestrictions,
     resetSelectionState,

--- a/frontend/web/src/features/hostdashboard/hostcalen/hooks/useCalendarSelection.js
+++ b/frontend/web/src/features/hostdashboard/hostcalen/hooks/useCalendarSelection.js
@@ -826,7 +826,7 @@ export const useCalendarSelection = ({
       return { ...previous, [selectedPropertyId]: next };
     });
     setPriceLabsIgnoredByPropertyId((previous) => {
-      const next = { ...(previous?.[selectedPropertyId] ?? {}) };
+      const next = { ...previous?.[selectedPropertyId] };
       for (const key of ignoredKeys) {
         next[key] = true;
       }
@@ -884,12 +884,12 @@ export const useCalendarSelection = ({
     }));
     // Optimistically remove suggestions and mark as applied
     setPriceLabsOverridesByPropertyId((previous) => {
-      const next = { ...(previous?.[selectedPropertyId] ?? {}) };
+      const next = { ...previous?.[selectedPropertyId] };
       for (const key of keysToApply) { delete next[key]; }
       return { ...previous, [selectedPropertyId]: next };
     });
     setPriceLabsAppliedByPropertyId((previous) => {
-      const next = { ...(previous?.[selectedPropertyId] ?? {}) };
+      const next = { ...previous?.[selectedPropertyId] };
       for (const key of keysToApply) { next[key] = nextPropertyPriceOverrides[key]; }
       return { ...previous, [selectedPropertyId]: next };
     });

--- a/frontend/web/src/features/hostdashboard/hostpricelabs/components/PriceLabsConnect.js
+++ b/frontend/web/src/features/hostdashboard/hostpricelabs/components/PriceLabsConnect.js
@@ -45,8 +45,7 @@ function PriceLabsConnect({ onConnect, isLoading = false, error = null, successM
             disabled={loading}
           />
           <p className="pl-connect__hint">
-            This is the email you registered with PriceLabs. Make sure PriceLabs
-            has enabled the Domits integration on your account.
+            This is the email you registered with PriceLabs.
           </p>
         </div>
 
@@ -65,6 +64,19 @@ function PriceLabsConnect({ onConnect, isLoading = false, error = null, successM
             </span>
           ) : "Connect PriceLabs"}
         </button>
+
+        <p className="pl-connect__signup">
+          Don&apos;t have a PriceLabs account yet?{" "}
+          <a
+            href="https://hello.pricelabs.co/signup/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="pl-connect__signup-link"
+          >
+            Create a free account
+          </a>
+          {" "}and come back here to connect it.
+        </p>
       </form>
     </div>
   );

--- a/frontend/web/src/features/hostdashboard/hostpricelabs/styles/HostPriceLabs.css
+++ b/frontend/web/src/features/hostdashboard/hostpricelabs/styles/HostPriceLabs.css
@@ -44,6 +44,9 @@
 .pl-connect__input:focus    { border-color: var(--pl-primary); background: #fff; }
 .pl-connect__input:disabled { opacity: .6; cursor: not-allowed; }
 .pl-connect__hint           { font-size: .8rem; color: #888; margin: 0; }
+.pl-connect__signup         { font-size: .85rem; color: #555; margin: .75rem 0 0; text-align: center; }
+.pl-connect__signup-link    { color: #2e7d32; font-weight: 600; text-decoration: underline; }
+.pl-connect__signup-link:hover { color: #33a446; }
 
 .pl-card {
   background: #fff; border-radius: 12px; padding: 1.5rem;


### PR DESCRIPTION
## Close or Relate the Issue
- Closes 
- Related Issue: #2297
## Proposed Changes
Description:
Completes the PriceLabs dynamic pricing integration by adding the ability to apply, ignore and undo price suggestions from PriceLabs, with full persistence and visual feedback. Also fixes a Lambda timeout that caused PriceLabs price syncs to silently fail, and populates the OTA listing IDs requested by PriceLabs.
**Backend:**
- Added `pricelabs_ignored` boolean column to `property_calendar_override` (migration `20260609`)
- `PropertyHandler` repository: SELECT/INSERT/UPSERT now includes `pricelabs_ignored`; UPSERT uses `COALESCE` to preserve existing value when null is sent
- `PropertyHandler` controller: normalises `priceLabsIgnored` in the PATCH payload
- `PriceLabs-Integration` webhook: sets `pricelabs_ignored = false` on new sync and on disconnect/clear
- `PriceLabs-Integration` sync webhook: batched price recommendation writes (one SELECT + chunked multi-row upserts instead of two queries per date); a full PriceLabs sync pushes 12-18 months of prices and exceeded the 30s Lambda timeout, causing syncs to silently fail
- `PriceLabs-Integration` listings push: `ota_listing_ids` is now populated from channel integration data (Airbnb / Booking.com / VRBO via account join) instead of being sent as an empty object
**Frontend:**
- `useCalendarSelection`: tracks `priceLabsAppliedByPropertyId` and `priceLabsIgnoredByPropertyId` state; `parseOverrideResponse` filters applied/ignored dates out of active suggestions; optimistic UI updates on Apply/Ignore (immediate visual feedback before API responds); fixed `persistOverrides` merge logic for all three PriceLabs state maps; added `markLocalOverrideTouched` to the ignore handler to prevent a stale fetch from overwriting the optimistic state
- Undo flow: after applying or ignoring a suggestion, hosts can undo the decision from the sidebar; undo restores the original suggestion (clears the copied nightly price for applied dates, sets `pricelabs_ignored = false`) and is fully persisted, surviving refresh and login/logout
- `CalendarGrid`: shows `✓ PL` (applied) and `✗ PL` (ignored) badges on date tiles
- `DynamicPricingCard`: shows "Price applied" / "Suggestion ignored" states with an Undo button in the sidebar; fixed z-index on Apply/Ignore buttons (were blocked by card hitarea at z-index 3)
- `HostCalendar`: passes applied/ignored state to CalendarGrid and sidebar; hides PriceLabs data when not connected; navigates to PriceLabsConnect form when clicking Dynamic Pricing while disconnected; disconnect now awaits completion so the "Disconnecting…" loading state is visible instead of the card disappearing instantly
- `PriceLabsConnect`: hosts without a PriceLabs account now see a direct link to the PriceLabs signup page below the connect button (opens in a new tab)
## Change Type
- [x] Bug fix
- [x] New feature
- [ ] Optimization
- [ ] Documentation update
## Change Size
- [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
- [x] Big change (+-max 1000)
- [ ] Small change (less than 300)
## Refactoring
N/A
## Evidence
- [ ] Screenshots or screen recording added for UI changes
- [ ] Before/after images added when relevant
- [ ] Images clearly show the implemented change
- [ ] Image quality is readable (no cropped or blurry images)
## Responsiveness
- [ ] UI checked on mobile
- [ ] UI checked on tablet
- [x] UI checked on desktop
- [ ] No broken layout, overflow, or hidden content on tested screen sizes
## Npm Packages
- [ ] NPM Packages installed
- [ ] NPM Packages removed
- [ ] NPM Packages updated
- [ ] Checked for vulnerabilities using "npm audit"
## Checklist
- [ ] Pull request has at least 2 reviewers assigned
- [x] PR title is descriptive and includes issue number
- [ ] Conventions
  - [x] No config files have been added (Amplify config, cache files)
  - [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  - [x] No global styling (see [#1691](https://github.com/domits1/Domits/issues/1691))
  - [x] No `console.log` left in code
  - [x] No commented-out code remains
- [ ] Testing
  - [x] Code tested locally
  - [x] Jest tests are included
  - [x] Jest tests are passing
## Keep or delete my branch
- [ ] Delete my branch after merge
- [x] Keep my branch