### PR TITLE
perf(ci): stop installing dependencies twice in the Cypress job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,18 @@ jobs:
           npm test -- --coverage --coverageDirectory=coverage
 
       # Run Cypress tests
+      # The composite action already installed with --ignore-scripts, which
+      # skips Cypress's postinstall, so the binary is fetched explicitly here.
+      - name: Install the Cypress binary
+        working-directory: frontend/web
+        run: npx cypress install
+
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
           working-directory: frontend/web
           start: npx vite --host
+          install: false
 
 #  sonarqube:
 #    name: SonarQube

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,11 @@ jobs:
       # Run Cypress tests
       # The composite action already installed with --ignore-scripts, which
       # skips Cypress's postinstall, so the binary is fetched explicitly here.
+      # Calling the linked binary rather than npx keeps the version the one
+      # the lockfile resolved, and never fetches a package on demand.
       - name: Install the Cypress binary
         working-directory: frontend/web
-        run: npx cypress install
+        run: ./node_modules/.bin/cypress install
 
       - name: Cypress run
         uses: cypress-io/github-action@v6


### PR DESCRIPTION
## Close or Relate the Issue
- Closes #
- Related Issue: # (follows #3164, which introduced the composite action)

## Proposed Changes
Description:

`ci.yml` installs the full dependency tree twice on every run. `cypress-io/github-action@v6` defaults to `install: true`, so it runs its own install on top of the one the composite action already did.

Measured on runs [33510852483](https://github.com/domits1/Domits/actions/runs/33510852483) and [33511476924](https://github.com/domits1/Domits/actions/runs/33511476924):

```
Step             Log line                                              Time
----             --------                                              ----
Setup frontend   added 2492 packages in 35s                             ~45s
Cypress run      added 2492 packages, audited 2493 packages in 2m    46s-2m
```

The second install is pure duplication of the first.

**Why the extra step is needed.** That second install was also the thing supplying the Cypress binary. The composite action installs with `--ignore-scripts`, which skips Cypress's postinstall, so turning the action's install off without replacing it would leave no binary at all. `npx cypress install` fetches just the binary rather than re-resolving 2492 packages.

**This also confirms something that was previously unverified.** `--ignore-scripts` landed in #3164 but had never run alongside Cypress, because `ci.yml` only fires on pushes to `acceptance` touching `frontend/**`. Both runs above show it does not break Cypress: no binary error, the suite runs and fails on assertions.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Optimization
- [ ] Documentation update

## Change Size
- [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
- [ ] Big change (+-max 1000)
- [x] Small change (less than 300)

Seven lines in one workflow.

## Refactoring
No refactoring.

## Evidence
- [ ] Screenshots or screen recording added for UI changes
- [ ] Before/after images added when relevant
- [ ] Images clearly show the implemented change
- [ ] Image quality is readable (no cropped or blurry evidence)

No UI change. Evidence is the two run logs quoted above.

## Responsiveness
- [ ] UI checked on mobile
- [ ] UI checked on tablet
- [ ] UI checked on desktop
- [ ] No broken layout, overflow, or hidden content on tested screen sizes

No UI change.

## Npm Packages
- [ ] NPM Packages installed
- [ ] NPM Packages removed
- [ ] NPM Packages updated
- [ ] Checked for vulnerabilities using "npm audit"

No dependency changes.

## Checklist
- [ ] Pull request has at least 2 reviewers assigned
- [x] PR title is descriptive and includes issue number
- [x] Conventions
  - [x] No config files have been added (Amplify config, cache files)
  - [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  - [x] No global styling (see [#1691](https://github.com/domits1/Domits/issues/1691))
  - [x] No `console.log` left in code
  - [x] No commented-out code remains
- [ ] Testing
  - [x] Code tested locally (verified against two completed CI runs)
  - [ ] Jest tests are included
  - [ ] Jest tests are passing

## Note for the reviewer, unrelated to this change

This suite currently fails **73 tests**, up from **51** on 30 June. That regression is not caused by this PR or by anything merged today: all three runs on 1 September report 73, including the one whose head predates the Swiper upgrade.

The cause is structural. `ci.yml` only runs on pushes to `acceptance` touching `frontend/**`, so it never appears on a pull request and cannot block a merge. Between 30 June and 1 September it did not run at all. Twenty-two tests broke in that window with nobody notified.

Worth its own issue. The merge gate in `CLAUDE.md` says "CI green" while an entire workflow has been red for ten weeks.

## Keep or delete my branch
- [x] Delete my branch after merge
- [ ] Keep my branch
