### PR TITLE
#3038 Add public quote endpoint for direct booking websites

### DIFF
--- a/backend/functions/PropertyHandler/controller/propertyController.js
+++ b/backend/functions/PropertyHandler/controller/propertyController.js
@@ -1,5 +1,6 @@
 import { PropertyBuilder } from "../business/service/propertyBuilder.js";
 import { PropertyService } from "../business/service/propertyService.js";
+import { WebsiteQuoteService } from "../business/service/websiteQuoteService.js";
 import { AuthManager } from "../auth/authManager.js";
 import { SystemManagerRepository } from "../data/repository/systemManagerRepository.js";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
@@ -17,6 +18,7 @@ import ChannexCalendarChangeSyncClient, {
 
 import responseHeaders from "../util/constant/responseHeader.json" with { type: "json" };
 import { NotFoundException } from "../util/exception/NotFoundException.js";
+import { WebsiteQuoteError } from "../util/exception/WebsiteQuoteError.js";
 import {
     getDirectBookingWebsiteFallbackDomainSuffix,
     isDirectBookingWebsiteFallbackDomain,
@@ -48,6 +50,14 @@ const WEBSITE_PUBLIC_ANALYTICS_EVENT_TYPES = new Set([
 const WEBSITE_ANALYTICS_SURFACES = new Set(["preview", "live"]);
 const WEBSITE_ANALYTICS_VIEWPORTS = new Set(["mobile", "tablet", "desktop"]);
 const DIRECT_BOOKING_WEBSITE_PUBLIC_STATUSES = new Set(["DRAFT", "PREVIEW", "PUBLISHED", "SUSPENDED"]);
+
+// String parameter (not SecureString): SystemManagerRepository reads with WithDecryption:false.
+const DIRECT_BOOKING_WEBSITE_QUOTE_TOKEN_SECRET_PARAMETER =
+    process.env.DIRECT_BOOKING_WEBSITE_QUOTE_TOKEN_SECRET_PARAMETER || "/direct-booking-website/quote-token-secret";
+
+// Only genuine availability conflicts count as quote_conflicted in the KPI stream;
+// validation 400s are guest input errors, not conflicts.
+const WEBSITE_QUOTE_CONFLICT_ERROR_CODES = new Set(["unavailable_dates", "stay_restriction_violation"]);
 const DIRECT_BOOKING_WEBSITE_DOMAIN_STATUSES = new Set(["PENDING", "VERIFIED", "ACTIVE", "FAILED", "DISABLED"]);
 const DIRECT_BOOKING_WEBSITE_DOMAIN_TYPE_FALLBACK = "FALLBACK";
 const CHANNEX_GLOBAL_CALENDAR_CHANGE_SYNC_DAYS = 500;
@@ -181,6 +191,9 @@ export class PropertyController {
         this.directBookingWebsiteSiteRepository = new DirectBookingWebsiteSiteRepository(systemManagerRepository);
         this.directBookingWebsiteDomainRepository = new DirectBookingWebsiteDomainRepository(systemManagerRepository);
         this.channexCalendarChangeSyncClient = channexCalendarChangeSyncClient;
+        this.systemManagerRepository = systemManagerRepository;
+        this.websiteQuoteService = null;
+        this.websiteQuoteTokenSecretPromise = null;
     }
 
     // -------------------------
@@ -2925,6 +2938,147 @@ export class PropertyController {
             }
             return this.websiteServerError();
         }
+    }
+
+    // -------------------------
+    // POST /property/website/public/quote
+    // -------------------------
+    async createPublicWebsiteQuote(event) {
+        const requestId = cleanWebsiteText(event?.requestContext?.requestId) || randomUUID();
+        let site = null;
+        try {
+            let requestBody = null;
+            try {
+                requestBody = JSON.parse(event?.body || "");
+            } catch {
+                requestBody = null;
+            }
+            if (!requestBody || typeof requestBody !== "object" || Array.isArray(requestBody)) {
+                return this.websiteQuoteErrorResponse(400, "invalid_request", "A JSON object request body is required.", requestId);
+            }
+
+            const siteId = cleanWebsiteText(requestBody.siteId);
+            if (!siteId) {
+                return this.websiteQuoteErrorResponse(400, "invalid_request", "siteId is required.", requestId);
+            }
+
+            site = await this.directBookingWebsiteSiteRepository.getSiteById(siteId);
+            if (!site) {
+                return this.websiteQuoteErrorResponse(404, "site_not_found", "No website was found for this request.", requestId);
+            }
+            if (site.status === "SUSPENDED") {
+                return this.websiteQuoteErrorResponse(410, "site_suspended", "This website is no longer available.", requestId);
+            }
+            if (site.status !== "PUBLISHED") {
+                return this.websiteQuoteErrorResponse(409, "site_not_published", "This website is not published.", requestId);
+            }
+
+            const sessionId = cleanWebsiteText(requestBody.session?.sessionId) || null;
+            await this.recordStandaloneWebsiteEventSafely({
+                draftId: null,
+                propertyId: site.propertyId,
+                hostId: site.hostId,
+                eventType: "SITE_QUOTE_REQUESTED",
+                payload: {
+                    requestId,
+                    siteId: site.id,
+                    sessionId,
+                    checkIn: requestBody.checkIn ?? null,
+                    checkOut: requestBody.checkOut ?? null,
+                    guests: requestBody.guests ?? null,
+                },
+            });
+
+            // The quoted property is the site's own; a client-supplied propertyId is never used.
+            const quote = await this.getWebsiteQuoteService().createQuote({
+                siteId: site.id,
+                propertyId: site.propertyId,
+                checkIn: requestBody.checkIn,
+                checkOut: requestBody.checkOut,
+                guests: requestBody.guests,
+                currency: requestBody.currency,
+            });
+
+            await this.recordStandaloneWebsiteEventSafely({
+                draftId: null,
+                propertyId: site.propertyId,
+                hostId: site.hostId,
+                eventType: "SITE_QUOTE_RETURNED",
+                payload: {
+                    requestId,
+                    siteId: site.id,
+                    sessionId,
+                    quoteId: quote.quoteId,
+                    nights: quote.nights,
+                    total: quote.priceBreakdown?.total ?? null,
+                },
+            });
+
+            console.log(JSON.stringify({
+                scope: "websiteQuote",
+                outcome: "returned",
+                requestId,
+                siteId: site.id,
+                propertyId: site.propertyId,
+                quoteId: quote.quoteId,
+            }));
+            return {
+                statusCode: 200,
+                headers: draftResponseHeaders,
+                body: JSON.stringify(quote),
+            };maa
+        } catch (error) {
+            if (error instanceof WebsiteQuoteError) {
+                if (site && WEBSITE_QUOTE_CONFLICT_ERROR_CODES.has(error.code)) {
+                    await this.recordStandaloneWebsiteEventSafely({
+                        draftId: null,
+                        propertyId: site.propertyId,
+                        hostId: site.hostId,
+                        eventType: "SITE_QUOTE_CONFLICTED",
+                        payload: { requestId, siteId: site.id, code: error.code },
+                    });
+                }
+                console.log(JSON.stringify({
+                    scope: "websiteQuote",
+                    outcome: error.code,
+                    requestId,
+                    siteId: site?.id ?? null,
+                    propertyId: site?.propertyId ?? null,
+                }));
+                return this.websiteQuoteErrorResponse(error.statusCode, error.code, error.message, requestId);
+            }
+            console.error("Website quote request failed.", error);
+            return this.websiteQuoteErrorResponse(500, "internal_error", "We could not complete this quote request. Please try again.", requestId);
+        }
+    }
+
+    websiteQuoteErrorResponse(statusCode, code, message, requestId) {
+        return {
+            statusCode,
+            headers: draftResponseHeaders,
+            body: JSON.stringify({ error: { code, message, requestId } }),
+        };
+    }
+
+    getWebsiteQuoteService() {
+        this.websiteQuoteService ??= new WebsiteQuoteService({
+            propertyService: this.propertyService,
+            quoteTokenSecretProvider: () => this.getWebsiteQuoteTokenSecret(),
+        });
+        return this.websiteQuoteService;
+    }
+
+    async getWebsiteQuoteTokenSecret() {
+        if (!this.websiteQuoteTokenSecretPromise) {
+            this.websiteQuoteTokenSecretPromise = this.systemManagerRepository
+                .getSystemManagerParameter(DIRECT_BOOKING_WEBSITE_QUOTE_TOKEN_SECRET_PARAMETER)
+                .catch((error) => {
+                    // A transient SSM failure must not poison the warm Lambda.
+                    this.websiteQuoteTokenSecretPromise = null;
+                    throw error;
+                });
+        }
+        return this.websiteQuoteTokenSecretPromise;
     }
 
     // -------------------------

--- a/backend/functions/PropertyHandler/controller/propertyController.js
+++ b/backend/functions/PropertyHandler/controller/propertyController.js
@@ -3026,7 +3026,7 @@ export class PropertyController {
                 statusCode: 200,
                 headers: draftResponseHeaders,
                 body: JSON.stringify(quote),
-            };maa
+            };
         } catch (error) {
             if (error instanceof WebsiteQuoteError) {
                 if (site && WEBSITE_QUOTE_CONFLICT_ERROR_CODES.has(error.code)) {

--- a/backend/functions/PropertyHandler/index.js
+++ b/backend/functions/PropertyHandler/index.js
@@ -32,6 +32,9 @@ const handlePost = async (event) => {
   if (isPath(event, "/property/website/event")) {
     return controller.recordWebsiteAnalyticsEvent(event);
   }
+  if (isPath(event, "/property/website/public/quote")) {
+    return controller.createPublicWebsiteQuote(event);
+  }
   if (isPath(event, "/property/website/site/publish")) {
     return controller.publishWebsiteSite(event);
   }

--- a/backend/test/PropertyHandler/publicWebsiteQuote.test.js
+++ b/backend/test/PropertyHandler/publicWebsiteQuote.test.js
@@ -1,0 +1,202 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { PropertyController } from "../../functions/PropertyHandler/controller/propertyController.js";
+import {
+  WebsiteQuoteError,
+  WEBSITE_QUOTE_ERROR_CODES,
+} from "../../functions/PropertyHandler/util/exception/WebsiteQuoteError.js";
+
+const PUBLISHED_SITE = {
+  id: "site-1",
+  propertyId: "property-1",
+  hostId: "host-1",
+  status: "PUBLISHED",
+  templateKey: "panorama-landing",
+};
+
+const QUOTE_FIXTURE = {
+  quoteId: "quote_test",
+  siteId: "site-1",
+  propertyId: "property-1",
+  nights: 4,
+  guestCount: 2,
+  priceBreakdown: { currency: "EUR", nightlyBaseTotal: 76000, cleaningFee: 5000, total: 81000 },
+  expiresAt: "2026-09-02T12:30:00.000Z",
+  quoteToken: "qtok_test",
+};
+
+// Carries a client propertyId on purpose: the controller must never forward it.
+const REQUEST_BODY = {
+  siteId: "site-1",
+  propertyId: "attacker-property",
+  checkIn: "2026-10-01",
+  checkOut: "2026-10-05",
+  guests: 2,
+  currency: "EUR",
+  session: { sessionId: "ses-1" },
+};
+
+const buildQuoteEvent = ({ body = REQUEST_BODY, requestContext = { requestId: "req-1" } } = {}) => ({
+  httpMethod: "POST",
+  resource: "/property/website/public/quote",
+  body: typeof body === "string" ? body : JSON.stringify(body),
+  requestContext,
+});
+
+const buildQuoteController = ({ site = PUBLISHED_SITE, quote = QUOTE_FIXTURE, createQuoteError = null, recordEventError = null } = {}) => {
+  const controller = new PropertyController();
+  controller.directBookingWebsiteSiteRepository = { getSiteById: jest.fn().mockResolvedValue(site) };
+  controller.directBookingWebsiteEventRepository = {
+    recordEvent: recordEventError
+      ? jest.fn().mockRejectedValue(recordEventError)
+      : jest.fn().mockResolvedValue(undefined),
+  };
+  controller.websiteQuoteService = createQuoteError
+    ? { createQuote: jest.fn().mockRejectedValue(createQuoteError) }
+    : { createQuote: jest.fn().mockResolvedValue(quote) };
+  return controller;
+};
+
+const parseBody = (response) => JSON.parse(response.body);
+
+describe("PropertyController.createPublicWebsiteQuote", () => {
+  it("returns the quote with no-store headers for a published site", async () => {
+    const controller = buildQuoteController();
+
+    const response = await controller.createPublicWebsiteQuote(buildQuoteEvent());
+
+    expect(response.statusCode).toBe(200);
+    expect(parseBody(response)).toEqual(QUOTE_FIXTURE);
+    expect(response.headers["Cache-Control"]).toContain("no-store");
+  });
+
+  it("quotes the site's own property and ignores the client-supplied propertyId", async () => {
+    const controller = buildQuoteController();
+
+    await controller.createPublicWebsiteQuote(buildQuoteEvent());
+
+    expect(controller.websiteQuoteService.createQuote).toHaveBeenCalledWith({
+      siteId: "site-1",
+      propertyId: "property-1",
+      checkIn: "2026-10-01",
+      checkOut: "2026-10-05",
+      guests: 2,
+      currency: "EUR",
+    });
+  });
+
+  it("records a requested and a returned event, attributed to the site owner", async () => {
+    const controller = buildQuoteController();
+
+    await controller.createPublicWebsiteQuote(buildQuoteEvent());
+
+    const recorded = controller.directBookingWebsiteEventRepository.recordEvent.mock.calls.map(([input]) => input);
+    expect(recorded).toHaveLength(2);
+    expect(recorded[0]).toMatchObject({
+      propertyId: "property-1",
+      hostId: "host-1",
+      eventType: "SITE_QUOTE_REQUESTED",
+      payload: { requestId: "req-1", siteId: "site-1", sessionId: "ses-1" },
+    });
+    expect(recorded[1]).toMatchObject({
+      eventType: "SITE_QUOTE_RETURNED",
+      payload: { requestId: "req-1", quoteId: "quote_test" },
+    });
+  });
+
+  it("still returns the quote when event recording fails", async () => {
+    const controller = buildQuoteController({ recordEventError: new Error("event store down") });
+
+    const response = await controller.createPublicWebsiteQuote(buildQuoteEvent());
+
+    expect(response.statusCode).toBe(200);
+    expect(parseBody(response)).toEqual(QUOTE_FIXTURE);
+  });
+
+  it.each([
+    ["a malformed JSON body", "{not json"],
+    ["a non-object body", JSON.stringify("just-a-string")],
+    ["a body without siteId", JSON.stringify({ checkIn: "2026-10-01" })],
+  ])("rejects %s as 400 invalid_request before resolving any site", async (_label, body) => {
+    const controller = buildQuoteController();
+
+    const response = await controller.createPublicWebsiteQuote(buildQuoteEvent({ body }));
+
+    expect(response.statusCode).toBe(400);
+    expect(parseBody(response).error).toMatchObject({ code: "invalid_request", requestId: "req-1" });
+    expect(controller.directBookingWebsiteSiteRepository.getSiteById).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["an unknown site", null, 404, "site_not_found"],
+    ["a suspended site", { ...PUBLISHED_SITE, status: "SUSPENDED" }, 410, "site_suspended"],
+    ["a preview site", { ...PUBLISHED_SITE, status: "PREVIEW" }, 409, "site_not_published"],
+    ["a draft site", { ...PUBLISHED_SITE, status: "DRAFT" }, 409, "site_not_published"],
+  ])("rejects %s without quoting or recording events", async (_label, site, expectedStatus, expectedCode) => {
+    const controller = buildQuoteController({ site });
+
+    const response = await controller.createPublicWebsiteQuote(buildQuoteEvent());
+
+    expect(response.statusCode).toBe(expectedStatus);
+    expect(parseBody(response).error).toMatchObject({ code: expectedCode, requestId: "req-1" });
+    expect(controller.websiteQuoteService.createQuote).not.toHaveBeenCalled();
+    expect(controller.directBookingWebsiteEventRepository.recordEvent).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [WEBSITE_QUOTE_ERROR_CODES.INVALID_DATE_RANGE, 400, false],
+    [WEBSITE_QUOTE_ERROR_CODES.INVALID_GUEST_COUNT, 400, false],
+    [WEBSITE_QUOTE_ERROR_CODES.UNAVAILABLE_DATES, 409, true],
+    [WEBSITE_QUOTE_ERROR_CODES.STAY_RESTRICTION_VIOLATION, 409, true],
+    [WEBSITE_QUOTE_ERROR_CODES.QUOTE_UNAVAILABLE, 422, false],
+    [WEBSITE_QUOTE_ERROR_CODES.PRICING_SERVICE_UNAVAILABLE, 503, false],
+  ])("maps a %s quote error to %i and records a conflict event only for conflicts", async (code, expectedStatus, expectsConflictEvent) => {
+    const controller = buildQuoteController({ createQuoteError: new WebsiteQuoteError(code, "Quote failed for the test.") });
+
+    const response = await controller.createPublicWebsiteQuote(buildQuoteEvent());
+
+    expect(response.statusCode).toBe(expectedStatus);
+    expect(parseBody(response).error).toMatchObject({
+      code,
+      message: "Quote failed for the test.",
+      requestId: "req-1",
+    });
+
+    const recorded = controller.directBookingWebsiteEventRepository.recordEvent.mock.calls.map(([input]) => input);
+    const conflictEvents = recorded.filter((input) => input.eventType === "SITE_QUOTE_CONFLICTED");
+    if (expectsConflictEvent) {
+      expect(conflictEvents).toHaveLength(1);
+      expect(conflictEvents[0]).toMatchObject({
+        propertyId: "property-1",
+        hostId: "host-1",
+        payload: { requestId: "req-1", siteId: "site-1", code },
+      });
+    } else {
+      expect(conflictEvents).toHaveLength(0);
+    }
+  });
+
+  it("returns a generic 500 internal_error without leaking the failure detail", async () => {
+    const controller = buildQuoteController({ createQuoteError: new Error("boom: connection string leaked") });
+
+    const response = await controller.createPublicWebsiteQuote(buildQuoteEvent());
+
+    expect(response.statusCode).toBe(500);
+    const { error } = parseBody(response);
+    expect(error.code).toBe("internal_error");
+    expect(error.requestId).toBe("req-1");
+    expect(error.message).not.toContain("boom");
+  });
+
+  it("generates a requestId when API Gateway does not provide one", async () => {
+    const controller = buildQuoteController();
+
+    const response = await controller.createPublicWebsiteQuote(
+      buildQuoteEvent({ body: JSON.stringify({}), requestContext: undefined })
+    );
+
+    expect(response.statusCode).toBe(400);
+    const { error } = parseBody(response);
+    expect(typeof error.requestId).toBe("string");
+    expect(error.requestId.length).toBeGreaterThan(0);
+  });
+});

--- a/backend/test/PropertyHandler/routing-unit.test.js
+++ b/backend/test/PropertyHandler/routing-unit.test.js
@@ -29,6 +29,7 @@ const directRouteSpecs = [
   ["PATCH property calendar overrides request", "updatePropertyCalendarOverrides", "PATCH", "/property/calendar/overrides", 200],
   ["PATCH property activation request", "activateProperty", "PATCH", "/property", 204],
   ["POST website analytics event request", "recordWebsiteAnalyticsEvent", "POST", "/property/website/event", 204],
+  ["POST public website quote request", "createPublicWebsiteQuote", "POST", "/property/website/public/quote", 200],
   ["POST website site publish request", "publishWebsiteSite", "POST", "/property/website/site/publish", 200],
   ["POST website site unpublish request", "unpublishWebsiteSite", "POST", "/property/website/site/unpublish", 200],
   ["POST website draft upsert request", "upsertWebsiteDraft", "POST", "/property/website/draft", 200],


### PR DESCRIPTION
## Close or Relate the Issue
[//]: # (Only if this should close the issue)
- Closes 

[//]: # (in the issue a reference will be added to this pr)
- Related Issue: #3038

## Proposed Changes
[//]: # (Add a detailed description of the changes here)
Description:

Adds an endpoint so a guest on a direct booking website can ask what a stay costs: POST /property/website/public/quote.

This builds on #3168, which added the code that does the actual work (checking the dates, checking if it's still free, calculating the price). This PR just makes that reachable from the website. That's why it targets #3168 instead of acceptance; once that one merges, the base moves to acceptance by itself.

Why everything happens on the server: guests on these sites don't have an account, so there's no login to check. If we calculated the price in the browser, anyone could open devtools and change it. So the server decides everything and the browser is trusted with nothing.

What it does:
* Takes only the siteId from the request and looks up the property in the database. If the browser sends a propertyId, it gets ignored, so you can't ask for a price on someone else's property
* Handles three cases for the site: 404 if it doesn't exist, 410 if it's suspended, 409 if it isn't published yet. In all three, no price is returned and nothing is logged
* Turns the error codes from the quote engine into HTTP status codes
* Writes three events for the KPI dashboard. The conflict event only fires when the dates are actually taken, not when someone types a wrong date, so input mistakes don't count as conflicts
* Returns a generic 500 on unexpected errors, so nothing internal ends up in the response


## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Optimization
- [ ] Documentation update

## Change Size
[//]: # (Indicate the size of this change.)
[//]: # (Clarify under Refactoring which parts are moved/unchanged code, so the reviewer doesn’t review old logic.)
- [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
- [x] Big change (+-max 1000)
- [ ] Small change (less than 300)

## Refactoring
Refactors following files, but didn't change the code. This is to avoid reviewing old logic.
- N/A

## Evidence
- [ ] Screenshots or screen recording added for UI changes
- [ ] Before/after images added when relevant
- [ ] Images clearly show the implemented change
- [ ] Image quality is readable (no cropped or blurry evidence)

## Responsiveness
- [ ] UI checked on mobile
- [ ] UI checked on tablet
- [ ] UI checked on desktop
- [ ] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages
- [ ] NPM Packages installed
- [ ] NPM Packages removed
- [ ] NPM Packages updated
- [ ] Checked for vulnerabilities using "npm audit"

## Checklist
[//]: # (All boxes must be checked before merging.)
- [ ] Pull request has at least 2 reviewers assigned
- [x] PR title is descriptive and includes issue number
- [x] Conventions
  - [x] No config files have been added (Amplify config, cache files)
  - [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  - [x] No global styling (see [#1691](https://github.com/domits1/Domits/issues/1691))
  - [ ] No `console.log` left in code
  - [x] No commented-out code remains
- [x] Testing
  - [x] Code tested locally
  - [x] Jest tests are included
  - [x] Jest tests are passing
 
Note on console.log: the handler writes one structured JSON log line per request with siteId, propertyId, requestId and the outcome. That's the logging the design pack asks for on these routes, and CloudWatch is the only place it can go in this Lambda. Happy to switch if the team has a logger I've missed.

## Keep or delete my branch
- [x] Delete my branch after merge
- [ ] Keep my branch  
