### PR TITLE
fix(ci): match npm major to the one Dependabot builds lockfiles with

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v6.0.0
+        with:
+          node-version: 22
+          cache-dependency-path: frontend/web/package-lock.json
+
+      - name: Match npm to the major Dependabot generates lockfiles with
+        run: npm install -g npm@11
+
       # Install NPM dependencies
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
           node-version: 22
           cache-dependency-path: frontend/web/package-lock.json
 
-      - name: Match npm to the major Dependabot generates lockfiles with
-        run: npm install -g npm@11
+      - name: Pin npm to the version Dependabot generates lockfiles with
+        run: npm install -g npm@11.6.2 --ignore-scripts
 
       # Install NPM dependencies
       - name: Install dependencies

--- a/.github/workflows/webapp-build-test.yml
+++ b/.github/workflows/webapp-build-test.yml
@@ -22,8 +22,8 @@ jobs:
         node-version: 22
         cache-dependency-path: frontend/web/package-lock.json
 
-    - name: Match npm to the major Dependabot generates lockfiles with
-      run: npm install -g npm@11
+    - name: Pin npm to the version Dependabot generates lockfiles with
+      run: npm install -g npm@11.6.2 --ignore-scripts
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/webapp-build-test.yml
+++ b/.github/workflows/webapp-build-test.yml
@@ -22,6 +22,9 @@ jobs:
         node-version: 22
         cache-dependency-path: frontend/web/package-lock.json
 
+    - name: Match npm to the major Dependabot generates lockfiles with
+      run: npm install -g npm@11
+
     - name: Install dependencies
       run: |
         cd frontend/web


### PR DESCRIPTION
## Close or Relate the Issue
[//]: # (Only if this should close the issue)
- Closes #

[//]: # (in the issue a reference will be added to this pr)
- Related Issue: # (unblocks Dependabot PRs #3160, #3161, #3162)

## Proposed Changes
Description:

Every Dependabot PR fails the `build` check while every human PR passes it. That is not a broken pipeline, it is a version mismatch, and it currently blocks the entire security backlog: 4 critical, 89 high, 69 moderate and 12 low alerts cannot drain while their PRs are red.

**Root cause.** No Node or npm version is declared anywhere in the repo. There is no `.nvmrc`, no `.node-version`, no `engines` and no `packageManager` field. So CI pins Node 22 in the workflow file (npm 10) and Dependabot uses its own newer npm (11). npm 11 prunes about 15 nested entries marked `"optional": true, "peer": true`; npm 10 expects them and reports the lockfile out of sync.

The failure is visible in the diff of an otherwise trivial PR. #3160 is `+3/-42`: three lines bump `shell-quote`, the other 39 delete `@types/react` and `yaml` peer entries Dependabot never intended to touch.

**Reproduced locally**, using the same installer CI runs:

```
                        acceptance lock       Dependabot lock (#3160)
npm 10  (CI, Node 22)   PASS, 2800 packages   FAIL, CI's exact error
npm 11  (Dependabot)    PASS, 2785 packages   PASS, 2785 packages
```

The 15-package gap is the pruned peer entries.

**Fix.** Pin npm to 11 in both frontend workflows so CI reads the lockfile shape Dependabot writes.

`ci.yml` also gains `setup-node`. It previously had none and ran on whatever Node the runner image shipped, so it drifted silently whenever GitHub updated the image. It now matches the other three workflows at Node 22.

**Not fixed here, deliberately.** This pins CI to chase Dependabot rather than declaring the version once in a file both read. If Dependabot moves to npm 12 this breaks again. Declaring `engines` or `.nvmrc` is the durable fix, but I could not confirm Dependabot honours those for npm, and an unverified guess is worse than an explicit pin.

`websocket-driver` (CVE-2026-54466, the fourth critical) has no Dependabot PR and cannot have one. It is transitive via `sockjs` and `faye-websocket`, so there is no manifest line to edit. Both parents already accept the patched 0.7.5, so a lockfile refresh fixes it. Separate change.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Optimization
- [ ] Documentation update

## Change Size
- [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
- [ ] Big change (+-max 1000)
- [x] Small change (less than 300)

12 added lines across two workflow files. No application code.

## Refactoring
No refactoring. Both files are additive only.

## Evidence
- [ ] Screenshots or screen recording added for UI changes
- [ ] Before/after images added when relevant
- [ ] Images clearly show the implemented change
- [ ] Image quality is readable (no cropped or blurry evidence)

No UI change. The evidence is the reproduction table above, and this PR's own `Node.js CI` check: that workflow has no `paths:` filter, so it runs on every PR to `acceptance`, and for `pull_request` events the workflow is taken from the merge ref. This PR therefore exercises its own fix. A green `build` here is the proof.

## Responsiveness
- [ ] UI checked on mobile
- [ ] UI checked on tablet
- [ ] UI checked on desktop
- [ ] No broken layout, overflow, or hidden content on tested screen sizes

No UI change.

## Npm Packages
- [ ] NPM Packages installed
- [ ] NPM Packages removed
- [ ] NPM Packages updated
- [ ] Checked for vulnerabilities using "npm audit"

No dependency changes. `package.json` and `package-lock.json` are untouched; this only changes which npm reads them.

## Checklist
- [ ] Pull request has at least 2 reviewers assigned
- [x] PR title is descriptive and includes issue number
- [x] Conventions
  - [x] No config files have been added (Amplify config, cache files)
  - [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  - [x] No global styling (see [#1691](https://github.com/domits1/Domits/issues/1691))
  - [x] No `console.log` left in code
  - [x] No commented-out code remains
- [ ] Testing
  - [x] Code tested locally (npm 10 and npm 11 against both lockfiles, see table)
  - [ ] Jest tests are included
  - [ ] Jest tests are passing

A CI workflow change is not unit-testable. It is verified by the reproduction above and by this PR's own checks.

## Keep or delete my branch
- [x] Delete my branch after merge
- [ ] Keep my branch
