### PR TITLE
fix(automations): register shared ORM entities

### DIFF
--- a/backend/functions/.shared/integrations/ORM/util/database/Tables.js
+++ b/backend/functions/.shared/integrations/ORM/util/database/Tables.js
@@ -1,5 +1,10 @@
 import { UnifiedThread } from "database/models/unified/messaging/UnifiedThread";
 import { UnifiedMessage } from "database/models/unified/messaging/UnifiedMessage";
+import { Booking } from "database/models/Booking";
+import { Property } from "database/models/Property";
+import { MessageAutomation } from "database/models/automation/MessageAutomation";
+import { MessageAutomationDelivery } from "database/models/automation/MessageAutomationDelivery";
+import { BookingAutomationOutbox } from "database/models/automation/BookingAutomationOutbox";
 
 import { ChannelIntegrationAccount } from "database/models/unified/integrations/ChannelIntegrationAccount";
 import { ChannelIntegrationProperty } from "database/models/unified/integrations/ChannelIntegrationProperty";
@@ -16,6 +21,11 @@ export const Tables = [
 
   UnifiedThread,
   UnifiedMessage,
+  Booking,
+  Property,
+  MessageAutomation,
+  MessageAutomationDelivery,
+  BookingAutomationOutbox,
 
   ChannelIntegrationAccount,
   ChannelIntegrationProperty,

--- a/backend/functions/AutomatedMessaging/index.js
+++ b/backend/functions/AutomatedMessaging/index.js
@@ -30,15 +30,24 @@ const deliveryWorker = new DeliveryWorker({
 });
 const controller = new AutomationController(automationService, schemaGuard);
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "Content-Type,Authorization",
-  "Access-Control-Allow-Methods": "GET,POST,PATCH,OPTIONS",
+const ACCEPTANCE_FRONTEND_ORIGIN = "https://acceptance.domits.com";
+
+const baseCorsHeaders = {
+  "Access-Control-Allow-Headers": "Authorization,Content-Type",
+  "Access-Control-Allow-Methods": "GET,POST,PUT,DELETE,OPTIONS",
 };
 
-const createResponse = ({ statusCode = 200, response }) => ({
+const resolveCorsOrigin = (event) => {
+  const origin = event?.headers?.origin || event?.headers?.Origin;
+  return origin === ACCEPTANCE_FRONTEND_ORIGIN ? ACCEPTANCE_FRONTEND_ORIGIN : "*";
+};
+
+const createResponse = ({ statusCode = 200, response }, event) => ({
   statusCode,
-  headers: corsHeaders,
+  headers: {
+    "Access-Control-Allow-Origin": resolveCorsOrigin(event),
+    ...baseCorsHeaders,
+  },
   body: JSON.stringify(response),
 });
 
@@ -119,7 +128,7 @@ export const handler = async (event) => {
       await schemaGuard.assertReady();
       return createResponse({ statusCode: 200, response: await deliveryWorker.processDue(event.detail || {}) });
     }
-    return createResponse(await routeHttpRequest(event));
+    return createResponse(await routeHttpRequest(event), event);
   } catch (error) {
     console.error("AutomatedMessaging request failed", {
       code: error?.code || error?.name || "INTERNAL_ERROR",
@@ -132,6 +141,6 @@ export const handler = async (event) => {
         message: error?.statusCode ? error.message : "Internal Server Error",
         ...(error?.details ? { details: error.details } : {}),
       },
-    });
+    }, event);
   }
 };

--- a/backend/functions/AutomatedMessaging/tests/index.auth.test.js
+++ b/backend/functions/AutomatedMessaging/tests/index.auth.test.js
@@ -37,10 +37,25 @@ describe("AutomatedMessaging HTTP authorization responses", () => {
     });
   });
 
-  test("keeps OPTIONS unauthenticated", async () => {
-    const response = await handler({ httpMethod: "OPTIONS", path: "/automations" });
+  test("keeps OPTIONS unauthenticated with acceptance CORS headers", async () => {
+    const response = await handler({
+      httpMethod: "OPTIONS",
+      path: "/automations",
+      headers: {
+        Origin: "https://acceptance.domits.com",
+        "Access-Control-Request-Method": "GET",
+        "Access-Control-Request-Headers": "authorization,content-type",
+      },
+    });
 
     expect(response.statusCode).toBe(200);
+    expect(response.headers).toEqual(
+      expect.objectContaining({
+        "Access-Control-Allow-Origin": "https://acceptance.domits.com",
+        "Access-Control-Allow-Methods": "GET,POST,PUT,DELETE,OPTIONS",
+        "Access-Control-Allow-Headers": "Authorization,Content-Type",
+      })
+    );
     expect(parseBody(response)).toBeNull();
   });
 

--- a/backend/functions/AutomatedMessaging/tests/sharedOrmEntities.test.js
+++ b/backend/functions/AutomatedMessaging/tests/sharedOrmEntities.test.js
@@ -1,0 +1,37 @@
+import { DataSource } from "typeorm";
+import { Tables } from "../../.shared/integrations/ORM/util/database/Tables.js";
+import { Booking } from "database/models/Booking";
+import { Property } from "database/models/Property";
+import { BookingAutomationOutbox } from "database/models/automation/BookingAutomationOutbox";
+import { MessageAutomation } from "database/models/automation/MessageAutomation";
+import { MessageAutomationDelivery } from "database/models/automation/MessageAutomationDelivery";
+
+const buildMetadataOnlyDataSource = async () => {
+  const dataSource = new DataSource({
+    type: "postgres",
+    host: "localhost",
+    username: "test",
+    password: "test",
+    database: "test",
+    entities: Tables,
+  });
+
+  await dataSource.buildMetadatas();
+  return dataSource;
+};
+
+describe("AutomatedMessaging shared ORM entity registry", () => {
+  test("registers every entity used by AutomatedMessaging repositories", async () => {
+    const dataSource = await buildMetadataOnlyDataSource();
+
+    [
+      Booking,
+      Property,
+      MessageAutomation,
+      MessageAutomationDelivery,
+      BookingAutomationOutbox,
+    ].forEach((entity) => {
+      expect(dataSource.hasMetadata(entity)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Close or Relate the Issue

* Related Issue: #

## Proposed Changes

Description:

This PR fixes the AutomatedMessaging backend error that occurred after the CORS preflight issue was resolved.

`GET /automations` reached the Lambda but returned `500 Internal Server Error` because TypeORM could not find metadata for the AutomatedMessaging entities. The deployed Lambda uses the shared ORM registry, but the required AutomatedMessaging entities were not registered there.

Changes:

* Register AutomatedMessaging entities in the shared ORM table registry:

  * `MessageAutomation`
  * `MessageAutomationDelivery`
  * `BookingAutomationOutbox`
  * `Booking`
  * `Property`
* Keep the AutomatedMessaging CORS response hardening for acceptance origin.
* Add/adjust backend tests to cover auth/CORS behavior and shared ORM entity registration.

## Change Type

* [x] Bug fix
* [ ] New feature
* [ ] Optimization
* [ ] Documentation update

## Change Size

* [x] Small change
* [ ] Medium change
* [ ] Big change
* [ ] Huge change

## Testing

Tested locally:

```bash
cd backend
npm test -- AutomatedMessaging/tests/sharedOrmEntities.test.js --runInBand
npm test -- AutomatedMessaging/tests/index.auth.test.js --runInBand
npm test -- AutomatedMessaging/tests --runInBand
git diff --check
```

Results:

* 8 AutomatedMessaging test suites passed.
* 40 tests passed.
* `git diff --check` passed.

## Deployment Verification

After merge/deploy to acceptance, verify:

```bash
curl -i -X OPTIONS 'https://54s3llwby8.execute-api.eu-north-1.amazonaws.com/default/automations' \
  -H 'Origin: https://acceptance.domits.com' \
  -H 'Access-Control-Request-Method: GET' \
  -H 'Access-Control-Request-Headers: authorization,content-type'
```

Expected:

* `200` or `204`
* CORS headers are present
* No `401 Unauthorized`

Then verify with a Cognito ID token:

```bash
curl -i 'https://54s3llwby8.execute-api.eu-north-1.amazonaws.com/default/automations' \
  -H 'Origin: https://acceptance.domits.com' \
  -H "Authorization: Bearer $ID_TOKEN" \
  -H 'Content-Type: application/json'
```

Expected:

* No `EntityMetadataNotFoundError`
* No `500 Internal Server Error`
* Response returns automations JSON, likely an empty list if no automations exist.

## Notes

This PR does not change frontend code or unrelated provider/channel integrations.
