### PR TITLE
#3038 Add quote panel to direct booking websites

### DIFF
--- a/frontend/web/src/features/hostdashboard/website/WebsitePublicSitePage.jsx
+++ b/frontend/web/src/features/hostdashboard/website/WebsitePublicSitePage.jsx
@@ -362,6 +362,7 @@ function WebsitePublicSitePage() {
             showContactWidget={publicModel.visibility?.chatWidget ?? true}
             showBrowserChrome={false}
             enableScrollReveal={isPanoramaTemplate}
+            quoteContext={renderPayload?.site?.id ? { siteId: String(renderPayload.site.id) } : null}
           />
         </div>
       </main>

--- a/frontend/web/src/features/hostdashboard/website/rendering/AvailabilityCalendarPreview.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/AvailabilityCalendarPreview.jsx
@@ -89,9 +89,6 @@ const selectionPropType = PropTypes.shape({
   onSelectDate: PropTypes.func,
 });
 
-// Selection is opt-in: the calendar stays a display-only snapshot in the editor
-// and the draft preview, and becomes a date-range picker only when the booking
-// section on the live site hands it a selection.
 const resolveCellSelectionState = (cell, selection) => {
   if (!selection?.selectable || !cell.isCurrentMonth) {
     return null;

--- a/frontend/web/src/features/hostdashboard/website/rendering/AvailabilityCalendarPreview.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/AvailabilityCalendarPreview.jsx
@@ -81,6 +81,61 @@ const availabilityPropType = PropTypes.shape({
   callout: PropTypes.string,
 });
 
+const selectionPropType = PropTypes.shape({
+  selectable: PropTypes.bool,
+  checkIn: PropTypes.string,
+  checkOut: PropTypes.string,
+  todayKey: PropTypes.string,
+  onSelectDate: PropTypes.func,
+});
+
+// Selection is opt-in: the calendar stays a display-only snapshot in the editor
+// and the draft preview, and becomes a date-range picker only when the booking
+// section on the live site hands it a selection.
+const resolveCellSelectionState = (cell, selection) => {
+  if (!selection?.selectable || !cell.isCurrentMonth) {
+    return null;
+  }
+  const checkIn = selection.checkIn || null;
+  const checkOut = selection.checkOut || null;
+  return {
+    isPast: Boolean(selection.todayKey) && cell.id < selection.todayKey,
+    isCheckIn: cell.id === checkIn,
+    isCheckOut: cell.id === checkOut,
+    isInRange: Boolean(checkIn && checkOut) && cell.id > checkIn && cell.id < checkOut,
+  };
+};
+
+const buildCellSelectionClassName = (selectionState, classNames) => {
+  if (!selectionState) {
+    return "";
+  }
+  const isSelected = selectionState.isCheckIn || selectionState.isCheckOut;
+  return `${classNames.selectable} ${isSelected ? classNames.selected : ""} ${
+    selectionState.isInRange ? classNames.inRange : ""
+  } ${selectionState.isPast ? classNames.past : ""}`.trim();
+};
+
+const buildCellSelectionProps = (cell, selection, selectionState) =>
+  selectionState
+    ? {
+        type: "button",
+        disabled: selectionState.isPast,
+        "aria-pressed": selectionState.isCheckIn || selectionState.isCheckOut,
+        onClick: () => selection.onSelectDate?.(cell.id),
+      }
+    : {};
+
+const resolveSelectionLabelSuffix = (selectionState) => {
+  if (selectionState?.isCheckIn) {
+    return ", check-in";
+  }
+  if (selectionState?.isCheckOut) {
+    return ", check-out";
+  }
+  return "";
+};
+
 const splitInteractiveTargetProps = (interactiveTargetProps = {}) => {
   const { className = "", ...targetProps } = interactiveTargetProps;
   return {
@@ -251,6 +306,7 @@ function LegacyAvailabilityCalendar({
   templateKey = "",
   titleInteractiveTargetProps = {},
   descriptionInteractiveTargetProps = {},
+  selection = null,
 }) {
   const { externalBlockedDateKeySet, unavailableDateKeySet } = useAvailabilityDateKeySets(availability);
   const baseMonth = useMemo(() => {
@@ -370,16 +426,27 @@ function LegacyAvailabilityCalendar({
         {calendarCells.map((cell) => {
           const status = getCalendarCellStatus(cell);
           const StatusIcon = status?.Icon;
+          const selectionState = resolveCellSelectionState(cell, selection);
+          const CellElement = selectionState ? "button" : "span";
 
           return (
-            <span
+            <CellElement
               key={cell.id}
               className={`${styles.calendarCell} ${cell.isCurrentMonth ? styles.calendarCellCurrent : ""} ${
                 cell.isExternalBlocked ? styles.calendarCellBlocked : ""
               } ${cell.isUnavailable && !cell.isExternalBlocked ? styles.calendarCellUnavailable : ""} ${
                 cell.isUnavailable ? styles.calendarCellBlockedBase : ""
-              } ${cell.isToday ? styles.calendarCellToday : ""}`.trim()}
+              } ${cell.isToday ? styles.calendarCellToday : ""} ${buildCellSelectionClassName(selectionState, {
+                selectable: styles.calendarCellSelectable,
+                selected: styles.calendarCellSelected,
+                inRange: styles.calendarCellInRange,
+                past: styles.calendarCellPast,
+              })}`.trim()}
               title={status?.title}
+              aria-label={
+                selectionState ? `${monthLabel} ${cell.dayOfMonth}${resolveSelectionLabelSuffix(selectionState)}` : undefined
+              }
+              {...buildCellSelectionProps(cell, selection, selectionState)}
             >
               <span className={styles.calendarCellDay}>{cell.dayOfMonth}</span>
               {status && StatusIcon ? (
@@ -388,7 +455,7 @@ function LegacyAvailabilityCalendar({
                   <span>{status.label}</span>
                 </span>
               ) : null}
-            </span>
+            </CellElement>
           );
         })}
       </div>
@@ -405,6 +472,7 @@ LegacyAvailabilityCalendar.propTypes = {
   templateKey: PropTypes.string,
   titleInteractiveTargetProps: interactiveTargetPropType,
   descriptionInteractiveTargetProps: interactiveTargetPropType,
+  selection: selectionPropType,
 };
 
 function PanoramaAvailabilityCalendar({
@@ -417,6 +485,7 @@ function PanoramaAvailabilityCalendar({
   templateKey = "",
   titleInteractiveTargetProps = {},
   descriptionInteractiveTargetProps = {},
+  selection = null,
 }) {
   const { externalBlockedDateKeySet, unavailableDateKeySet } = useAvailabilityDateKeySets(availability);
   const baseMonth = useMemo(() => {
@@ -514,24 +583,37 @@ function PanoramaAvailabilityCalendar({
                 const isReserved = cell.isExternalBlocked || cell.isUnavailable;
                 const isPlaceholder = !cell.isCurrentMonth;
                 const availabilityLabel = isReserved ? "Reserved" : "Available";
+                const selectionState = resolveCellSelectionState(cell, selection);
+                const CellElement = selectionState ? "button" : "span";
                 const calendarCellLabel = isPlaceholder
                   ? undefined
-                  : `${monthView.label} ${cell.dayOfMonth}, ${availabilityLabel}`;
+                  : `${monthView.label} ${cell.dayOfMonth}, ${availabilityLabel}${resolveSelectionLabelSuffix(
+                      selectionState
+                    )}`;
 
                 return (
-                  <span
+                  <CellElement
                     key={cell.id}
                     className={`${styles.panoramaCalendarCell} ${
                       isReserved ? styles.panoramaCalendarCellReserved : ""
-                    } ${isPlaceholder ? styles.panoramaCalendarCellPlaceholder : ""}`.trim()}
+                    } ${isPlaceholder ? styles.panoramaCalendarCellPlaceholder : ""} ${buildCellSelectionClassName(
+                      selectionState,
+                      {
+                        selectable: styles.panoramaCalendarCellSelectable,
+                        selected: styles.panoramaCalendarCellSelected,
+                        inRange: styles.panoramaCalendarCellInRange,
+                        past: styles.panoramaCalendarCellPast,
+                      }
+                    )}`.trim()}
                     title={status?.title}
                     aria-label={calendarCellLabel}
                     aria-hidden={isPlaceholder}
+                    {...buildCellSelectionProps(cell, selection, selectionState)}
                   >
                     {cell.isCurrentMonth ? (
                       <span className={styles.panoramaCalendarCellDay}>{cell.dayOfMonth}</span>
                     ) : null}
-                  </span>
+                  </CellElement>
                 );
               })}
             </div>
@@ -566,6 +648,7 @@ PanoramaAvailabilityCalendar.propTypes = {
   templateKey: PropTypes.string,
   titleInteractiveTargetProps: interactiveTargetPropType,
   descriptionInteractiveTargetProps: interactiveTargetPropType,
+  selection: selectionPropType,
 };
 
 export default function AvailabilityCalendarPreview({
@@ -577,6 +660,7 @@ export default function AvailabilityCalendarPreview({
   variant = "default",
   propertyTitle = "",
   templateKey = "",
+  selection = null,
 }) {
   const { className: interactiveClassName = "", ...rootInteractiveProps } = interactiveTargetProps || {};
 
@@ -592,6 +676,7 @@ export default function AvailabilityCalendarPreview({
         interactiveClassName={interactiveClassName}
         templateKey={templateKey}
         titleInteractiveTargetProps={titleInteractiveTargetProps}
+        selection={selection}
       />
     );
   }
@@ -606,6 +691,7 @@ export default function AvailabilityCalendarPreview({
       interactiveClassName={interactiveClassName}
       templateKey={templateKey}
       titleInteractiveTargetProps={titleInteractiveTargetProps}
+      selection={selection}
     />
   );
 }

--- a/frontend/web/src/features/hostdashboard/website/rendering/AvailabilityCalendarPreview.module.scss
+++ b/frontend/web/src/features/hostdashboard/website/rendering/AvailabilityCalendarPreview.module.scss
@@ -507,7 +507,6 @@
   }
 }
 
-/* Date-range selection (live site only; the calendar stays display-only elsewhere). */
 .calendarCellSelectable,
 .panoramaCalendarCellSelectable {
   appearance: none;

--- a/frontend/web/src/features/hostdashboard/website/rendering/AvailabilityCalendarPreview.module.scss
+++ b/frontend/web/src/features/hostdashboard/website/rendering/AvailabilityCalendarPreview.module.scss
@@ -506,3 +506,50 @@
     font-size: 0.92rem;
   }
 }
+
+/* Date-range selection (live site only; the calendar stays display-only elsewhere). */
+.calendarCellSelectable,
+.panoramaCalendarCellSelectable {
+  appearance: none;
+  -webkit-appearance: none;
+  font: inherit;
+  cursor: pointer;
+  transition: background-color 120ms ease, color 120ms ease;
+}
+
+.calendarCellSelectable:focus-visible,
+.panoramaCalendarCellSelectable:focus-visible {
+  outline: 2px solid #1e3150;
+  outline-offset: -2px;
+}
+
+.calendarCellSelectable:not(:disabled):hover {
+  border-color: rgba(31, 78, 121, 0.4);
+}
+
+.panoramaCalendarCellSelectable {
+  border-radius: 10px;
+  background: transparent;
+}
+
+.panoramaCalendarCellSelectable:not(:disabled):hover {
+  background: rgba(30, 49, 80, 0.08);
+}
+
+.calendarCellInRange,
+.panoramaCalendarCellInRange {
+  background: rgba(30, 49, 80, 0.14);
+}
+
+.calendarCellSelected,
+.panoramaCalendarCellSelected,
+.panoramaCalendarCellSelectable.panoramaCalendarCellSelected:hover {
+  background: #1e3150;
+  color: #ffffff;
+}
+
+.calendarCellPast,
+.panoramaCalendarCellPast {
+  color: rgba(30, 49, 80, 0.35);
+  cursor: not-allowed;
+}

--- a/frontend/web/src/features/hostdashboard/website/rendering/WebsiteTemplatePreview.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/WebsiteTemplatePreview.jsx
@@ -188,6 +188,7 @@ export function WebsiteTemplateSurface({
   browserTitle = "",
   onSelectTarget,
   activeTargetId = "",
+  quoteContext = null,
 }) {
   const template = getWebsiteTemplateById(templateId);
   const TemplateComponent = getWebsiteTemplateRenderer(template.id);
@@ -234,6 +235,7 @@ export function WebsiteTemplateSurface({
             model={model}
             onSelectTarget={onSelectTarget}
             activeTargetId={activeTargetId}
+            quoteContext={quoteContext}
           />
         ) : (
           <UnsupportedTemplatePreview templateName={template.name} />
@@ -252,6 +254,7 @@ export function WebsiteTemplateSurface({
 
 WebsiteTemplateSurface.propTypes = {
   templateId: PropTypes.string.isRequired,
+  quoteContext: PropTypes.shape({ siteId: PropTypes.string }),
   model: websiteTemplatePreviewModelPropType,
   viewport: PropTypes.oneOf(["desktop", "tablet", "mobile"]),
   showContactWidget: PropTypes.bool,

--- a/frontend/web/src/features/hostdashboard/website/rendering/WebsiteTemplatePreview.module.scss
+++ b/frontend/web/src/features/hostdashboard/website/rendering/WebsiteTemplatePreview.module.scss
@@ -1316,8 +1316,6 @@
   }
 }
 
-/* Switched on before an in-page navigation scrolls, so the target is measured
-   against real section heights and the layout stays stable mid-scroll. */
 .panoramaDeferredRenderSection.panoramaDeferredRenderSectionRevealed {
   content-visibility: visible;
 }

--- a/frontend/web/src/features/hostdashboard/website/rendering/WebsiteTemplatePreview.module.scss
+++ b/frontend/web/src/features/hostdashboard/website/rendering/WebsiteTemplatePreview.module.scss
@@ -1316,6 +1316,12 @@
   }
 }
 
+/* Switched on before an in-page navigation scrolls, so the target is measured
+   against real section heights and the layout stays stable mid-scroll. */
+.panoramaDeferredRenderSection.panoramaDeferredRenderSectionRevealed {
+  content-visibility: visible;
+}
+
 .sectionHeadingTitle {
   margin: 0;
   color: #0f172a;

--- a/frontend/web/src/features/hostdashboard/website/rendering/WebsiteTemplatePreview.module.scss
+++ b/frontend/web/src/features/hostdashboard/website/rendering/WebsiteTemplatePreview.module.scss
@@ -2961,3 +2961,15 @@
     padding: 16px;
   }
 }
+
+.panoramaHeroPrimaryActionButton {
+  appearance: none;
+  -webkit-appearance: none;
+  font: inherit;
+  cursor: pointer;
+}
+
+.panoramaHeroPrimaryActionButton:focus-visible {
+  outline: 2px solid #f8f4ed;
+  outline-offset: 3px;
+}

--- a/frontend/web/src/features/hostdashboard/website/rendering/animations/WebsiteTemplateMotion.module.scss
+++ b/frontend/web/src/features/hostdashboard/website/rendering/animations/WebsiteTemplateMotion.module.scss
@@ -16,8 +16,6 @@
   filter: blur(0) !important;
 }
 
-/* Added once the reveal transition has ended: a settled section is a plain block
-   again, not a composited layer with lingering transform/filter/will-change. */
 .scrollRevealSettled {
   transform: none !important;
   filter: none !important;

--- a/frontend/web/src/features/hostdashboard/website/rendering/animations/WebsiteTemplateMotion.module.scss
+++ b/frontend/web/src/features/hostdashboard/website/rendering/animations/WebsiteTemplateMotion.module.scss
@@ -16,6 +16,14 @@
   filter: blur(0) !important;
 }
 
+/* Added once the reveal transition has ended: a settled section is a plain block
+   again, not a composited layer with lingering transform/filter/will-change. */
+.scrollRevealSettled {
+  transform: none !important;
+  filter: none !important;
+  will-change: auto !important;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .previewCanvasAnimated [data-scroll-reveal] {
     opacity: 1;

--- a/frontend/web/src/features/hostdashboard/website/rendering/animations/revealDeferredSections.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/animations/revealDeferredSections.js
@@ -1,9 +1,3 @@
-// Sections below the fold render with content-visibility: auto and a placeholder
-// intrinsic size. Measuring an anchor while those placeholders are in effect
-// gives a stale scroll target, and the sections then re-lay-out at their real
-// height while the smooth scroll is in flight — Safari's hit-testing goes stale
-// until the next real scroll. Once a guest navigates, deferral has done its job,
-// so every deferred section is switched to normal rendering before measuring.
 export const revealDeferredSections = (rootNode, deferredClassName, revealedClassName) => {
   if (!rootNode?.querySelectorAll || !deferredClassName || !revealedClassName) {
     return 0;

--- a/frontend/web/src/features/hostdashboard/website/rendering/animations/revealDeferredSections.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/animations/revealDeferredSections.js
@@ -1,0 +1,17 @@
+// Sections below the fold render with content-visibility: auto and a placeholder
+// intrinsic size. Measuring an anchor while those placeholders are in effect
+// gives a stale scroll target, and the sections then re-lay-out at their real
+// height while the smooth scroll is in flight — Safari's hit-testing goes stale
+// until the next real scroll. Once a guest navigates, deferral has done its job,
+// so every deferred section is switched to normal rendering before measuring.
+export const revealDeferredSections = (rootNode, deferredClassName, revealedClassName) => {
+  if (!rootNode?.querySelectorAll || !deferredClassName || !revealedClassName) {
+    return 0;
+  }
+
+  const deferredSections = Array.from(rootNode.querySelectorAll(`.${deferredClassName}`));
+  deferredSections.forEach((section) => {
+    section.classList.add(revealedClassName);
+  });
+  return deferredSections.length;
+};

--- a/frontend/web/src/features/hostdashboard/website/rendering/animations/useWebsiteScrollReveal.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/animations/useWebsiteScrollReveal.js
@@ -4,6 +4,23 @@ import motionStyles from "./WebsiteTemplateMotion.module.scss";
 const WEBSITE_SCROLL_REVEAL_THRESHOLD = 0.08;
 const WEBSITE_SCROLL_REVEAL_ROOT_MARGIN = "0px 0px 6% 0px";
 
+// A revealed section keeps its transform, filter and will-change until the
+// transition ends, then settles into a plain block. Leaving those hints on
+// keeps every section on its own compositing layer for the life of the page,
+// which is what makes Safari's hit-testing go stale after a smooth scroll.
+const settleAfterTransition = (target, settledClassName) => {
+  const handleTransitionEnd = (event) => {
+    if (event.target !== target) {
+      return;
+    }
+    target.classList.add(settledClassName);
+    target.removeEventListener("transitionend", handleTransitionEnd);
+  };
+
+  target.addEventListener("transitionend", handleTransitionEnd);
+  return () => target.removeEventListener("transitionend", handleTransitionEnd);
+};
+
 export const useWebsiteScrollReveal = ({ enabled = false, deps = [] } = {}) => {
   const previewCanvasRef = useRef(null);
 
@@ -23,8 +40,9 @@ export const useWebsiteScrollReveal = ({ enabled = false, deps = [] } = {}) => {
     }
 
     const revealClassName = motionStyles.scrollRevealVisible;
+    const settledClassName = motionStyles.scrollRevealSettled;
     revealTargets.forEach((target) => {
-      target.classList.remove(revealClassName);
+      target.classList.remove(revealClassName, settledClassName);
     });
 
     const prefersReducedMotion =
@@ -32,12 +50,14 @@ export const useWebsiteScrollReveal = ({ enabled = false, deps = [] } = {}) => {
       globalThis.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
     if (typeof IntersectionObserver === "undefined" || prefersReducedMotion) {
+      // Nothing animates on this path, so no transitionend will ever arrive.
       revealTargets.forEach((target) => {
-        target.classList.add(revealClassName);
+        target.classList.add(revealClassName, settledClassName);
       });
       return undefined;
     }
 
+    const stopSettling = [];
     const observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
@@ -45,6 +65,7 @@ export const useWebsiteScrollReveal = ({ enabled = false, deps = [] } = {}) => {
             return;
           }
 
+          stopSettling.push(settleAfterTransition(entry.target, settledClassName));
           entry.target.classList.add(revealClassName);
           observer.unobserve(entry.target);
         });
@@ -61,6 +82,7 @@ export const useWebsiteScrollReveal = ({ enabled = false, deps = [] } = {}) => {
 
     return () => {
       observer.disconnect();
+      stopSettling.forEach((stop) => stop());
     };
   }, [enabled, ...deps]);
 

--- a/frontend/web/src/features/hostdashboard/website/rendering/animations/useWebsiteScrollReveal.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/animations/useWebsiteScrollReveal.js
@@ -4,10 +4,6 @@ import motionStyles from "./WebsiteTemplateMotion.module.scss";
 const WEBSITE_SCROLL_REVEAL_THRESHOLD = 0.08;
 const WEBSITE_SCROLL_REVEAL_ROOT_MARGIN = "0px 0px 6% 0px";
 
-// A revealed section keeps its transform, filter and will-change until the
-// transition ends, then settles into a plain block. Leaving those hints on
-// keeps every section on its own compositing layer for the life of the page,
-// which is what makes Safari's hit-testing go stale after a smooth scroll.
 const settleAfterTransition = (target, settledClassName) => {
   const handleTransitionEnd = (event) => {
     if (event.target !== target) {
@@ -50,7 +46,6 @@ export const useWebsiteScrollReveal = ({ enabled = false, deps = [] } = {}) => {
       globalThis.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
     if (typeof IntersectionObserver === "undefined" || prefersReducedMotion) {
-      // Nothing animates on this path, so no transitionend will ever arrive.
       revealTargets.forEach((target) => {
         target.classList.add(revealClassName, settledClassName);
       });

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/GuestCountField.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/GuestCountField.jsx
@@ -1,0 +1,57 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styles from "./QuoteAvailabilitySection.module.scss";
+
+export default function GuestCountField({ value, onChange, min = 1, max = null, disabled = false, errorMessage = "" }) {
+  const hasMax = Number.isInteger(max) && max > 0;
+  const canDecrement = !disabled && value > min;
+  const canIncrement = !disabled && (!hasMax || value < max);
+
+  return (
+    <div className={styles.guestField}>
+      <div className={styles.guestFieldHeader}>
+        <span id="website-quote-guests-label" className={styles.fieldLabel}>
+          Guests
+        </span>
+        {hasMax ? <span className={styles.hint}>{`Up to ${max} guests`}</span> : null}
+      </div>
+      <div className={styles.stepper} role="group" aria-labelledby="website-quote-guests-label">
+        <button
+          type="button"
+          className={styles.stepperButton}
+          aria-label="Remove a guest"
+          disabled={!canDecrement}
+          onClick={() => onChange(value - 1)}
+        >
+          −
+        </button>
+        <span className={styles.stepperValue} aria-live="polite">
+          {value}
+        </span>
+        <button
+          type="button"
+          className={styles.stepperButton}
+          aria-label="Add a guest"
+          disabled={!canIncrement}
+          onClick={() => onChange(value + 1)}
+        >
+          +
+        </button>
+      </div>
+      {errorMessage ? (
+        <p className={styles.fieldError} role="alert">
+          {errorMessage}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+GuestCountField.propTypes = {
+  value: PropTypes.number.isRequired,
+  onChange: PropTypes.func.isRequired,
+  min: PropTypes.number,
+  max: PropTypes.number,
+  disabled: PropTypes.bool,
+  errorMessage: PropTypes.string,
+};

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/GuestCountField.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/GuestCountField.jsx
@@ -8,14 +8,12 @@ export default function GuestCountField({ value, onChange, min = 1, max = null, 
   const canIncrement = !disabled && (!hasMax || value < max);
 
   return (
-    <div className={styles.guestField}>
-      <div className={styles.guestFieldHeader}>
-        <span id="website-quote-guests-label" className={styles.fieldLabel}>
-          Guests
-        </span>
+    <fieldset className={styles.guestField}>
+      <legend className={styles.guestFieldLegend}>
+        <span className={styles.fieldLabel}>Guests</span>
         {hasMax ? <span className={styles.hint}>{`Up to ${max} guests`}</span> : null}
-      </div>
-      <div className={styles.stepper} role="group" aria-labelledby="website-quote-guests-label">
+      </legend>
+      <div className={styles.stepper}>
         <button
           type="button"
           className={styles.stepperButton}
@@ -43,7 +41,7 @@ export default function GuestCountField({ value, onChange, min = 1, max = null, 
           {errorMessage}
         </p>
       ) : null}
-    </div>
+    </fieldset>
   );
 }
 

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/QuoteAvailabilitySection.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/QuoteAvailabilitySection.jsx
@@ -26,8 +26,6 @@ const resolveContactHref = (model) => {
   return whatsapp?.isAvailable && digits ? `https://wa.me/${digits}` : null;
 };
 
-// Owns the guest's booking selection so the calendar and the quote panel stay
-// siblings and the templates stay orchestration-only.
 export default function QuoteAvailabilitySection({
   model,
   siteId,

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/QuoteAvailabilitySection.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/QuoteAvailabilitySection.jsx
@@ -1,0 +1,147 @@
+import React, { useCallback, useMemo, useState } from "react";
+import PropTypes from "prop-types";
+import styles from "./QuoteAvailabilitySection.module.scss";
+import QuotePanel from "./QuotePanel";
+import { useWebsiteQuote } from "./useWebsiteQuote";
+import { resolveQuoteErrorPresentation } from "./quoteErrorCopy";
+import { EMPTY_STAY_RANGE, getTodayDateKey, selectStayDate } from "./quoteSelection";
+import { TemplateAvailabilityCalendar } from "../templates/templateSharedSections";
+import { getOrCreateVisitorId } from "../../services/websiteVisitorId";
+
+const DEFAULT_GUEST_COUNT = 2;
+
+const resolveCapacity = (model) => {
+  const capacity = Number(model?.stay?.guests);
+  return Number.isInteger(capacity) && capacity > 0 ? capacity : null;
+};
+
+const resolveMinimumStay = (model) => {
+  const minimumStay = Number(model?.stay?.minimumStay);
+  return Number.isFinite(minimumStay) && minimumStay > 0 ? minimumStay : null;
+};
+
+const resolveContactHref = (model) => {
+  const whatsapp = model?.host?.whatsapp;
+  const digits = String(whatsapp?.phoneNumberDigits || "").replaceAll(/\D/g, "");
+  return whatsapp?.isAvailable && digits ? `https://wa.me/${digits}` : null;
+};
+
+// Owns the guest's booking selection so the calendar and the quote panel stay
+// siblings and the templates stay orchestration-only.
+export default function QuoteAvailabilitySection({
+  model,
+  siteId,
+  variant = "default",
+  templateKey = "",
+  propertyTitle = "",
+  onSelectTarget = undefined,
+  activeTargetId = "",
+}) {
+  const sessionId = useMemo(() => getOrCreateVisitorId(), []);
+  const todayKey = useMemo(() => getTodayDateKey(), []);
+  const capacity = resolveCapacity(model);
+  const blockedDateKeys = useMemo(
+    () =>
+      new Set([
+        ...(Array.isArray(model?.availability?.externalBlockedDates) ? model.availability.externalBlockedDates : []),
+        ...(Array.isArray(model?.availability?.unavailableDateKeys) ? model.availability.unavailableDateKeys : []),
+      ]),
+    [model?.availability]
+  );
+
+  const [range, setRange] = useState(EMPTY_STAY_RANGE);
+  const [guests, setGuests] = useState(() => (capacity ? Math.min(DEFAULT_GUEST_COUNT, capacity) : DEFAULT_GUEST_COUNT));
+  const { requestQuote, notifySelectionChanged, ...quoteState } = useWebsiteQuote({ siteId, sessionId });
+
+  const handleSelectDate = useCallback(
+    (dateKey) => {
+      const nextRange = selectStayDate({ range, dateKey, blockedDateKeys, todayKey });
+      if (nextRange === range) {
+        return;
+      }
+      setRange(nextRange);
+      notifySelectionChanged();
+    },
+    [blockedDateKeys, notifySelectionChanged, range, todayKey]
+  );
+
+  const handleGuestsChange = useCallback(
+    (nextGuests) => {
+      setGuests(nextGuests);
+      notifySelectionChanged();
+    },
+    [notifySelectionChanged]
+  );
+
+  const handleRequestQuote = useCallback(async () => {
+    const result = await requestQuote({ checkIn: range.checkIn, checkOut: range.checkOut, guests });
+    if (result?.error && resolveQuoteErrorPresentation(result.error).clearSelection) {
+      setRange(EMPTY_STAY_RANGE);
+    }
+  }, [guests, range.checkIn, range.checkOut, requestQuote]);
+
+  const selection = useMemo(
+    () => ({
+      selectable: true,
+      checkIn: range.checkIn,
+      checkOut: range.checkOut,
+      todayKey,
+      onSelectDate: handleSelectDate,
+    }),
+    [handleSelectDate, range.checkIn, range.checkOut, todayKey]
+  );
+
+  return (
+    <div className={`${styles.quoteSection} ${variant === "panorama" ? styles.quoteSectionPanorama : ""}`.trim()}>
+      <div className={styles.quoteSectionCalendar}>
+        <TemplateAvailabilityCalendar
+          model={model}
+          variant={variant}
+          templateKey={templateKey}
+          propertyTitle={propertyTitle}
+          onSelectTarget={onSelectTarget}
+          activeTargetId={activeTargetId}
+          selection={selection}
+        />
+      </div>
+      <div className={styles.quoteSectionPanel}>
+        <QuotePanel
+          range={range}
+          guests={guests}
+          onGuestsChange={handleGuestsChange}
+          capacity={capacity}
+          minimumStay={resolveMinimumStay(model)}
+          quoteState={quoteState}
+          onRequestQuote={handleRequestQuote}
+          contactHref={resolveContactHref(model)}
+        />
+      </div>
+    </div>
+  );
+}
+
+QuoteAvailabilitySection.propTypes = {
+  model: PropTypes.shape({
+    availability: PropTypes.shape({
+      externalBlockedDates: PropTypes.arrayOf(PropTypes.string),
+      unavailableDateKeys: PropTypes.arrayOf(PropTypes.string),
+    }).isRequired,
+    calendarSection: PropTypes.shape({}),
+    stay: PropTypes.shape({
+      guests: PropTypes.number,
+      minimumStay: PropTypes.number,
+    }),
+    host: PropTypes.shape({
+      whatsapp: PropTypes.shape({
+        isAvailable: PropTypes.bool,
+        phoneNumberDigits: PropTypes.string,
+      }),
+    }),
+  }).isRequired,
+  siteId: PropTypes.string.isRequired,
+  variant: PropTypes.oneOf(["default", "panorama"]),
+  templateKey: PropTypes.string,
+  propertyTitle: PropTypes.string,
+  onSelectTarget: PropTypes.func,
+  activeTargetId: PropTypes.string,
+};

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/QuoteAvailabilitySection.module.scss
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/QuoteAvailabilitySection.module.scss
@@ -1,0 +1,255 @@
+.quoteSection {
+  display: grid;
+  gap: clamp(16px, 2.4vw, 28px);
+  align-items: start;
+}
+
+@media (min-width: 900px) {
+  .quoteSection {
+    grid-template-columns: minmax(0, 1.55fr) minmax(280px, 0.85fr);
+  }
+}
+
+.quoteSectionCalendar,
+.quoteSectionPanel {
+  min-width: 0;
+}
+
+.panel {
+  --website-quote-ink: #1e3150;
+  --website-quote-muted: #60708a;
+  --website-quote-line: rgba(30, 49, 80, 0.12);
+  --website-quote-accent: #1e3150;
+  display: grid;
+  gap: clamp(12px, 1.6vw, 18px);
+  padding: clamp(18px, 2.4vw, 26px);
+  border-radius: 22px;
+  border: 1px solid var(--website-quote-line);
+  background: #ffffff;
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.06);
+  color: var(--website-quote-ink);
+}
+
+.panelEyebrow {
+  margin: 0;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--website-quote-muted);
+}
+
+.panelTitle {
+  margin: 0;
+  font-size: clamp(1.15rem, 0.9rem + 0.9vw, 1.45rem);
+  line-height: 1.2;
+  text-wrap: balance;
+}
+
+.stayBlock {
+  display: grid;
+  gap: 6px;
+  padding-bottom: clamp(10px, 1.4vw, 14px);
+  border-bottom: 1px solid var(--website-quote-line);
+}
+
+.staySummary {
+  margin: 0;
+  font-weight: 600;
+}
+
+.stayNights {
+  margin: 0;
+  color: var(--website-quote-muted);
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.84rem;
+  color: var(--website-quote-muted);
+}
+
+.fieldError {
+  margin: 0;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #9f3a2b;
+}
+
+.guestField {
+  display: grid;
+  gap: 8px;
+}
+
+.guestFieldHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.fieldLabel {
+  font-weight: 600;
+}
+
+.stepper {
+  display: inline-grid;
+  grid-template-columns: 40px minmax(48px, auto) 40px;
+  align-items: center;
+  border: 1px solid var(--website-quote-line);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.stepperButton {
+  appearance: none;
+  -webkit-appearance: none;
+  height: 40px;
+  border: 0;
+  background: transparent;
+  color: var(--website-quote-ink);
+  font: inherit;
+  font-size: 1.15rem;
+  cursor: pointer;
+}
+
+.stepperButton:disabled {
+  color: rgba(30, 49, 80, 0.3);
+  cursor: not-allowed;
+}
+
+.stepperButton:focus-visible,
+.action:focus-visible,
+.secondaryAction:focus-visible,
+.contactLink:focus-visible {
+  outline: 2px solid var(--website-quote-accent);
+  outline-offset: 2px;
+}
+
+.stepperValue {
+  text-align: center;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.action {
+  appearance: none;
+  -webkit-appearance: none;
+  min-height: 48px;
+  padding: 0.7rem 1.1rem;
+  border: 0;
+  border-radius: 999px;
+  background: var(--website-quote-accent);
+  color: #f8f4ed;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  transition: opacity 120ms ease;
+}
+
+.action:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.alert {
+  display: grid;
+  gap: 10px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(159, 58, 43, 0.28);
+  background: rgba(159, 58, 43, 0.06);
+}
+
+.alertMessage {
+  margin: 0;
+  font-weight: 600;
+}
+
+.alertActions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 14px;
+}
+
+.secondaryAction {
+  appearance: none;
+  -webkit-appearance: none;
+  padding: 0.45rem 0.9rem;
+  border: 1px solid var(--website-quote-line);
+  border-radius: 999px;
+  background: #ffffff;
+  color: var(--website-quote-ink);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.contactLink {
+  color: var(--website-quote-ink);
+  font-weight: 600;
+}
+
+.reference {
+  margin: 0;
+  width: 100%;
+  font-size: 0.78rem;
+  color: var(--website-quote-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.breakdown {
+  display: grid;
+  gap: 8px;
+  padding-top: clamp(10px, 1.4vw, 14px);
+  border-top: 1px solid var(--website-quote-line);
+}
+
+.breakdownStale {
+  opacity: 0.6;
+}
+
+.staleNotice {
+  margin: 0;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--website-quote-muted);
+}
+
+.breakdownList {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+}
+
+.breakdownRow {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.breakdownRow dt,
+.breakdownRow dd {
+  margin: 0;
+}
+
+.breakdownTotal {
+  padding-top: 6px;
+  border-top: 1px dashed var(--website-quote-line);
+  font-weight: 700;
+}
+
+.validity {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--website-quote-muted);
+}
+
+.note {
+  margin: 0;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  color: var(--website-quote-muted);
+}

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/QuoteAvailabilitySection.module.scss
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/QuoteAvailabilitySection.module.scss
@@ -79,13 +79,19 @@
 .guestField {
   display: grid;
   gap: 8px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  min-width: 0;
 }
 
-.guestFieldHeader {
+.guestFieldLegend {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
   gap: 12px;
+  width: 100%;
+  padding: 0;
 }
 
 .fieldLabel {

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/QuoteAvailabilitySection.module.scss
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/QuoteAvailabilitySection.module.scss
@@ -30,15 +30,6 @@
   color: var(--website-quote-ink);
 }
 
-.panelEyebrow {
-  margin: 0;
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--website-quote-muted);
-}
-
 .panelTitle {
   margin: 0;
   font-size: clamp(1.15rem, 0.9rem + 0.9vw, 1.45rem);
@@ -250,12 +241,5 @@
 .validity {
   margin: 0;
   font-size: 0.82rem;
-  color: var(--website-quote-muted);
-}
-
-.note {
-  margin: 0;
-  font-size: 0.78rem;
-  line-height: 1.45;
   color: var(--website-quote-muted);
 }

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/QuotePanel.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/QuotePanel.jsx
@@ -10,18 +10,16 @@ const pluralizeNights = (count) => `${count} ${count === 1 ? "night" : "nights"}
 
 const resolveStaySummary = ({ checkIn, checkOut }) => {
   if (!checkIn) {
-    return "Select your check-in date on the calendar.";
+    return "Pick a check-in date";
   }
   if (!checkOut) {
-    return "Now pick your check-out date on the calendar.";
+    return "Now pick a check-out date";
   }
   return `${formatStayDate(checkIn)} → ${formatStayDate(checkOut)}`;
 };
 
 const resolveStaleNotice = (staleReason) =>
-  staleReason === QUOTE_STALE_REASONS.EXPIRED
-    ? "This price has expired — check again."
-    : "Dates or guests changed — check the price again.";
+  staleReason === QUOTE_STALE_REASONS.EXPIRED ? "Price expired — check again" : "Selection changed — check again";
 
 function QuoteBreakdown({ quote, isStale, staleReason }) {
   const { priceBreakdown, nights } = quote;
@@ -47,7 +45,7 @@ function QuoteBreakdown({ quote, isStale, staleReason }) {
           <dd>{formatMinorUnits(priceBreakdown.total)}</dd>
         </div>
       </dl>
-      {!isStale && validUntil ? <p className={styles.validity}>{`Price valid until ${validUntil}`}</p> : null}
+      {!isStale && validUntil ? <p className={styles.validity}>{`Valid until ${validUntil}`}</p> : null}
     </div>
   );
 }
@@ -133,7 +131,6 @@ export default function QuotePanel({
 
   return (
     <aside className={styles.panel} aria-labelledby="website-quote-panel-title">
-      <p className={styles.panelEyebrow}>Live price</p>
       <h3 id="website-quote-panel-title" className={styles.panelTitle}>
         Check availability &amp; price
       </h3>
@@ -159,7 +156,7 @@ export default function QuotePanel({
 
       {showAction ? (
         <button type="button" className={styles.action} onClick={onRequestQuote} disabled={!canRequestQuote}>
-          {isLoading ? "Checking…" : "Check availability & price"}
+          {isLoading ? "Checking…" : "Check availability"}
         </button>
       ) : null}
 
@@ -175,8 +172,6 @@ export default function QuotePanel({
       {showBreakdown ? (
         <QuoteBreakdown quote={quoteState.quote} isStale={isStale} staleReason={quoteState.staleReason} />
       ) : null}
-
-      <p className={styles.note}>Live pricing and availability are checked when you request a price.</p>
     </aside>
   );
 }

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/QuotePanel.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/QuotePanel.jsx
@@ -1,0 +1,205 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styles from "./QuoteAvailabilitySection.module.scss";
+import GuestCountField from "./GuestCountField";
+import { QUOTE_STALE_REASONS, QUOTE_STATUS } from "./useWebsiteQuote";
+import { QUOTE_ERROR_SCOPES, resolveQuoteErrorPresentation } from "./quoteErrorCopy";
+import { countStayNights, formatMinorUnits, formatQuoteValidUntil, formatStayDate } from "./quoteSelection";
+
+const pluralizeNights = (count) => `${count} ${count === 1 ? "night" : "nights"}`;
+
+const resolveStaySummary = ({ checkIn, checkOut }) => {
+  if (!checkIn) {
+    return "Select your check-in date on the calendar.";
+  }
+  if (!checkOut) {
+    return "Now pick your check-out date on the calendar.";
+  }
+  return `${formatStayDate(checkIn)} → ${formatStayDate(checkOut)}`;
+};
+
+const resolveStaleNotice = (staleReason) =>
+  staleReason === QUOTE_STALE_REASONS.EXPIRED
+    ? "This price has expired — check again."
+    : "Dates or guests changed — check the price again.";
+
+function QuoteBreakdown({ quote, isStale, staleReason }) {
+  const { priceBreakdown, nights } = quote;
+  const nightlyRate = nights > 0 ? Math.round(priceBreakdown.nightlyBaseTotal / nights) : null;
+  const validUntil = formatQuoteValidUntil(quote.expiresAt);
+
+  return (
+    <div className={`${styles.breakdown} ${isStale ? styles.breakdownStale : ""}`.trim()} aria-live="polite">
+      {isStale ? <p className={styles.staleNotice}>{resolveStaleNotice(staleReason)}</p> : null}
+      <dl className={styles.breakdownList}>
+        <div className={styles.breakdownRow}>
+          <dt>{`${formatMinorUnits(nightlyRate)} × ${pluralizeNights(nights)}`}</dt>
+          <dd>{formatMinorUnits(priceBreakdown.nightlyBaseTotal)}</dd>
+        </div>
+        {priceBreakdown.cleaningFee > 0 ? (
+          <div className={styles.breakdownRow}>
+            <dt>Cleaning fee</dt>
+            <dd>{formatMinorUnits(priceBreakdown.cleaningFee)}</dd>
+          </div>
+        ) : null}
+        <div className={`${styles.breakdownRow} ${styles.breakdownTotal}`}>
+          <dt>Total</dt>
+          <dd>{formatMinorUnits(priceBreakdown.total)}</dd>
+        </div>
+      </dl>
+      {!isStale && validUntil ? <p className={styles.validity}>{`Price valid until ${validUntil}`}</p> : null}
+    </div>
+  );
+}
+
+QuoteBreakdown.propTypes = {
+  quote: PropTypes.shape({
+    nights: PropTypes.number.isRequired,
+    expiresAt: PropTypes.string,
+    priceBreakdown: PropTypes.shape({
+      nightlyBaseTotal: PropTypes.number.isRequired,
+      cleaningFee: PropTypes.number.isRequired,
+      total: PropTypes.number.isRequired,
+    }).isRequired,
+  }).isRequired,
+  isStale: PropTypes.bool.isRequired,
+  staleReason: PropTypes.string,
+};
+
+function QuotePanelAlert({ presentation, requestId, contactHref, onRetry }) {
+  const showActions = presentation.canRetry || (presentation.showContact && contactHref) || presentation.showReference;
+
+  return (
+    <div className={styles.alert} role="alert">
+      <p className={styles.alertMessage}>{presentation.message}</p>
+      {showActions ? (
+        <div className={styles.alertActions}>
+          {presentation.canRetry ? (
+            <button type="button" className={styles.secondaryAction} onClick={onRetry}>
+              Try again
+            </button>
+          ) : null}
+          {presentation.showContact && contactHref ? (
+            <a className={styles.contactLink} href={contactHref} target="_blank" rel="noreferrer">
+              Contact the host
+            </a>
+          ) : null}
+          {presentation.showReference && requestId ? (
+            <p className={styles.reference}>{`Reference: ${requestId}`}</p>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+QuotePanelAlert.propTypes = {
+  presentation: PropTypes.shape({
+    message: PropTypes.string.isRequired,
+    canRetry: PropTypes.bool,
+    showContact: PropTypes.bool,
+    showReference: PropTypes.bool,
+  }).isRequired,
+  requestId: PropTypes.string,
+  contactHref: PropTypes.string,
+  onRetry: PropTypes.func.isRequired,
+};
+
+export default function QuotePanel({
+  range,
+  guests,
+  onGuestsChange,
+  capacity = null,
+  minimumStay = null,
+  quoteState,
+  onRequestQuote,
+  contactHref = null,
+}) {
+  const checkIn = range?.checkIn || null;
+  const checkOut = range?.checkOut || null;
+  const nights = countStayNights(checkIn, checkOut);
+  const isLoading = quoteState.status === QUOTE_STATUS.LOADING;
+  const isStale = quoteState.status === QUOTE_STATUS.STALE;
+  const showBreakdown = Boolean(quoteState.quote) && (quoteState.status === QUOTE_STATUS.SUCCESS || isStale);
+
+  const errorPresentation =
+    quoteState.status === QUOTE_STATUS.ERROR ? resolveQuoteErrorPresentation(quoteState.error) : null;
+  const datesError = errorPresentation?.scope === QUOTE_ERROR_SCOPES.DATES ? errorPresentation.message : "";
+  const guestsError = errorPresentation?.scope === QUOTE_ERROR_SCOPES.GUESTS ? errorPresentation.message : "";
+  const panelError = errorPresentation?.scope === QUOTE_ERROR_SCOPES.PANEL ? errorPresentation : null;
+
+  const showAction = !panelError?.hideAction;
+  const canRequestQuote = nights > 0 && guests >= 1 && !isLoading;
+
+  return (
+    <aside className={styles.panel} aria-labelledby="website-quote-panel-title">
+      <p className={styles.panelEyebrow}>Live price</p>
+      <h3 id="website-quote-panel-title" className={styles.panelTitle}>
+        Check availability &amp; price
+      </h3>
+
+      <div className={styles.stayBlock}>
+        <p className={styles.staySummary}>{resolveStaySummary({ checkIn, checkOut })}</p>
+        {nights > 0 ? <p className={styles.stayNights}>{pluralizeNights(nights)}</p> : null}
+        {minimumStay > 0 ? <p className={styles.hint}>{`Minimum stay: ${pluralizeNights(minimumStay)}`}</p> : null}
+        {datesError ? (
+          <p className={styles.fieldError} role="alert">
+            {datesError}
+          </p>
+        ) : null}
+      </div>
+
+      <GuestCountField
+        value={guests}
+        onChange={onGuestsChange}
+        max={capacity}
+        disabled={isLoading}
+        errorMessage={guestsError}
+      />
+
+      {showAction ? (
+        <button type="button" className={styles.action} onClick={onRequestQuote} disabled={!canRequestQuote}>
+          {isLoading ? "Checking…" : "Check availability & price"}
+        </button>
+      ) : null}
+
+      {panelError ? (
+        <QuotePanelAlert
+          presentation={panelError}
+          requestId={quoteState.error?.requestId || ""}
+          contactHref={contactHref}
+          onRetry={onRequestQuote}
+        />
+      ) : null}
+
+      {showBreakdown ? (
+        <QuoteBreakdown quote={quoteState.quote} isStale={isStale} staleReason={quoteState.staleReason} />
+      ) : null}
+
+      <p className={styles.note}>Live pricing and availability are checked when you request a price.</p>
+    </aside>
+  );
+}
+
+QuotePanel.propTypes = {
+  range: PropTypes.shape({
+    checkIn: PropTypes.string,
+    checkOut: PropTypes.string,
+  }).isRequired,
+  guests: PropTypes.number.isRequired,
+  onGuestsChange: PropTypes.func.isRequired,
+  capacity: PropTypes.number,
+  minimumStay: PropTypes.number,
+  quoteState: PropTypes.shape({
+    status: PropTypes.oneOf(Object.values(QUOTE_STATUS)).isRequired,
+    quote: PropTypes.shape({}),
+    error: PropTypes.shape({
+      code: PropTypes.string,
+      message: PropTypes.string,
+      requestId: PropTypes.string,
+    }),
+    staleReason: PropTypes.string,
+  }).isRequired,
+  onRequestQuote: PropTypes.func.isRequired,
+  contactHref: PropTypes.string,
+};

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/quoteErrorCopy.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/quoteErrorCopy.js
@@ -1,0 +1,90 @@
+export const QUOTE_ERROR_SCOPES = Object.freeze({
+  DATES: "dates",
+  GUESTS: "guests",
+  PANEL: "panel",
+});
+
+const SITE_LIFECYCLE_CODES = new Set(["site_not_found", "site_not_published", "site_suspended"]);
+const TRANSIENT_CODES = new Set(["pricing_service_unavailable", "network_error", "rate_limited"]);
+const SERVER_MESSAGE_CODES = Object.freeze({
+  invalid_date_range: QUOTE_ERROR_SCOPES.DATES,
+  stay_restriction_violation: QUOTE_ERROR_SCOPES.DATES,
+  invalid_guest_count: QUOTE_ERROR_SCOPES.GUESTS,
+});
+
+const FALLBACK_MESSAGES = Object.freeze({
+  invalid_date_range: "Please choose a valid check-in and check-out date.",
+  stay_restriction_violation: "These dates don't meet this property's stay rules.",
+  invalid_guest_count: "Please choose a valid number of guests.",
+});
+
+const presentation = ({
+  scope,
+  message,
+  canRetry = false,
+  showContact = false,
+  showReference = false,
+  hideAction = false,
+  clearSelection = false,
+}) => ({ scope, message, canRetry, showContact, showReference, hideAction, clearSelection });
+
+// Server messages for guest-input problems were written guest-facing on purpose,
+// so they are shown as-is. Infrastructure and lifecycle failures get client copy.
+export const resolveQuoteErrorPresentation = (error) => {
+  const code = String(error?.code || "");
+  const serverMessage = String(error?.message || "").trim();
+
+  if (SERVER_MESSAGE_CODES[code]) {
+    return presentation({
+      scope: SERVER_MESSAGE_CODES[code],
+      message: serverMessage || FALLBACK_MESSAGES[code],
+    });
+  }
+
+  if (code === "unavailable_dates") {
+    return presentation({
+      scope: QUOTE_ERROR_SCOPES.DATES,
+      message: "Those dates are no longer available — please choose different dates.",
+      clearSelection: true,
+    });
+  }
+
+  if (SITE_LIFECYCLE_CODES.has(code)) {
+    return presentation({
+      scope: QUOTE_ERROR_SCOPES.PANEL,
+      message: "Online booking isn't available for this site right now.",
+      hideAction: true,
+    });
+  }
+
+  if (code === "quote_unavailable") {
+    return presentation({
+      scope: QUOTE_ERROR_SCOPES.PANEL,
+      message: "This property can't be booked online right now.",
+      showContact: true,
+    });
+  }
+
+  if (code === "rate_limited") {
+    return presentation({
+      scope: QUOTE_ERROR_SCOPES.PANEL,
+      message: "Too many requests — please try again in a moment.",
+      canRetry: true,
+    });
+  }
+
+  if (TRANSIENT_CODES.has(code)) {
+    return presentation({
+      scope: QUOTE_ERROR_SCOPES.PANEL,
+      message: "We couldn't check live pricing. Please try again.",
+      canRetry: true,
+    });
+  }
+
+  return presentation({
+    scope: QUOTE_ERROR_SCOPES.PANEL,
+    message: "Something went wrong while checking this price. Please try again.",
+    canRetry: true,
+    showReference: Boolean(String(error?.requestId || "").trim()),
+  });
+};

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/quoteErrorCopy.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/quoteErrorCopy.js
@@ -28,8 +28,6 @@ const presentation = ({
   clearSelection = false,
 }) => ({ scope, message, canRetry, showContact, showReference, hideAction, clearSelection });
 
-// Server messages for guest-input problems were written guest-facing on purpose,
-// so they are shown as-is. Infrastructure and lifecycle failures get client copy.
 export const resolveQuoteErrorPresentation = (error) => {
   const code = String(error?.code || "");
   const serverMessage = String(error?.message || "").trim();

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/quotePanelGate.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/quotePanelGate.js
@@ -1,8 +1,14 @@
 // The quote panel exists only on the live published surface: the editor and the
 // draft preview never pass a quoteContext, and a host must opt in per site.
 // It is built around the availability calendar, so it follows that flag too.
-export const resolveQuotePanelVisibility = ({ quoteContext, model, onSelectTarget = undefined }) =>
-  Boolean(String(quoteContext?.siteId || "").trim()) &&
-  model?.visibility?.quotePanel === true &&
-  model?.visibility?.availabilityCalendar !== false &&
-  !onSelectTarget;
+// Returns the site id to quote against, or null when the panel must not render,
+// so callers never dereference quoteContext themselves.
+export const resolveQuotePanelSiteId = ({ quoteContext, model, onSelectTarget = undefined }) => {
+  const siteId = String(quoteContext?.siteId || "").trim();
+  const isEnabled =
+    Boolean(siteId) &&
+    model?.visibility?.quotePanel === true &&
+    model?.visibility?.availabilityCalendar !== false &&
+    !onSelectTarget;
+  return isEnabled ? siteId : null;
+};

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/quotePanelGate.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/quotePanelGate.js
@@ -1,8 +1,3 @@
-// The quote panel exists only on the live published surface: the editor and the
-// draft preview never pass a quoteContext, and a host must opt in per site.
-// It is built around the availability calendar, so it follows that flag too.
-// Returns the site id to quote against, or null when the panel must not render,
-// so callers never dereference quoteContext themselves.
 export const resolveQuotePanelSiteId = ({ quoteContext, model, onSelectTarget = undefined }) => {
   const siteId = String(quoteContext?.siteId || "").trim();
   const isEnabled =

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/quotePanelGate.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/quotePanelGate.js
@@ -1,0 +1,8 @@
+// The quote panel exists only on the live published surface: the editor and the
+// draft preview never pass a quoteContext, and a host must opt in per site.
+// It is built around the availability calendar, so it follows that flag too.
+export const resolveQuotePanelVisibility = ({ quoteContext, model, onSelectTarget = undefined }) =>
+  Boolean(String(quoteContext?.siteId || "").trim()) &&
+  model?.visibility?.quotePanel === true &&
+  model?.visibility?.availabilityCalendar !== false &&
+  !onSelectTarget;

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/quoteSelection.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/quoteSelection.js
@@ -3,8 +3,6 @@ const padDatePart = (value) => String(value).padStart(2, "0");
 
 export const EMPTY_STAY_RANGE = Object.freeze({ checkIn: null, checkOut: null });
 
-// Calendar keys are local dates ("YYYY-MM-DD"), matching the availability calendar's
-// own keys. ISO keys compare lexicographically, so string comparison is date order.
 export const toLocalDateKey = (date) =>
   `${date.getFullYear()}-${padDatePart(date.getMonth() + 1)}-${padDatePart(date.getDate())}`;
 
@@ -39,8 +37,6 @@ export const countStayNights = (checkIn, checkOut) => buildStayNightKeys(checkIn
 export const hasBlockedNight = (checkIn, checkOut, blockedDateKeys) =>
   buildStayNightKeys(checkIn, checkOut).some((nightKey) => blockedDateKeys?.has?.(nightKey) === true);
 
-// Two-click range selection. A blocked day can end a stay (checkout is exclusive)
-// but never start one; a click that would span a blocked night restarts the range.
 export const selectStayDate = ({ range, dateKey, blockedDateKeys, todayKey }) => {
   const currentRange = range || EMPTY_STAY_RANGE;
   if (!isValidDateKey(dateKey) || (todayKey && dateKey < todayKey)) {

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/quoteSelection.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/quoteSelection.js
@@ -1,0 +1,84 @@
+const DATE_KEY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+const padDatePart = (value) => String(value).padStart(2, "0");
+
+export const EMPTY_STAY_RANGE = Object.freeze({ checkIn: null, checkOut: null });
+
+// Calendar keys are local dates ("YYYY-MM-DD"), matching the availability calendar's
+// own keys. ISO keys compare lexicographically, so string comparison is date order.
+export const toLocalDateKey = (date) =>
+  `${date.getFullYear()}-${padDatePart(date.getMonth() + 1)}-${padDatePart(date.getDate())}`;
+
+export const getTodayDateKey = (now = new Date()) => toLocalDateKey(now);
+
+export const isValidDateKey = (value) => typeof value === "string" && DATE_KEY_PATTERN.test(value);
+
+const parseLocalDate = (dateKey) => {
+  const match = DATE_KEY_PATTERN.exec(String(dateKey || ""));
+  if (!match) {
+    return null;
+  }
+  return new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+};
+
+export const buildStayNightKeys = (checkIn, checkOut) => {
+  if (!isValidDateKey(checkIn) || !isValidDateKey(checkOut) || checkOut <= checkIn) {
+    return [];
+  }
+
+  const nightKeys = [];
+  const cursor = parseLocalDate(checkIn);
+  while (toLocalDateKey(cursor) < checkOut) {
+    nightKeys.push(toLocalDateKey(cursor));
+    cursor.setDate(cursor.getDate() + 1);
+  }
+  return nightKeys;
+};
+
+export const countStayNights = (checkIn, checkOut) => buildStayNightKeys(checkIn, checkOut).length;
+
+export const hasBlockedNight = (checkIn, checkOut, blockedDateKeys) =>
+  buildStayNightKeys(checkIn, checkOut).some((nightKey) => blockedDateKeys?.has?.(nightKey) === true);
+
+// Two-click range selection. A blocked day can end a stay (checkout is exclusive)
+// but never start one; a click that would span a blocked night restarts the range.
+export const selectStayDate = ({ range, dateKey, blockedDateKeys, todayKey }) => {
+  const currentRange = range || EMPTY_STAY_RANGE;
+  if (!isValidDateKey(dateKey) || (todayKey && dateKey < todayKey)) {
+    return currentRange;
+  }
+
+  const { checkIn, checkOut } = currentRange;
+  const isChoosingCheckOut = Boolean(checkIn) && !checkOut && dateKey > checkIn;
+  if (isChoosingCheckOut && !hasBlockedNight(checkIn, dateKey, blockedDateKeys)) {
+    return { checkIn, checkOut: dateKey };
+  }
+
+  if (blockedDateKeys?.has?.(dateKey) === true) {
+    return currentRange;
+  }
+
+  return { checkIn: dateKey, checkOut: null };
+};
+
+export const formatMinorUnits = (amount, currency = "EUR") => {
+  if (typeof amount !== "number" || !Number.isFinite(amount)) {
+    return "";
+  }
+  return new Intl.NumberFormat("en", { style: "currency", currency }).format(amount / 100);
+};
+
+export const formatStayDate = (dateKey) => {
+  const date = parseLocalDate(dateKey);
+  if (!date) {
+    return "";
+  }
+  return new Intl.DateTimeFormat("en-GB", { weekday: "short", day: "numeric", month: "short" }).format(date);
+};
+
+export const formatQuoteValidUntil = (expiresAt) => {
+  const expiresAtMs = Date.parse(expiresAt);
+  if (!Number.isFinite(expiresAtMs)) {
+    return "";
+  }
+  return new Intl.DateTimeFormat("en-GB", { hour: "2-digit", minute: "2-digit" }).format(new Date(expiresAtMs));
+};

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/useWebsiteQuote.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/useWebsiteQuote.js
@@ -75,8 +75,6 @@ export const useWebsiteQuote = ({ siteId, sessionId }) => {
     );
   }, []);
 
-  // A change to dates or guests keeps a previous price visible but marked stale,
-  // and clears a previous error so the guest starts from a clean panel.
   const notifySelectionChanged = useCallback(() => {
     setState((currentState) => {
       if (currentState.quote) {

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/useWebsiteQuote.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/useWebsiteQuote.js
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  WEBSITE_PUBLIC_QUOTE_CLIENT_ERROR_CODES,
+  WebsitePublicQuoteError,
+  requestPublicWebsiteQuote,
+} from "../../services/websitePublicQuoteService";
+
+export const QUOTE_STATUS = Object.freeze({
+  IDLE: "idle",
+  LOADING: "loading",
+  SUCCESS: "success",
+  STALE: "stale",
+  ERROR: "error",
+});
+
+export const QUOTE_STALE_REASONS = Object.freeze({
+  CHANGED: "changed",
+  EXPIRED: "expired",
+});
+
+const EXPIRY_CHECK_INTERVAL_MS = 30_000;
+
+const INITIAL_STATE = Object.freeze({
+  status: QUOTE_STATUS.IDLE,
+  quote: null,
+  error: null,
+  staleReason: null,
+});
+
+const toQuoteError = (error) =>
+  error instanceof WebsitePublicQuoteError
+    ? error
+    : new WebsitePublicQuoteError({ code: WEBSITE_PUBLIC_QUOTE_CLIENT_ERROR_CODES.UNEXPECTED_RESPONSE });
+
+export const useWebsiteQuote = ({ siteId, sessionId }) => {
+  const [state, setState] = useState(INITIAL_STATE);
+  const abortControllerRef = useRef(null);
+
+  const requestQuote = useCallback(
+    async ({ checkIn, checkOut, guests }) => {
+      abortControllerRef.current?.abort();
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
+      setState((currentState) => ({ ...currentState, status: QUOTE_STATUS.LOADING, error: null }));
+
+      try {
+        const quote = await requestPublicWebsiteQuote({
+          siteId,
+          checkIn,
+          checkOut,
+          guests,
+          sessionId,
+          signal: abortController.signal,
+        });
+        if (abortController.signal.aborted) {
+          return { ok: false, aborted: true };
+        }
+        setState({ status: QUOTE_STATUS.SUCCESS, quote, error: null, staleReason: null });
+        return { ok: true, quote };
+      } catch (error) {
+        if (abortController.signal.aborted || error?.name === "AbortError") {
+          return { ok: false, aborted: true };
+        }
+        const quoteError = toQuoteError(error);
+        setState({ status: QUOTE_STATUS.ERROR, quote: null, error: quoteError, staleReason: null });
+        return { ok: false, error: quoteError };
+      }
+    },
+    [sessionId, siteId]
+  );
+
+  const markStale = useCallback((reason = QUOTE_STALE_REASONS.CHANGED) => {
+    setState((currentState) =>
+      currentState.quote ? { ...currentState, status: QUOTE_STATUS.STALE, staleReason: reason } : currentState
+    );
+  }, []);
+
+  // A change to dates or guests keeps a previous price visible but marked stale,
+  // and clears a previous error so the guest starts from a clean panel.
+  const notifySelectionChanged = useCallback(() => {
+    setState((currentState) => {
+      if (currentState.quote) {
+        return { ...currentState, status: QUOTE_STATUS.STALE, staleReason: QUOTE_STALE_REASONS.CHANGED };
+      }
+      if (currentState.status === QUOTE_STATUS.ERROR) {
+        return INITIAL_STATE;
+      }
+      return currentState;
+    });
+  }, []);
+
+  const reset = useCallback(() => {
+    abortControllerRef.current?.abort();
+    setState(INITIAL_STATE);
+  }, []);
+
+  useEffect(() => {
+    if (state.status !== QUOTE_STATUS.SUCCESS) {
+      return undefined;
+    }
+
+    const checkExpiry = () => {
+      const expiresAtMs = Date.parse(state.quote?.expiresAt);
+      if (Number.isFinite(expiresAtMs) && Date.now() >= expiresAtMs) {
+        markStale(QUOTE_STALE_REASONS.EXPIRED);
+      }
+    };
+
+    checkExpiry();
+    const intervalId = globalThis.setInterval(checkExpiry, EXPIRY_CHECK_INTERVAL_MS);
+    return () => globalThis.clearInterval(intervalId);
+  }, [markStale, state.quote, state.status]);
+
+  useEffect(() => () => abortControllerRef.current?.abort(), []);
+
+  return { ...state, requestQuote, markStale, notifySelectionChanged, reset };
+};

--- a/frontend/web/src/features/hostdashboard/website/rendering/buildWebsiteTemplateModel.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/buildWebsiteTemplateModel.js
@@ -719,6 +719,8 @@ export const buildWebsiteTemplateModel = ({ propertyDetails, summaryProperty = n
       journeyStops: true,
       contactSection: true,
       chatWidget: true,
+      // Off until a host opts in: the booking flow behind the panel is still landing.
+      quotePanel: false,
     },
   };
 };

--- a/frontend/web/src/features/hostdashboard/website/rendering/buildWebsiteTemplateModel.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/buildWebsiteTemplateModel.js
@@ -719,7 +719,6 @@ export const buildWebsiteTemplateModel = ({ propertyDetails, summaryProperty = n
       journeyStops: true,
       contactSection: true,
       chatWidget: true,
-      // Off until a host opts in: the booking flow behind the panel is still landing.
       quotePanel: false,
     },
   };

--- a/frontend/web/src/features/hostdashboard/website/rendering/templates/ExperienceJourneyTemplate.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/templates/ExperienceJourneyTemplate.jsx
@@ -26,7 +26,7 @@ import {
   quoteContextPropType,
 } from "./templatePropTypes";
 import { resolveWebsiteAmenityIconColor } from "../../config/websiteAmenitiesConfig";
-import { resolveQuotePanelVisibility } from "../booking/quotePanelGate";
+import { resolveQuotePanelSiteId } from "../booking/quotePanelGate";
 
 const LazyQuoteAvailabilitySection = lazy(() => import("../booking/QuoteAvailabilitySection"));
 
@@ -41,7 +41,7 @@ export default function ExperienceJourneyTemplate({ model, onSelectTarget, activ
     model.amenities?.iconColor,
     "experience-journey"
   );
-  const showQuotePanel = resolveQuotePanelVisibility({ quoteContext, model, onSelectTarget });
+  const quotePanelSiteId = resolveQuotePanelSiteId({ quoteContext, model, onSelectTarget });
 
   const availabilityCalendar = (
     <TemplateAvailabilityCalendar
@@ -51,9 +51,9 @@ export default function ExperienceJourneyTemplate({ model, onSelectTarget, activ
       activeTargetId={activeTargetId}
     />
   );
-  const availabilityContent = showQuotePanel ? (
+  const availabilityContent = quotePanelSiteId ? (
     <Suspense fallback={availabilityCalendar}>
-      <LazyQuoteAvailabilitySection model={model} siteId={quoteContext.siteId} templateKey="experience-journey" />
+      <LazyQuoteAvailabilitySection model={model} siteId={quotePanelSiteId} templateKey="experience-journey" />
     </Suspense>
   ) : (
     availabilityCalendar

--- a/frontend/web/src/features/hostdashboard/website/rendering/templates/ExperienceJourneyTemplate.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/templates/ExperienceJourneyTemplate.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Suspense, lazy } from "react";
 import PropTypes from "prop-types";
 import styles from "../WebsiteTemplatePreview.module.scss";
 import { getAmenityIconNode } from "../amenityIconRegistry";
@@ -23,10 +23,14 @@ import {
   sitePropType,
   templateInteractionPropTypes,
   visibilityPropType,
+  quoteContextPropType,
 } from "./templatePropTypes";
 import { resolveWebsiteAmenityIconColor } from "../../config/websiteAmenitiesConfig";
+import { resolveQuotePanelVisibility } from "../booking/quotePanelGate";
 
-export default function ExperienceJourneyTemplate({ model, onSelectTarget, activeTargetId }) {
+const LazyQuoteAvailabilitySection = lazy(() => import("../booking/QuoteAvailabilitySection"));
+
+export default function ExperienceJourneyTemplate({ model, onSelectTarget, activeTargetId, quoteContext = null }) {
   const showTopBar = model.visibility?.topBar !== false;
   const showJourneyStops = model.visibility?.journeyStops !== false;
   const showAmenitiesPanel = model.visibility?.amenitiesPanel !== false;
@@ -36,6 +40,23 @@ export default function ExperienceJourneyTemplate({ model, onSelectTarget, activ
   const amenityIconColor = resolveWebsiteAmenityIconColor(
     model.amenities?.iconColor,
     "experience-journey"
+  );
+  const showQuotePanel = resolveQuotePanelVisibility({ quoteContext, model, onSelectTarget });
+
+  const availabilityCalendar = (
+    <TemplateAvailabilityCalendar
+      model={model}
+      templateKey="experience-journey"
+      onSelectTarget={onSelectTarget}
+      activeTargetId={activeTargetId}
+    />
+  );
+  const availabilityContent = showQuotePanel ? (
+    <Suspense fallback={availabilityCalendar}>
+      <LazyQuoteAvailabilitySection model={model} siteId={quoteContext.siteId} templateKey="experience-journey" />
+    </Suspense>
+  ) : (
+    availabilityCalendar
   );
 
   return (
@@ -103,14 +124,7 @@ export default function ExperienceJourneyTemplate({ model, onSelectTarget, activ
         </section>
       ) : null}
 
-      {showAvailabilityCalendar ? (
-        <TemplateAvailabilityCalendar
-          model={model}
-          templateKey="experience-journey"
-          onSelectTarget={onSelectTarget}
-          activeTargetId={activeTargetId}
-        />
-      ) : null}
+      {showAvailabilityCalendar ? availabilityContent : null}
 
       {showExperienceFooter ? (
         <section className={styles.sectionCard}>
@@ -190,4 +204,5 @@ ExperienceJourneyTemplate.propTypes = {
     visibility: visibilityPropType.isRequired,
   }).isRequired,
   ...templateInteractionPropTypes,
+  quoteContext: quoteContextPropType,
 };

--- a/frontend/web/src/features/hostdashboard/website/rendering/templates/PanoramaLandingTemplate.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/templates/PanoramaLandingTemplate.jsx
@@ -30,6 +30,7 @@ import {
   sitePropType,
   templateInteractionPropTypes,
   visibilityPropType,
+  quoteContextPropType,
 } from "./templatePropTypes";
 import {
   DEFAULT_WEBSITE_CONTACT_DESCRIPTION,
@@ -43,6 +44,7 @@ import {
   resolveWebsiteContactSectionCopy,
 } from "../../config/websiteContactSectionConfig";
 import { getDefaultWebsiteCalendarTitle } from "../../config/websiteCalendarSectionConfig";
+import { resolveQuotePanelVisibility } from "../booking/quotePanelGate";
 import { resolveWebsiteResidencePanelColor } from "../../config/websiteResidenceSectionConfig";
 import { resolveWebsiteGalleryPanelColor } from "../../config/websiteGallerySectionConfig";
 import {
@@ -601,6 +603,44 @@ const renderPanoramaTrustCards = ({ featuredTrustCards, onSelectTarget, activeTa
   );
 };
 
+const PANORAMA_AVAILABILITY_ANCHOR = "#availability";
+const LazyQuoteAvailabilitySection = lazy(() => import("../booking/QuoteAvailabilitySection"));
+
+// In the editor the CTA stays a selectable target; on the live site it scrolls to
+// the availability section, whether or not the host has enabled the quote panel.
+const renderPanoramaHeroCallToAction = ({ model, onSelectTarget, activeTargetId }) => {
+  const callToActionContent = (
+    <>
+      <strong>{model.callToAction.label}</strong>
+      <span>{model.callToAction.note || model.stay?.nightlyRateLabel || "Direct booking website"}</span>
+    </>
+  );
+
+  if (onSelectTarget) {
+    return (
+      <div
+        {...getInteractiveTargetProps(styles.panoramaHeroPrimaryAction, onSelectTarget, {
+          sectionId: "common",
+          targetId: "common.ctaLabel",
+        }, activeTargetId)}
+      >
+        {callToActionContent}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className={`${styles.panoramaHeroPrimaryAction} ${styles.panoramaHeroPrimaryActionButton}`}
+      data-preview-target-id="common.ctaLabel"
+      onClick={handlePanoramaNavItemClick(PANORAMA_AVAILABILITY_ANCHOR)}
+    >
+      {callToActionContent}
+    </button>
+  );
+};
+
 const renderPanoramaHeroSection = ({
   model,
   onSelectTarget,
@@ -667,17 +707,7 @@ const renderPanoramaHeroSection = ({
               className={styles.panoramaHeroActionRow}
               data-panorama-hero-alignment={heroContentAlignment}
             >
-              {showCallToAction ? (
-                <div
-                  {...getInteractiveTargetProps(styles.panoramaHeroPrimaryAction, onSelectTarget, {
-                    sectionId: "common",
-                    targetId: "common.ctaLabel",
-                  }, activeTargetId)}
-                >
-                  <strong>{model.callToAction.label}</strong>
-                  <span>{model.callToAction.note || model.stay?.nightlyRateLabel || "Direct booking website"}</span>
-                </div>
-              ) : null}
+              {showCallToAction ? renderPanoramaHeroCallToAction({ model, onSelectTarget, activeTargetId }) : null}
             </div>
           </div>
         </div>
@@ -1135,13 +1165,14 @@ const renderPanoramaContactSection = ({
   );
 };
 
-export default function PanoramaLandingTemplate({ model, onSelectTarget, activeTargetId }) {
+export default function PanoramaLandingTemplate({ model, onSelectTarget, activeTargetId, quoteContext = null }) {
   const viewState = useMemo(() => buildPanoramaViewState(model), [model]);
   const [showAmenitiesModal, setShowAmenitiesModal] = useState(false);
   const [isGalleryBrowserOpen, setIsGalleryBrowserOpen] = useState(false);
   const [galleryBrowserInitialIndex, setGalleryBrowserInitialIndex] = useState(0);
   const [isNavDrawerOpen, setIsNavDrawerOpen] = useState(false);
   const isInteractivePreview = Boolean(onSelectTarget);
+  const showQuotePanel = resolveQuotePanelVisibility({ quoteContext, model, onSelectTarget });
   const canOpenGalleryBrowser = !isInteractivePreview;
   const shouldDeferBelowFoldSections = !isInteractivePreview;
   const { heroSectionRef, isTopBarSolid } = usePanoramaTopBarSolidState(viewState.showTopBar);
@@ -1191,6 +1222,30 @@ export default function PanoramaLandingTemplate({ model, onSelectTarget, activeT
       }
     };
   }, [isNavDrawerOpen]);
+
+  const availabilityCalendar = (
+    <TemplateAvailabilityCalendar
+      model={model}
+      variant="panorama"
+      templateKey="panorama-landing"
+      propertyTitle={model.site.title}
+      onSelectTarget={onSelectTarget}
+      activeTargetId={activeTargetId}
+    />
+  );
+  const availabilityContent = showQuotePanel ? (
+    <Suspense fallback={availabilityCalendar}>
+      <LazyQuoteAvailabilitySection
+        model={model}
+        siteId={quoteContext.siteId}
+        variant="panorama"
+        templateKey="panorama-landing"
+        propertyTitle={model.site.title}
+      />
+    </Suspense>
+  ) : (
+    availabilityCalendar
+  );
 
   return (
     <>
@@ -1262,14 +1317,7 @@ export default function PanoramaLandingTemplate({ model, onSelectTarget, activeT
             )}
             {...getScrollRevealProps(160)}
           >
-            <TemplateAvailabilityCalendar
-              model={model}
-              variant="panorama"
-              templateKey="panorama-landing"
-              propertyTitle={model.site.title}
-              onSelectTarget={onSelectTarget}
-              activeTargetId={activeTargetId}
-            />
+            {availabilityContent}
           </section>
         ) : null}
 
@@ -1354,4 +1402,5 @@ PanoramaLandingTemplate.propTypes = {
     contactSection: contactSectionPropType.isRequired,
   }).isRequired,
   ...templateInteractionPropTypes,
+  quoteContext: quoteContextPropType,
 };

--- a/frontend/web/src/features/hostdashboard/website/rendering/templates/PanoramaLandingTemplate.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/templates/PanoramaLandingTemplate.jsx
@@ -44,7 +44,7 @@ import {
   resolveWebsiteContactSectionCopy,
 } from "../../config/websiteContactSectionConfig";
 import { getDefaultWebsiteCalendarTitle } from "../../config/websiteCalendarSectionConfig";
-import { resolveQuotePanelVisibility } from "../booking/quotePanelGate";
+import { resolveQuotePanelSiteId } from "../booking/quotePanelGate";
 import { resolveWebsiteResidencePanelColor } from "../../config/websiteResidenceSectionConfig";
 import { resolveWebsiteGalleryPanelColor } from "../../config/websiteGallerySectionConfig";
 import {
@@ -1172,7 +1172,7 @@ export default function PanoramaLandingTemplate({ model, onSelectTarget, activeT
   const [galleryBrowserInitialIndex, setGalleryBrowserInitialIndex] = useState(0);
   const [isNavDrawerOpen, setIsNavDrawerOpen] = useState(false);
   const isInteractivePreview = Boolean(onSelectTarget);
-  const showQuotePanel = resolveQuotePanelVisibility({ quoteContext, model, onSelectTarget });
+  const quotePanelSiteId = resolveQuotePanelSiteId({ quoteContext, model, onSelectTarget });
   const canOpenGalleryBrowser = !isInteractivePreview;
   const shouldDeferBelowFoldSections = !isInteractivePreview;
   const { heroSectionRef, isTopBarSolid } = usePanoramaTopBarSolidState(viewState.showTopBar);
@@ -1233,11 +1233,11 @@ export default function PanoramaLandingTemplate({ model, onSelectTarget, activeT
       activeTargetId={activeTargetId}
     />
   );
-  const availabilityContent = showQuotePanel ? (
+  const availabilityContent = quotePanelSiteId ? (
     <Suspense fallback={availabilityCalendar}>
       <LazyQuoteAvailabilitySection
         model={model}
-        siteId={quoteContext.siteId}
+        siteId={quotePanelSiteId}
         variant="panorama"
         templateKey="panorama-landing"
         propertyTitle={model.site.title}

--- a/frontend/web/src/features/hostdashboard/website/rendering/templates/PanoramaLandingTemplate.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/templates/PanoramaLandingTemplate.jsx
@@ -5,6 +5,7 @@ import MenuRoundedIcon from "@mui/icons-material/MenuRounded";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import styles from "../WebsiteTemplatePreview.module.scss";
 import { getScrollRevealProps } from "../animations/scrollRevealProps";
+import { revealDeferredSections } from "../animations/revealDeferredSections";
 import { getAmenityIconNode } from "../amenityIconRegistry";
 import {
   getInteractiveTargetProps,
@@ -89,6 +90,13 @@ const handlePanoramaNavItemClick = (href, onAfterNavigate = undefined) => (event
   }
 
   event.preventDefault();
+
+  // Measure only after deferred sections render at their real height (see revealDeferredSections).
+  revealDeferredSections(
+    globalThis.document,
+    styles.panoramaDeferredRenderSection,
+    styles.panoramaDeferredRenderSectionRevealed
+  );
 
   const topBarElement = globalThis.document.querySelector(PANORAMA_TOP_BAR_SELECTOR);
   const topBarInnerElement =

--- a/frontend/web/src/features/hostdashboard/website/rendering/templates/PanoramaLandingTemplate.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/templates/PanoramaLandingTemplate.jsx
@@ -91,7 +91,6 @@ const handlePanoramaNavItemClick = (href, onAfterNavigate = undefined) => (event
 
   event.preventDefault();
 
-  // Measure only after deferred sections render at their real height (see revealDeferredSections).
   revealDeferredSections(
     globalThis.document,
     styles.panoramaDeferredRenderSection,
@@ -614,8 +613,6 @@ const renderPanoramaTrustCards = ({ featuredTrustCards, onSelectTarget, activeTa
 const PANORAMA_AVAILABILITY_ANCHOR = "#availability";
 const LazyQuoteAvailabilitySection = lazy(() => import("../booking/QuoteAvailabilitySection"));
 
-// In the editor the CTA stays a selectable target; on the live site it scrolls to
-// the availability section, whether or not the host has enabled the quote panel.
 const renderPanoramaHeroCallToAction = ({ model, onSelectTarget, activeTargetId }) => {
   const callToActionContent = (
     <>

--- a/frontend/web/src/features/hostdashboard/website/rendering/templates/TrustSignalsTemplate.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/templates/TrustSignalsTemplate.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Suspense, lazy } from "react";
 import PropTypes from "prop-types";
 import styles from "../WebsiteTemplatePreview.module.scss";
 import { getAmenityIconNode } from "../amenityIconRegistry";
@@ -21,13 +21,34 @@ import {
   sitePropType,
   templateInteractionPropTypes,
   visibilityPropType,
+  quoteContextPropType,
 } from "./templatePropTypes";
+import { resolveQuotePanelVisibility } from "../booking/quotePanelGate";
 
-export default function TrustSignalsTemplate({ model, onSelectTarget, activeTargetId }) {
+const LazyQuoteAvailabilitySection = lazy(() => import("../booking/QuoteAvailabilitySection"));
+
+export default function TrustSignalsTemplate({ model, onSelectTarget, activeTargetId, quoteContext = null }) {
   const showTopBar = model.visibility?.topBar !== false;
   const showTrustCards = model.visibility?.trustCards !== false;
   const showAvailabilityCalendar = model.visibility?.availabilityCalendar !== false;
   const showCallToAction = model.visibility?.callToAction !== false;
+  const showQuotePanel = resolveQuotePanelVisibility({ quoteContext, model, onSelectTarget });
+
+  const availabilityCalendar = (
+    <TemplateAvailabilityCalendar
+      model={model}
+      templateKey="trust-signals"
+      onSelectTarget={onSelectTarget}
+      activeTargetId={activeTargetId}
+    />
+  );
+  const availabilityContent = showQuotePanel ? (
+    <Suspense fallback={availabilityCalendar}>
+      <LazyQuoteAvailabilitySection model={model} siteId={quoteContext.siteId} templateKey="trust-signals" />
+    </Suspense>
+  ) : (
+    availabilityCalendar
+  );
 
   return (
     <article className={styles.templateSite}>
@@ -106,14 +127,7 @@ export default function TrustSignalsTemplate({ model, onSelectTarget, activeTarg
           </div>
         ) : null}
 
-        {showAvailabilityCalendar ? (
-          <TemplateAvailabilityCalendar
-            model={model}
-            templateKey="trust-signals"
-            onSelectTarget={onSelectTarget}
-            activeTargetId={activeTargetId}
-          />
-        ) : null}
+        {showAvailabilityCalendar ? availabilityContent : null}
 
         {showCallToAction ? (
           <div className={styles.trustSignalsFooter}>
@@ -148,4 +162,5 @@ TrustSignalsTemplate.propTypes = {
     visibility: visibilityPropType.isRequired,
   }).isRequired,
   ...templateInteractionPropTypes,
+  quoteContext: quoteContextPropType,
 };

--- a/frontend/web/src/features/hostdashboard/website/rendering/templates/TrustSignalsTemplate.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/templates/TrustSignalsTemplate.jsx
@@ -23,7 +23,7 @@ import {
   visibilityPropType,
   quoteContextPropType,
 } from "./templatePropTypes";
-import { resolveQuotePanelVisibility } from "../booking/quotePanelGate";
+import { resolveQuotePanelSiteId } from "../booking/quotePanelGate";
 
 const LazyQuoteAvailabilitySection = lazy(() => import("../booking/QuoteAvailabilitySection"));
 
@@ -32,7 +32,7 @@ export default function TrustSignalsTemplate({ model, onSelectTarget, activeTarg
   const showTrustCards = model.visibility?.trustCards !== false;
   const showAvailabilityCalendar = model.visibility?.availabilityCalendar !== false;
   const showCallToAction = model.visibility?.callToAction !== false;
-  const showQuotePanel = resolveQuotePanelVisibility({ quoteContext, model, onSelectTarget });
+  const quotePanelSiteId = resolveQuotePanelSiteId({ quoteContext, model, onSelectTarget });
 
   const availabilityCalendar = (
     <TemplateAvailabilityCalendar
@@ -42,9 +42,9 @@ export default function TrustSignalsTemplate({ model, onSelectTarget, activeTarg
       activeTargetId={activeTargetId}
     />
   );
-  const availabilityContent = showQuotePanel ? (
+  const availabilityContent = quotePanelSiteId ? (
     <Suspense fallback={availabilityCalendar}>
-      <LazyQuoteAvailabilitySection model={model} siteId={quoteContext.siteId} templateKey="trust-signals" />
+      <LazyQuoteAvailabilitySection model={model} siteId={quotePanelSiteId} templateKey="trust-signals" />
     </Suspense>
   ) : (
     availabilityCalendar

--- a/frontend/web/src/features/hostdashboard/website/rendering/templates/templatePropTypes.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/templates/templatePropTypes.js
@@ -131,6 +131,12 @@ export const visibilityPropType = PropTypes.shape({
   journeyStops: PropTypes.bool,
   contactSection: PropTypes.bool,
   chatWidget: PropTypes.bool,
+  quotePanel: PropTypes.bool,
+});
+
+// Present only on the live published surface; its absence hides every booking control.
+export const quoteContextPropType = PropTypes.shape({
+  siteId: PropTypes.string,
 });
 
 export const templateInteractionPropTypes = {

--- a/frontend/web/src/features/hostdashboard/website/rendering/templates/templatePropTypes.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/templates/templatePropTypes.js
@@ -134,7 +134,6 @@ export const visibilityPropType = PropTypes.shape({
   quotePanel: PropTypes.bool,
 });
 
-// Present only on the live published surface; its absence hides every booking control.
 export const quoteContextPropType = PropTypes.shape({
   siteId: PropTypes.string,
 });

--- a/frontend/web/src/features/hostdashboard/website/rendering/templates/templateSharedSections.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/templates/templateSharedSections.jsx
@@ -273,6 +273,7 @@ export function TemplateAvailabilityCalendar({
   variant = "default",
   propertyTitle = "",
   templateKey = "",
+  selection = null,
 }) {
   const titleInteractiveTargetProps = getInteractiveTargetProps("", onSelectTarget, {
     sectionId: "calendar",
@@ -300,6 +301,7 @@ export function TemplateAvailabilityCalendar({
         templateKey={templateKey}
         variant={variant}
         propertyTitle={propertyTitle}
+        selection={selection}
         interactiveTargetProps={getInteractiveTargetProps(styles.availabilityCalendarTarget, onSelectTarget, {
           sectionId: "calendar",
           targetId: "calendar.visibility",
@@ -310,6 +312,13 @@ export function TemplateAvailabilityCalendar({
 }
 
 TemplateAvailabilityCalendar.propTypes = {
+  selection: PropTypes.shape({
+    selectable: PropTypes.bool,
+    checkIn: PropTypes.string,
+    checkOut: PropTypes.string,
+    todayKey: PropTypes.string,
+    onSelectDate: PropTypes.func,
+  }),
   model: PropTypes.shape({
     availability: PropTypes.shape({}).isRequired,
     calendarSection: PropTypes.shape({}),

--- a/frontend/web/src/features/hostdashboard/website/rendering/websiteDraftContentOverrides.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/websiteDraftContentOverrides.js
@@ -87,8 +87,6 @@ const MANAGED_OVERRIDE_KEYS = Object.freeze([
   "journeyStops",
 ]);
 
-// Every section defaults to visible except the booking panel, which a host opts into.
-// The editor seeds its values from this map, so a new draft never turns it on by accident.
 const VISIBILITY_DEFAULTS = Object.freeze({
   topBar: true,
   trustCards: true,

--- a/frontend/web/src/features/hostdashboard/website/rendering/websiteDraftContentOverrides.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/websiteDraftContentOverrides.js
@@ -87,17 +87,22 @@ const MANAGED_OVERRIDE_KEYS = Object.freeze([
   "journeyStops",
 ]);
 
-const VISIBILITY_KEYS = Object.freeze([
-  "topBar",
-  "trustCards",
-  "gallerySection",
-  "amenitiesPanel",
-  "availabilityCalendar",
-  "callToAction",
-  "journeyStops",
-  "contactSection",
-  "chatWidget",
-]);
+// Every section defaults to visible except the booking panel, which a host opts into.
+// The editor seeds its values from this map, so a new draft never turns it on by accident.
+const VISIBILITY_DEFAULTS = Object.freeze({
+  topBar: true,
+  trustCards: true,
+  gallerySection: true,
+  amenitiesPanel: true,
+  availabilityCalendar: true,
+  callToAction: true,
+  journeyStops: true,
+  contactSection: true,
+  chatWidget: true,
+  quotePanel: false,
+});
+
+const VISIBILITY_KEYS = Object.freeze(Object.keys(VISIBILITY_DEFAULTS));
 
 const cleanText = (value) => String(value || "").trim();
 
@@ -405,13 +410,7 @@ export const createEmptyWebsiteDraftEditorValues = (templateKey = "") => ({
     accentColor: DEFAULT_WEBSITE_CONTACT_ACCENT_COLOR,
     backgroundColor: DEFAULT_WEBSITE_CONTACT_BACKGROUND_COLOR,
   },
-  visibility: VISIBILITY_KEYS.reduce(
-    (visibilityMap, visibilityKey) => ({
-      ...visibilityMap,
-      [visibilityKey]: true,
-    }),
-    {}
-  ),
+  visibility: { ...VISIBILITY_DEFAULTS },
   images: {
     heroImage: "",
     residenceImage: "",

--- a/frontend/web/src/features/hostdashboard/website/services/websitePublicQuoteService.js
+++ b/frontend/web/src/features/hostdashboard/website/services/websitePublicQuoteService.js
@@ -1,0 +1,137 @@
+import { PROPERTY_API_BASE } from "../../hostproperty/constants";
+
+const PUBLIC_WEBSITE_QUOTE_URL = `${PROPERTY_API_BASE}/website/public/quote`;
+const QUOTE_SESSION_SOURCE = "standalone_site";
+const QUOTE_CURRENCY = "EUR";
+
+export const WEBSITE_PUBLIC_QUOTE_CLIENT_ERROR_CODES = Object.freeze({
+  NETWORK_ERROR: "network_error",
+  RATE_LIMITED: "rate_limited",
+  UNEXPECTED_RESPONSE: "unexpected_response",
+});
+
+export class WebsitePublicQuoteError extends Error {
+  constructor({ code, message = "", status = 0, requestId = "" }) {
+    super(message);
+    this.name = "WebsitePublicQuoteError";
+    this.code = code;
+    this.status = status;
+    this.requestId = requestId;
+  }
+}
+
+const parseJsonSafely = (rawBody) => {
+  try {
+    return rawBody ? JSON.parse(rawBody) : null;
+  } catch {
+    return null;
+  }
+};
+
+const toArray = (value) => (Array.isArray(value) ? value : []);
+const toAmount = (value) => (Number.isFinite(Number(value)) ? Number(value) : 0);
+
+const normalizePublicWebsiteQuote = (payload) => {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const total = Number(payload.priceBreakdown?.total);
+  const hasEssentials =
+    Boolean(payload.quoteId) && Boolean(payload.quoteToken) && Boolean(payload.expiresAt) && Number.isFinite(total);
+  if (!hasEssentials) {
+    return null;
+  }
+
+  return {
+    quoteId: String(payload.quoteId),
+    siteId: String(payload.siteId || ""),
+    propertyId: String(payload.propertyId || ""),
+    timezone: payload.timezone ?? null,
+    checkIn: String(payload.checkIn || ""),
+    checkOut: String(payload.checkOut || ""),
+    nights: toAmount(payload.nights),
+    guestCount: toAmount(payload.guestCount),
+    availability: payload.availability && typeof payload.availability === "object" ? payload.availability : null,
+    priceBreakdown: {
+      currency: String(payload.priceBreakdown.currency || QUOTE_CURRENCY),
+      nightlyBaseTotal: toAmount(payload.priceBreakdown.nightlyBaseTotal),
+      cleaningFee: toAmount(payload.priceBreakdown.cleaningFee),
+      discounts: toArray(payload.priceBreakdown.discounts),
+      taxes: toArray(payload.priceBreakdown.taxes),
+      fees: toArray(payload.priceBreakdown.fees),
+      total,
+    },
+    policiesApplied: toArray(payload.policiesApplied),
+    expiresAt: String(payload.expiresAt),
+    quoteToken: String(payload.quoteToken),
+  };
+};
+
+// Deliberately sends no Authorization header: this is the one public, anonymous
+// call in the website feature, and a host token in localStorage must never leak
+// into a guest-facing request.
+export const requestPublicWebsiteQuote = async ({ siteId, checkIn, checkOut, guests, sessionId, signal }) => {
+  let response;
+  try {
+    response = await fetch(PUBLIC_WEBSITE_QUOTE_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      cache: "no-store",
+      signal,
+      body: JSON.stringify({
+        siteId,
+        checkIn,
+        checkOut,
+        guests,
+        currency: QUOTE_CURRENCY,
+        session: { sessionId, source: QUOTE_SESSION_SOURCE },
+      }),
+    });
+  } catch (error) {
+    if (error?.name === "AbortError") {
+      throw error;
+    }
+    throw new WebsitePublicQuoteError({
+      code: WEBSITE_PUBLIC_QUOTE_CLIENT_ERROR_CODES.NETWORK_ERROR,
+      message: "The quote request could not reach the server.",
+    });
+  }
+
+  const payload = parseJsonSafely(await response.text());
+
+  if (!response.ok) {
+    const errorBody = payload?.error;
+    if (errorBody?.code) {
+      throw new WebsitePublicQuoteError({
+        code: String(errorBody.code),
+        message: String(errorBody.message || ""),
+        status: response.status,
+        requestId: String(errorBody.requestId || ""),
+      });
+    }
+    if (response.status === 429) {
+      throw new WebsitePublicQuoteError({
+        code: WEBSITE_PUBLIC_QUOTE_CLIENT_ERROR_CODES.RATE_LIMITED,
+        message: "Too many quote requests.",
+        status: response.status,
+      });
+    }
+    throw new WebsitePublicQuoteError({
+      code: WEBSITE_PUBLIC_QUOTE_CLIENT_ERROR_CODES.UNEXPECTED_RESPONSE,
+      message: "The quote service returned an unexpected response.",
+      status: response.status,
+    });
+  }
+
+  const quote = normalizePublicWebsiteQuote(payload);
+  if (!quote) {
+    throw new WebsitePublicQuoteError({
+      code: WEBSITE_PUBLIC_QUOTE_CLIENT_ERROR_CODES.UNEXPECTED_RESPONSE,
+      message: "The quote service returned an unexpected response.",
+      status: response.status,
+    });
+  }
+
+  return quote;
+};

--- a/frontend/web/src/features/hostdashboard/website/services/websitePublicQuoteService.js
+++ b/frontend/web/src/features/hostdashboard/website/services/websitePublicQuoteService.js
@@ -68,9 +68,6 @@ const normalizePublicWebsiteQuote = (payload) => {
   };
 };
 
-// Deliberately sends no Authorization header: this is the one public, anonymous
-// call in the website feature, and a host token in localStorage must never leak
-// into a guest-facing request.
 export const requestPublicWebsiteQuote = async ({ siteId, checkIn, checkOut, guests, sessionId, signal }) => {
   let response;
   try {

--- a/frontend/web/src/features/hostdashboard/website/services/websiteVisitorId.js
+++ b/frontend/web/src/features/hostdashboard/website/services/websiteVisitorId.js
@@ -25,8 +25,6 @@ const createVisitorId = () => {
   return `visitor-${createRandomVisitorSegment()}`;
 };
 
-// Anonymous, per-browser identity for public direct booking website visitors.
-// It is a correlation id for quote sessions, never an authenticated identity.
 export const getOrCreateVisitorId = () => {
   let storage = null;
   try {

--- a/frontend/web/src/features/hostdashboard/website/services/websiteVisitorId.js
+++ b/frontend/web/src/features/hostdashboard/website/services/websiteVisitorId.js
@@ -1,0 +1,53 @@
+const DIRECT_BOOKING_WEBSITE_VISITOR_ID_STORAGE_KEY = "domits_direct_booking_website_visitor_id";
+const LEGACY_STANDALONE_VISITOR_ID_STORAGE_KEY = "domits_standalone_visitor_id";
+
+const cleanText = (value) => String(value || "").trim();
+
+let fallbackVisitorIdSequence = 0;
+
+const createRandomVisitorSegment = () => {
+  const cryptoApi = globalThis.crypto;
+  if (!cryptoApi?.getRandomValues) {
+    fallbackVisitorIdSequence += 1;
+    return `${Date.now()}-${fallbackVisitorIdSequence}`;
+  }
+
+  const randomBytes = new Uint32Array(4);
+  cryptoApi.getRandomValues(randomBytes);
+  return Array.from(randomBytes, (value) => value.toString(16).padStart(8, "0")).join("");
+};
+
+const createVisitorId = () => {
+  if (globalThis.crypto?.randomUUID) {
+    return `visitor-${globalThis.crypto.randomUUID()}`;
+  }
+
+  return `visitor-${createRandomVisitorSegment()}`;
+};
+
+// Anonymous, per-browser identity for public direct booking website visitors.
+// It is a correlation id for quote sessions, never an authenticated identity.
+export const getOrCreateVisitorId = () => {
+  let storage = null;
+  try {
+    storage = globalThis.localStorage;
+  } catch {
+    storage = null;
+  }
+  if (!storage) {
+    return createVisitorId();
+  }
+
+  const existingVisitorId = cleanText(
+    storage.getItem(DIRECT_BOOKING_WEBSITE_VISITOR_ID_STORAGE_KEY) ||
+      storage.getItem(LEGACY_STANDALONE_VISITOR_ID_STORAGE_KEY)
+  );
+  if (existingVisitorId) {
+    storage.setItem(DIRECT_BOOKING_WEBSITE_VISITOR_ID_STORAGE_KEY, existingVisitorId);
+    return existingVisitorId;
+  }
+
+  const nextVisitorId = createVisitorId();
+  storage.setItem(DIRECT_BOOKING_WEBSITE_VISITOR_ID_STORAGE_KEY, nextVisitorId);
+  return nextVisitorId;
+};

--- a/frontend/web/src/features/hostdashboard/website/tests/QuoteAvailabilitySection.test.jsx
+++ b/frontend/web/src/features/hostdashboard/website/tests/QuoteAvailabilitySection.test.jsx
@@ -2,6 +2,10 @@ import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import QuoteAvailabilitySection from "../rendering/booking/QuoteAvailabilitySection";
 import { WebsitePublicQuoteError, requestPublicWebsiteQuote } from "../services/websitePublicQuoteService";
+// The section lazy-loads the calendar. Importing it here first puts the module in
+// Jest's registry, so the lazy import() resolves from cache instead of transpiling
+// the calendar (and its icon imports) inside the test's wait window on a cold runner.
+import "../rendering/AvailabilityCalendarPreview";
 
 jest.mock("../services/websitePublicQuoteService", () => {
   const actual = jest.requireActual("../services/websitePublicQuoteService");
@@ -57,9 +61,14 @@ const renderSection = () =>
     />
   );
 
+// The calendar replaces a Suspense fallback; its month navigation is the landmark
+// that proves the real calendar is on screen before any day is looked up.
+const waitForCalendar = () => screen.findByRole("button", { name: "Show next months" });
+
 const selectStay = async () => {
-  fireEvent.click(await screen.findByRole("button", { name: `${monthLabel} 1, Available` }));
-  fireEvent.click(await screen.findByRole("button", { name: `${monthLabel} 4, Available` }));
+  await waitForCalendar();
+  fireEvent.click(screen.getByRole("button", { name: `${monthLabel} 1, Available` }));
+  fireEvent.click(screen.getByRole("button", { name: `${monthLabel} 4, Available` }));
 };
 
 describe("QuoteAvailabilitySection", () => {

--- a/frontend/web/src/features/hostdashboard/website/tests/QuoteAvailabilitySection.test.jsx
+++ b/frontend/web/src/features/hostdashboard/website/tests/QuoteAvailabilitySection.test.jsx
@@ -2,9 +2,6 @@ import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import QuoteAvailabilitySection from "../rendering/booking/QuoteAvailabilitySection";
 import { WebsitePublicQuoteError, requestPublicWebsiteQuote } from "../services/websitePublicQuoteService";
-// The section lazy-loads the calendar. Importing it here first puts the module in
-// Jest's registry, so the lazy import() resolves from cache instead of transpiling
-// the calendar (and its icon imports) inside the test's wait window on a cold runner.
 import "../rendering/AvailabilityCalendarPreview";
 
 jest.mock("../services/websitePublicQuoteService", () => {
@@ -19,7 +16,6 @@ jest.mock("../services/websiteVisitorId", () => ({
 const padDatePart = (value) => String(value).padStart(2, "0");
 const toKey = (date) => `${date.getFullYear()}-${padDatePart(date.getMonth() + 1)}-${padDatePart(date.getDate())}`;
 
-// The panorama calendar shows the current and next month; next month is always fully visible.
 const today = new Date();
 const nextMonth = new Date(today.getFullYear(), today.getMonth() + 1, 1);
 const checkInDate = new Date(nextMonth.getFullYear(), nextMonth.getMonth(), 1);
@@ -61,8 +57,6 @@ const renderSection = () =>
     />
   );
 
-// The calendar replaces a Suspense fallback; its month navigation is the landmark
-// that proves the real calendar is on screen before any day is looked up.
 const waitForCalendar = () => screen.findByRole("button", { name: "Show next months" });
 
 const selectStay = async () => {

--- a/frontend/web/src/features/hostdashboard/website/tests/QuoteAvailabilitySection.test.jsx
+++ b/frontend/web/src/features/hostdashboard/website/tests/QuoteAvailabilitySection.test.jsx
@@ -83,7 +83,7 @@ describe("QuoteAvailabilitySection", () => {
     await selectStay();
     expect(screen.getByText(/3 nights/i)).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: /check availability & price/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^check availability$/i }));
 
     expect(await screen.findByText("€620.00")).toBeInTheDocument();
     expect(requestPublicWebsiteQuote).toHaveBeenCalledWith(
@@ -102,12 +102,12 @@ describe("QuoteAvailabilitySection", () => {
     renderSection();
 
     await selectStay();
-    fireEvent.click(screen.getByRole("button", { name: /check availability & price/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^check availability$/i }));
     await screen.findByText("€620.00");
 
     fireEvent.click(screen.getByRole("button", { name: /add a guest/i }));
 
-    expect(screen.getByText(/changed/i)).toBeInTheDocument();
+    expect(screen.getByText("Selection changed — check again")).toBeInTheDocument();
   });
 
   it("clears the selection when the server reports the dates as unavailable", async () => {
@@ -117,9 +117,9 @@ describe("QuoteAvailabilitySection", () => {
     renderSection();
 
     await selectStay();
-    fireEvent.click(screen.getByRole("button", { name: /check availability & price/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^check availability$/i }));
 
     expect(await screen.findByText(/no longer available/i)).toBeInTheDocument();
-    expect(screen.getByText(/select your check-in date/i)).toBeInTheDocument();
+    expect(screen.getByText("Pick a check-in date")).toBeInTheDocument();
   });
 });

--- a/frontend/web/src/features/hostdashboard/website/tests/QuoteAvailabilitySection.test.jsx
+++ b/frontend/web/src/features/hostdashboard/website/tests/QuoteAvailabilitySection.test.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import QuoteAvailabilitySection from "../rendering/booking/QuoteAvailabilitySection";
 import { WebsitePublicQuoteError, requestPublicWebsiteQuote } from "../services/websitePublicQuoteService";
 // The section lazy-loads the calendar. Importing it here first puts the module in
@@ -119,7 +119,7 @@ describe("QuoteAvailabilitySection", () => {
     await selectStay();
     fireEvent.click(screen.getByRole("button", { name: /check availability & price/i }));
 
-    await waitFor(() => expect(screen.getByText(/no longer available/i)).toBeInTheDocument());
+    expect(await screen.findByText(/no longer available/i)).toBeInTheDocument();
     expect(screen.getByText(/select your check-in date/i)).toBeInTheDocument();
   });
 });

--- a/frontend/web/src/features/hostdashboard/website/tests/QuoteAvailabilitySection.test.jsx
+++ b/frontend/web/src/features/hostdashboard/website/tests/QuoteAvailabilitySection.test.jsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import QuoteAvailabilitySection from "../rendering/booking/QuoteAvailabilitySection";
+import { WebsitePublicQuoteError, requestPublicWebsiteQuote } from "../services/websitePublicQuoteService";
+
+jest.mock("../services/websitePublicQuoteService", () => {
+  const actual = jest.requireActual("../services/websitePublicQuoteService");
+  return { ...actual, requestPublicWebsiteQuote: jest.fn() };
+});
+
+jest.mock("../services/websiteVisitorId", () => ({
+  getOrCreateVisitorId: () => "visitor-test",
+}));
+
+const padDatePart = (value) => String(value).padStart(2, "0");
+const toKey = (date) => `${date.getFullYear()}-${padDatePart(date.getMonth() + 1)}-${padDatePart(date.getDate())}`;
+
+// The panorama calendar shows the current and next month; next month is always fully visible.
+const today = new Date();
+const nextMonth = new Date(today.getFullYear(), today.getMonth() + 1, 1);
+const checkInDate = new Date(nextMonth.getFullYear(), nextMonth.getMonth(), 1);
+const checkOutDate = new Date(nextMonth.getFullYear(), nextMonth.getMonth(), 4);
+const monthLabel = new Intl.DateTimeFormat("en-GB", { month: "long", year: "numeric" }).format(nextMonth);
+
+const MODEL = {
+  site: { title: "Cliff House" },
+  stay: { guests: 4, minimumStay: 2 },
+  host: { name: "Host", whatsapp: { isAvailable: false } },
+  calendarSection: { title: "Availability", description: "Pick your dates.", showPanel: true },
+  availability: {
+    externalBlockedDates: [],
+    unavailableDateKeys: [],
+    blockedDateCount: 0,
+    syncSummary: "",
+    blockedDateSummary: "",
+    callout: "",
+  },
+};
+
+const QUOTE = {
+  quoteId: "quote_1",
+  nights: 3,
+  guestCount: 2,
+  priceBreakdown: { currency: "EUR", nightlyBaseTotal: 57000, cleaningFee: 5000, discounts: [], taxes: [], fees: [], total: 62000 },
+  expiresAt: "2099-01-01T10:30:00.000Z",
+  quoteToken: "qtok",
+};
+
+const renderSection = () =>
+  render(
+    <QuoteAvailabilitySection
+      model={MODEL}
+      siteId="site-1"
+      variant="panorama"
+      templateKey="panorama-landing"
+      propertyTitle="Cliff House"
+    />
+  );
+
+const selectStay = async () => {
+  fireEvent.click(await screen.findByRole("button", { name: `${monthLabel} 1, Available` }));
+  fireEvent.click(await screen.findByRole("button", { name: `${monthLabel} 4, Available` }));
+};
+
+describe("QuoteAvailabilitySection", () => {
+  beforeEach(() => {
+    requestPublicWebsiteQuote.mockReset();
+  });
+
+  it("lets a guest pick a stay on the calendar and fetch the server price", async () => {
+    requestPublicWebsiteQuote.mockResolvedValue(QUOTE);
+    renderSection();
+
+    await selectStay();
+    expect(screen.getByText(/3 nights/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /check availability & price/i }));
+
+    expect(await screen.findByText("€620.00")).toBeInTheDocument();
+    expect(requestPublicWebsiteQuote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        siteId: "site-1",
+        checkIn: toKey(checkInDate),
+        checkOut: toKey(checkOutDate),
+        guests: 2,
+        sessionId: "visitor-test",
+      })
+    );
+  });
+
+  it("marks the price stale when the selection changes afterwards", async () => {
+    requestPublicWebsiteQuote.mockResolvedValue(QUOTE);
+    renderSection();
+
+    await selectStay();
+    fireEvent.click(screen.getByRole("button", { name: /check availability & price/i }));
+    await screen.findByText("€620.00");
+
+    fireEvent.click(screen.getByRole("button", { name: /add a guest/i }));
+
+    expect(screen.getByText(/changed/i)).toBeInTheDocument();
+  });
+
+  it("clears the selection when the server reports the dates as unavailable", async () => {
+    requestPublicWebsiteQuote.mockRejectedValue(
+      new WebsitePublicQuoteError({ code: "unavailable_dates", message: "Taken.", status: 409, requestId: "req-1" })
+    );
+    renderSection();
+
+    await selectStay();
+    fireEvent.click(screen.getByRole("button", { name: /check availability & price/i }));
+
+    await waitFor(() => expect(screen.getByText(/no longer available/i)).toBeInTheDocument());
+    expect(screen.getByText(/select your check-in date/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/web/src/features/hostdashboard/website/tests/QuotePanel.test.jsx
+++ b/frontend/web/src/features/hostdashboard/website/tests/QuotePanel.test.jsx
@@ -1,0 +1,200 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import QuotePanel from "../rendering/booking/QuotePanel";
+import { QUOTE_STATUS } from "../rendering/booking/useWebsiteQuote";
+
+const QUOTE = {
+  quoteId: "quote_1",
+  nights: 4,
+  guestCount: 2,
+  priceBreakdown: { currency: "EUR", nightlyBaseTotal: 76000, cleaningFee: 5000, discounts: [], taxes: [], fees: [], total: 81000 },
+  expiresAt: "2099-01-01T10:30:00.000Z",
+  quoteToken: "qtok",
+};
+
+const COMPLETE_RANGE = { checkIn: "2026-10-10", checkOut: "2026-10-14" };
+const IDLE = { status: QUOTE_STATUS.IDLE, quote: null, error: null, staleReason: null };
+
+const renderPanel = (props = {}) => {
+  const onRequestQuote = jest.fn();
+  const onGuestsChange = jest.fn();
+  const utils = render(
+    <QuotePanel
+      range={{ checkIn: null, checkOut: null }}
+      guests={2}
+      onGuestsChange={onGuestsChange}
+      capacity={4}
+      minimumStay={2}
+      quoteState={IDLE}
+      onRequestQuote={onRequestQuote}
+      contactHref={null}
+      {...props}
+    />
+  );
+  return { ...utils, onRequestQuote, onGuestsChange };
+};
+
+const actionButton = () => screen.queryByRole("button", { name: /check availability & price/i });
+
+describe("QuotePanel", () => {
+  it("prompts for dates and keeps the action disabled until the range is complete", () => {
+    renderPanel();
+    expect(screen.getByText(/select your check-in date/i)).toBeInTheDocument();
+    expect(actionButton()).toBeDisabled();
+  });
+
+  it("asks for the check-out date after a check-in is chosen", () => {
+    renderPanel({ range: { checkIn: "2026-10-10", checkOut: null } });
+    expect(screen.getByText(/pick your check-out date/i)).toBeInTheDocument();
+    expect(actionButton()).toBeDisabled();
+  });
+
+  it("summarises the stay and requests a quote when asked", () => {
+    const { onRequestQuote } = renderPanel({ range: COMPLETE_RANGE });
+    expect(screen.getByText(/4 nights/i)).toBeInTheDocument();
+    expect(screen.getByText(/minimum stay: 2 nights/i)).toBeInTheDocument();
+
+    fireEvent.click(actionButton());
+    expect(onRequestQuote).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a busy label while the quote loads", () => {
+    renderPanel({ range: COMPLETE_RANGE, quoteState: { ...IDLE, status: QUOTE_STATUS.LOADING } });
+    const button = screen.getByRole("button", { name: /checking/i });
+    expect(button).toBeDisabled();
+  });
+
+  it("renders the server price breakdown and its validity", () => {
+    renderPanel({ range: COMPLETE_RANGE, quoteState: { ...IDLE, status: QUOTE_STATUS.SUCCESS, quote: QUOTE } });
+    expect(screen.getByText("€190.00 × 4 nights")).toBeInTheDocument();
+    expect(screen.getByText("€50.00")).toBeInTheDocument();
+    expect(screen.getByText("€810.00")).toBeInTheDocument();
+    expect(screen.getByText(/price valid until/i)).toBeInTheDocument();
+  });
+
+  it("explains a stale quote after the selection changed or the price expired", () => {
+    const { rerender } = renderPanel({
+      range: COMPLETE_RANGE,
+      quoteState: { ...IDLE, status: QUOTE_STATUS.STALE, quote: QUOTE, staleReason: "changed" },
+    });
+    expect(screen.getByText(/changed/i)).toBeInTheDocument();
+
+    rerender(
+      <QuotePanel
+        range={COMPLETE_RANGE}
+        guests={2}
+        onGuestsChange={jest.fn()}
+        capacity={4}
+        minimumStay={2}
+        quoteState={{ ...IDLE, status: QUOTE_STATUS.STALE, quote: QUOTE, staleReason: "expired" }}
+        onRequestQuote={jest.fn()}
+        contactHref={null}
+      />
+    );
+    expect(screen.getByText(/expired/i)).toBeInTheDocument();
+  });
+
+  it("puts date and guest errors next to the field they concern", () => {
+    const { rerender } = renderPanel({
+      range: COMPLETE_RANGE,
+      quoteState: {
+        ...IDLE,
+        status: QUOTE_STATUS.ERROR,
+        error: { code: "stay_restriction_violation", message: "At least 3 nights.", status: 409, requestId: "r" },
+      },
+    });
+    expect(screen.getByText("At least 3 nights.")).toBeInTheDocument();
+
+    rerender(
+      <QuotePanel
+        range={COMPLETE_RANGE}
+        guests={5}
+        onGuestsChange={jest.fn()}
+        capacity={4}
+        minimumStay={2}
+        quoteState={{
+          ...IDLE,
+          status: QUOTE_STATUS.ERROR,
+          error: { code: "invalid_guest_count", message: "Sleeps at most 4.", status: 400, requestId: "r" },
+        }}
+        onRequestQuote={jest.fn()}
+        contactHref={null}
+      />
+    );
+    expect(screen.getByText("Sleeps at most 4.")).toBeInTheDocument();
+  });
+
+  it("offers a retry for transient failures", () => {
+    const { onRequestQuote } = renderPanel({
+      range: COMPLETE_RANGE,
+      quoteState: {
+        ...IDLE,
+        status: QUOTE_STATUS.ERROR,
+        error: { code: "network_error", message: "", status: 0, requestId: "" },
+      },
+    });
+    expect(screen.getByRole("alert")).toHaveTextContent(/couldn't check live pricing/i);
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+    expect(onRequestQuote).toHaveBeenCalledTimes(1);
+  });
+
+  it("points at the host contact when the property cannot be quoted", () => {
+    renderPanel({
+      range: COMPLETE_RANGE,
+      contactHref: "https://wa.me/31600000000",
+      quoteState: {
+        ...IDLE,
+        status: QUOTE_STATUS.ERROR,
+        error: { code: "quote_unavailable", message: "", status: 422, requestId: "req-1" },
+      },
+    });
+    const contactLink = screen.getByRole("link", { name: /contact the host/i });
+    expect(contactLink).toHaveAttribute("href", "https://wa.me/31600000000");
+  });
+
+  it("hides the action entirely when the site can no longer be quoted", () => {
+    renderPanel({
+      range: COMPLETE_RANGE,
+      quoteState: {
+        ...IDLE,
+        status: QUOTE_STATUS.ERROR,
+        error: { code: "site_suspended", message: "", status: 410, requestId: "req-1" },
+      },
+    });
+    expect(actionButton()).not.toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(/isn't available/i);
+  });
+
+  it("shows the request reference for unexpected failures", () => {
+    renderPanel({
+      range: COMPLETE_RANGE,
+      quoteState: {
+        ...IDLE,
+        status: QUOTE_STATUS.ERROR,
+        error: { code: "internal_error", message: "", status: 500, requestId: "req-42" },
+      },
+    });
+    expect(screen.getByText(/reference: req-42/i)).toBeInTheDocument();
+  });
+
+  it("clamps the guest stepper to capacity and reports changes", () => {
+    const { onGuestsChange, rerender } = renderPanel({ guests: 1 });
+    expect(screen.getByRole("button", { name: /remove a guest/i })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: /add a guest/i }));
+    expect(onGuestsChange).toHaveBeenCalledWith(2);
+
+    rerender(
+      <QuotePanel
+        range={{ checkIn: null, checkOut: null }}
+        guests={4}
+        onGuestsChange={onGuestsChange}
+        capacity={4}
+        minimumStay={null}
+        quoteState={IDLE}
+        onRequestQuote={jest.fn()}
+        contactHref={null}
+      />
+    );
+    expect(screen.getByRole("button", { name: /add a guest/i })).toBeDisabled();
+  });
+});

--- a/frontend/web/src/features/hostdashboard/website/tests/QuotePanel.test.jsx
+++ b/frontend/web/src/features/hostdashboard/website/tests/QuotePanel.test.jsx
@@ -34,19 +34,25 @@ const renderPanel = (props = {}) => {
   return { ...utils, onRequestQuote, onGuestsChange };
 };
 
-const actionButton = () => screen.queryByRole("button", { name: /check availability & price/i });
+const actionButton = () => screen.queryByRole("button", { name: /^check availability$/i });
 
 describe("QuotePanel", () => {
   it("prompts for dates and keeps the action disabled until the range is complete", () => {
     renderPanel();
-    expect(screen.getByText(/select your check-in date/i)).toBeInTheDocument();
+    expect(screen.getByText("Pick a check-in date")).toBeInTheDocument();
     expect(actionButton()).toBeDisabled();
   });
 
   it("asks for the check-out date after a check-in is chosen", () => {
     renderPanel({ range: { checkIn: "2026-10-10", checkOut: null } });
-    expect(screen.getByText(/pick your check-out date/i)).toBeInTheDocument();
+    expect(screen.getByText("Now pick a check-out date")).toBeInTheDocument();
     expect(actionButton()).toBeDisabled();
+  });
+
+  it("names the region after its heading", () => {
+    renderPanel();
+    expect(screen.getByRole("heading", { name: "Check availability & price" })).toBeInTheDocument();
+    expect(screen.getByRole("complementary", { name: "Check availability & price" })).toBeInTheDocument();
   });
 
   it("summarises the stay and requests a quote when asked", () => {
@@ -69,7 +75,7 @@ describe("QuotePanel", () => {
     expect(screen.getByText("€190.00 × 4 nights")).toBeInTheDocument();
     expect(screen.getByText("€50.00")).toBeInTheDocument();
     expect(screen.getByText("€810.00")).toBeInTheDocument();
-    expect(screen.getByText(/price valid until/i)).toBeInTheDocument();
+    expect(screen.getByText(/^valid until/i)).toBeInTheDocument();
   });
 
   it("explains a stale quote after the selection changed or the price expired", () => {
@@ -77,7 +83,7 @@ describe("QuotePanel", () => {
       range: COMPLETE_RANGE,
       quoteState: { ...IDLE, status: QUOTE_STATUS.STALE, quote: QUOTE, staleReason: "changed" },
     });
-    expect(screen.getByText(/changed/i)).toBeInTheDocument();
+    expect(screen.getByText("Selection changed — check again")).toBeInTheDocument();
 
     rerender(
       <QuotePanel
@@ -91,7 +97,7 @@ describe("QuotePanel", () => {
         contactHref={null}
       />
     );
-    expect(screen.getByText(/expired/i)).toBeInTheDocument();
+    expect(screen.getByText("Price expired — check again")).toBeInTheDocument();
   });
 
   it("puts date and guest errors next to the field they concern", () => {

--- a/frontend/web/src/features/hostdashboard/website/tests/quoteErrorCopy.test.js
+++ b/frontend/web/src/features/hostdashboard/website/tests/quoteErrorCopy.test.js
@@ -1,0 +1,77 @@
+import { QUOTE_ERROR_SCOPES, resolveQuoteErrorPresentation } from "../rendering/booking/quoteErrorCopy";
+
+const buildError = (code, overrides = {}) => ({
+  code,
+  message: "Server says so.",
+  status: 400,
+  requestId: "req-1",
+  ...overrides,
+});
+
+describe("resolveQuoteErrorPresentation", () => {
+  it.each([
+    ["invalid_date_range", QUOTE_ERROR_SCOPES.DATES],
+    ["stay_restriction_violation", QUOTE_ERROR_SCOPES.DATES],
+    ["invalid_guest_count", QUOTE_ERROR_SCOPES.GUESTS],
+  ])("uses the server message inline for %s", (code, expectedScope) => {
+    const presentation = resolveQuoteErrorPresentation(buildError(code));
+    expect(presentation.scope).toBe(expectedScope);
+    expect(presentation.message).toBe("Server says so.");
+    expect(presentation.canRetry).toBe(false);
+  });
+
+  it("replaces the unavailable_dates message and asks for a new selection", () => {
+    const presentation = resolveQuoteErrorPresentation(buildError("unavailable_dates", { status: 409 }));
+    expect(presentation.scope).toBe(QUOTE_ERROR_SCOPES.DATES);
+    expect(presentation.message).toMatch(/no longer available/i);
+    expect(presentation.clearSelection).toBe(true);
+  });
+
+  it.each(["site_not_found", "site_not_published", "site_suspended"])(
+    "hides the action for a site lifecycle problem (%s)",
+    (code) => {
+      const presentation = resolveQuoteErrorPresentation(buildError(code));
+      expect(presentation.scope).toBe(QUOTE_ERROR_SCOPES.PANEL);
+      expect(presentation.hideAction).toBe(true);
+      expect(presentation.message).toMatch(/isn't available/i);
+    }
+  );
+
+  it("offers the host contact for quote_unavailable", () => {
+    const presentation = resolveQuoteErrorPresentation(buildError("quote_unavailable", { status: 422 }));
+    expect(presentation.scope).toBe(QUOTE_ERROR_SCOPES.PANEL);
+    expect(presentation.showContact).toBe(true);
+    expect(presentation.canRetry).toBe(false);
+  });
+
+  it.each(["pricing_service_unavailable", "network_error", "rate_limited"])(
+    "offers a retry for a transient failure (%s)",
+    (code) => {
+      const presentation = resolveQuoteErrorPresentation(buildError(code));
+      expect(presentation.scope).toBe(QUOTE_ERROR_SCOPES.PANEL);
+      expect(presentation.canRetry).toBe(true);
+      expect(presentation.showReference).toBe(false);
+    }
+  );
+
+  it("shows the request reference for unexpected failures", () => {
+    for (const code of ["internal_error", "unexpected_response", "something_new"]) {
+      const presentation = resolveQuoteErrorPresentation(buildError(code));
+      expect(presentation.scope).toBe(QUOTE_ERROR_SCOPES.PANEL);
+      expect(presentation.canRetry).toBe(true);
+      expect(presentation.showReference).toBe(true);
+      expect(presentation.message).not.toBe("Server says so.");
+    }
+  });
+
+  it("does not show a reference when the error carries none", () => {
+    const presentation = resolveQuoteErrorPresentation(buildError("internal_error", { requestId: "" }));
+    expect(presentation.showReference).toBe(false);
+  });
+
+  it("survives a missing error object", () => {
+    const presentation = resolveQuoteErrorPresentation(null);
+    expect(presentation.scope).toBe(QUOTE_ERROR_SCOPES.PANEL);
+    expect(presentation.canRetry).toBe(true);
+  });
+});

--- a/frontend/web/src/features/hostdashboard/website/tests/quotePanelGate.test.js
+++ b/frontend/web/src/features/hostdashboard/website/tests/quotePanelGate.test.js
@@ -1,37 +1,37 @@
-import { resolveQuotePanelVisibility } from "../rendering/booking/quotePanelGate";
+import { resolveQuotePanelSiteId } from "../rendering/booking/quotePanelGate";
 
 const liveContext = { siteId: "site-1" };
 const optedInModel = { visibility: { quotePanel: true, availabilityCalendar: true } };
 
-describe("resolveQuotePanelVisibility", () => {
-  it("renders only on the live surface for an opted-in site", () => {
-    expect(resolveQuotePanelVisibility({ quoteContext: liveContext, model: optedInModel })).toBe(true);
+describe("resolveQuotePanelSiteId", () => {
+  it("returns the site id only on the live surface for an opted-in site", () => {
+    expect(resolveQuotePanelSiteId({ quoteContext: liveContext, model: optedInModel })).toBe("site-1");
   });
 
-  it("stays hidden without a site id (editor and draft preview surfaces)", () => {
-    expect(resolveQuotePanelVisibility({ quoteContext: null, model: optedInModel })).toBe(false);
-    expect(resolveQuotePanelVisibility({ quoteContext: { siteId: "" }, model: optedInModel })).toBe(false);
+  it("returns null without a site id (editor and draft preview surfaces)", () => {
+    expect(resolveQuotePanelSiteId({ quoteContext: null, model: optedInModel })).toBeNull();
+    expect(resolveQuotePanelSiteId({ quoteContext: { siteId: "  " }, model: optedInModel })).toBeNull();
   });
 
-  it("stays hidden until the host opts in — a missing flag is off", () => {
-    expect(resolveQuotePanelVisibility({ quoteContext: liveContext, model: { visibility: {} } })).toBe(false);
+  it("returns null until the host opts in — a missing flag is off", () => {
+    expect(resolveQuotePanelSiteId({ quoteContext: liveContext, model: { visibility: {} } })).toBeNull();
     expect(
-      resolveQuotePanelVisibility({ quoteContext: liveContext, model: { visibility: { quotePanel: false } } })
-    ).toBe(false);
+      resolveQuotePanelSiteId({ quoteContext: liveContext, model: { visibility: { quotePanel: false } } })
+    ).toBeNull();
   });
 
-  it("stays hidden inside the editor even with a site id", () => {
+  it("returns null inside the editor even with a site id", () => {
     expect(
-      resolveQuotePanelVisibility({ quoteContext: liveContext, model: optedInModel, onSelectTarget: () => {} })
-    ).toBe(false);
+      resolveQuotePanelSiteId({ quoteContext: liveContext, model: optedInModel, onSelectTarget: () => {} })
+    ).toBeNull();
   });
 
   it("needs the availability calendar it is built around", () => {
     expect(
-      resolveQuotePanelVisibility({
+      resolveQuotePanelSiteId({
         quoteContext: liveContext,
         model: { visibility: { quotePanel: true, availabilityCalendar: false } },
       })
-    ).toBe(false);
+    ).toBeNull();
   });
 });

--- a/frontend/web/src/features/hostdashboard/website/tests/quotePanelGate.test.js
+++ b/frontend/web/src/features/hostdashboard/website/tests/quotePanelGate.test.js
@@ -1,0 +1,37 @@
+import { resolveQuotePanelVisibility } from "../rendering/booking/quotePanelGate";
+
+const liveContext = { siteId: "site-1" };
+const optedInModel = { visibility: { quotePanel: true, availabilityCalendar: true } };
+
+describe("resolveQuotePanelVisibility", () => {
+  it("renders only on the live surface for an opted-in site", () => {
+    expect(resolveQuotePanelVisibility({ quoteContext: liveContext, model: optedInModel })).toBe(true);
+  });
+
+  it("stays hidden without a site id (editor and draft preview surfaces)", () => {
+    expect(resolveQuotePanelVisibility({ quoteContext: null, model: optedInModel })).toBe(false);
+    expect(resolveQuotePanelVisibility({ quoteContext: { siteId: "" }, model: optedInModel })).toBe(false);
+  });
+
+  it("stays hidden until the host opts in — a missing flag is off", () => {
+    expect(resolveQuotePanelVisibility({ quoteContext: liveContext, model: { visibility: {} } })).toBe(false);
+    expect(
+      resolveQuotePanelVisibility({ quoteContext: liveContext, model: { visibility: { quotePanel: false } } })
+    ).toBe(false);
+  });
+
+  it("stays hidden inside the editor even with a site id", () => {
+    expect(
+      resolveQuotePanelVisibility({ quoteContext: liveContext, model: optedInModel, onSelectTarget: () => {} })
+    ).toBe(false);
+  });
+
+  it("needs the availability calendar it is built around", () => {
+    expect(
+      resolveQuotePanelVisibility({
+        quoteContext: liveContext,
+        model: { visibility: { quotePanel: true, availabilityCalendar: false } },
+      })
+    ).toBe(false);
+  });
+});

--- a/frontend/web/src/features/hostdashboard/website/tests/quoteSelection.test.js
+++ b/frontend/web/src/features/hostdashboard/website/tests/quoteSelection.test.js
@@ -1,0 +1,114 @@
+import {
+  EMPTY_STAY_RANGE,
+  buildStayNightKeys,
+  countStayNights,
+  formatMinorUnits,
+  hasBlockedNight,
+  selectStayDate,
+  toLocalDateKey,
+} from "../rendering/booking/quoteSelection";
+
+const TODAY = "2026-10-01";
+const blocked = (...keys) => new Set(keys);
+
+describe("buildStayNightKeys / countStayNights", () => {
+  it("lists every stayed night, checkout-exclusive", () => {
+    expect(buildStayNightKeys("2026-10-01", "2026-10-04")).toEqual(["2026-10-01", "2026-10-02", "2026-10-03"]);
+    expect(countStayNights("2026-10-01", "2026-10-04")).toBe(3);
+  });
+
+  it("crosses month and year boundaries without timezone drift", () => {
+    expect(buildStayNightKeys("2026-12-30", "2027-01-02")).toEqual(["2026-12-30", "2026-12-31", "2027-01-01"]);
+  });
+
+  it("returns nothing for an incomplete or inverted range", () => {
+    expect(buildStayNightKeys(null, "2026-10-04")).toEqual([]);
+    expect(buildStayNightKeys("2026-10-04", "2026-10-01")).toEqual([]);
+    expect(countStayNights("2026-10-04", "2026-10-04")).toBe(0);
+  });
+});
+
+describe("hasBlockedNight", () => {
+  it("ignores a block on the checkout day itself", () => {
+    expect(hasBlockedNight("2026-10-01", "2026-10-04", blocked("2026-10-04"))).toBe(false);
+    expect(hasBlockedNight("2026-10-01", "2026-10-04", blocked("2026-10-02"))).toBe(true);
+  });
+});
+
+describe("selectStayDate", () => {
+  const select = (range, dateKey, blockedKeys = blocked()) =>
+    selectStayDate({ range, dateKey, blockedDateKeys: blockedKeys, todayKey: TODAY });
+
+  it("starts a range on the first click", () => {
+    expect(select(EMPTY_STAY_RANGE, "2026-10-10")).toEqual({ checkIn: "2026-10-10", checkOut: null });
+  });
+
+  it("completes the range on a later click", () => {
+    expect(select({ checkIn: "2026-10-10", checkOut: null }, "2026-10-14")).toEqual({
+      checkIn: "2026-10-10",
+      checkOut: "2026-10-14",
+    });
+  });
+
+  it("restarts the range when clicking on or before the check-in", () => {
+    expect(select({ checkIn: "2026-10-10", checkOut: null }, "2026-10-10")).toEqual({
+      checkIn: "2026-10-10",
+      checkOut: null,
+    });
+    expect(select({ checkIn: "2026-10-10", checkOut: null }, "2026-10-08")).toEqual({
+      checkIn: "2026-10-08",
+      checkOut: null,
+    });
+  });
+
+  it("starts over once a range is complete", () => {
+    expect(select({ checkIn: "2026-10-10", checkOut: "2026-10-14" }, "2026-10-20")).toEqual({
+      checkIn: "2026-10-20",
+      checkOut: null,
+    });
+  });
+
+  it("ignores past dates entirely", () => {
+    expect(select(EMPTY_STAY_RANGE, "2026-09-30")).toBe(EMPTY_STAY_RANGE);
+  });
+
+  it("refuses to start a stay on a blocked night", () => {
+    const range = EMPTY_STAY_RANGE;
+    expect(select(range, "2026-10-10", blocked("2026-10-10"))).toBe(range);
+  });
+
+  it("allows a blocked day as the checkout when the nights before it are free", () => {
+    expect(select({ checkIn: "2026-10-10", checkOut: null }, "2026-10-12", blocked("2026-10-12"))).toEqual({
+      checkIn: "2026-10-10",
+      checkOut: "2026-10-12",
+    });
+  });
+
+  it("restarts at the clicked date when a blocked night sits inside the attempted range", () => {
+    expect(select({ checkIn: "2026-10-10", checkOut: null }, "2026-10-14", blocked("2026-10-12"))).toEqual({
+      checkIn: "2026-10-14",
+      checkOut: null,
+    });
+  });
+
+  it("keeps the range unchanged when a blocked night sits inside and the clicked date is itself blocked", () => {
+    const range = { checkIn: "2026-10-10", checkOut: null };
+    expect(select(range, "2026-10-14", blocked("2026-10-12", "2026-10-14"))).toBe(range);
+  });
+});
+
+describe("formatMinorUnits / toLocalDateKey", () => {
+  it("formats cents as a currency string", () => {
+    expect(formatMinorUnits(81000)).toBe("€810.00");
+    expect(formatMinorUnits(1)).toBe("€0.01");
+  });
+
+  it("falls back to an empty string for non-numeric input", () => {
+    expect(formatMinorUnits(null)).toBe("");
+    expect(formatMinorUnits("abc")).toBe("");
+  });
+
+  it("builds local date keys with zero padding", () => {
+    expect(toLocalDateKey(new Date(2026, 0, 5))).toBe("2026-01-05");
+  });
+});

--- a/frontend/web/src/features/hostdashboard/website/tests/revealDeferredSections.test.js
+++ b/frontend/web/src/features/hostdashboard/website/tests/revealDeferredSections.test.js
@@ -1,0 +1,39 @@
+import { revealDeferredSections } from "../rendering/animations/revealDeferredSections";
+
+const buildDocument = () => {
+  const root = document.createElement("div");
+  root.innerHTML = `
+    <section class="deferred" id="gallery"></section>
+    <section class="plain" id="hero"></section>
+    <section class="deferred" id="availability"></section>
+  `;
+  return root;
+};
+
+describe("revealDeferredSections", () => {
+  it("marks every deferred section as revealed and leaves other sections alone", () => {
+    const root = buildDocument();
+
+    const revealedCount = revealDeferredSections(root, "deferred", "revealed");
+
+    expect(revealedCount).toBe(2);
+    expect(root.querySelector("#gallery").classList.contains("revealed")).toBe(true);
+    expect(root.querySelector("#availability").classList.contains("revealed")).toBe(true);
+    expect(root.querySelector("#hero").classList.contains("revealed")).toBe(false);
+  });
+
+  it("is idempotent across repeated navigations", () => {
+    const root = buildDocument();
+
+    revealDeferredSections(root, "deferred", "revealed");
+    revealDeferredSections(root, "deferred", "revealed");
+
+    expect(root.querySelector("#gallery").className).toBe("deferred revealed");
+  });
+
+  it("does nothing without a root or class names", () => {
+    expect(revealDeferredSections(null, "deferred", "revealed")).toBe(0);
+    expect(revealDeferredSections(buildDocument(), "", "revealed")).toBe(0);
+    expect(revealDeferredSections(buildDocument(), "deferred", "")).toBe(0);
+  });
+});

--- a/frontend/web/src/features/hostdashboard/website/tests/useWebsiteScrollReveal.test.jsx
+++ b/frontend/web/src/features/hostdashboard/website/tests/useWebsiteScrollReveal.test.jsx
@@ -73,7 +73,6 @@ describe("useWebsiteScrollReveal", () => {
     expect(first.classList.contains(VISIBLE)).toBe(true);
     expect(first.classList.contains(SETTLED)).toBe(false);
 
-    // A child's transition bubbling up must not settle the section early.
     fireTransitionEnd(getByTestId("child"));
     expect(first.classList.contains(SETTLED)).toBe(false);
 

--- a/frontend/web/src/features/hostdashboard/website/tests/useWebsiteScrollReveal.test.jsx
+++ b/frontend/web/src/features/hostdashboard/website/tests/useWebsiteScrollReveal.test.jsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { act, render } from "@testing-library/react";
+import { useWebsiteScrollReveal } from "../rendering/animations/useWebsiteScrollReveal";
+import motionStyles from "../rendering/animations/WebsiteTemplateMotion.module.scss";
+
+const VISIBLE = motionStyles.scrollRevealVisible;
+const SETTLED = motionStyles.scrollRevealSettled;
+
+function RevealCanvas() {
+  const canvasRef = useWebsiteScrollReveal({ enabled: true });
+  return (
+    <div ref={canvasRef}>
+      <section data-scroll-reveal="true" data-testid="first">
+        <img alt="" data-testid="child" />
+      </section>
+      <section data-scroll-reveal="true" data-testid="second" />
+    </div>
+  );
+}
+
+const installFakeIntersectionObserver = () => {
+  const observers = [];
+  class FakeIntersectionObserver {
+    constructor(callback) {
+      this.callback = callback;
+      this.observed = new Set();
+      observers.push(this);
+    }
+    observe(target) {
+      this.observed.add(target);
+    }
+    unobserve(target) {
+      this.observed.delete(target);
+    }
+    disconnect() {
+      this.observed.clear();
+    }
+    intersect(target) {
+      this.callback([{ target, isIntersecting: true }], this);
+    }
+  }
+  global.IntersectionObserver = FakeIntersectionObserver;
+  return observers;
+};
+
+const fireTransitionEnd = (element) => {
+  act(() => {
+    element.dispatchEvent(new Event("transitionend", { bubbles: true }));
+  });
+};
+
+describe("useWebsiteScrollReveal", () => {
+  afterEach(() => {
+    delete global.IntersectionObserver;
+  });
+
+  it("reveals and settles every target immediately when nothing can animate", () => {
+    const { getByTestId } = render(<RevealCanvas />);
+
+    expect(getByTestId("first").classList.contains(VISIBLE)).toBe(true);
+    expect(getByTestId("first").classList.contains(SETTLED)).toBe(true);
+    expect(getByTestId("second").classList.contains(SETTLED)).toBe(true);
+  });
+
+  it("reveals on intersection and settles only once the target's own transition ends", () => {
+    const observers = installFakeIntersectionObserver();
+    const { getByTestId } = render(<RevealCanvas />);
+    const first = getByTestId("first");
+
+    act(() => {
+      observers[0].intersect(first);
+    });
+    expect(first.classList.contains(VISIBLE)).toBe(true);
+    expect(first.classList.contains(SETTLED)).toBe(false);
+
+    // A child's transition bubbling up must not settle the section early.
+    fireTransitionEnd(getByTestId("child"));
+    expect(first.classList.contains(SETTLED)).toBe(false);
+
+    fireTransitionEnd(first);
+    expect(first.classList.contains(SETTLED)).toBe(true);
+    expect(getByTestId("second").classList.contains(VISIBLE)).toBe(false);
+  });
+
+  it("stops listening for transitions on unmount", () => {
+    const observers = installFakeIntersectionObserver();
+    const { getByTestId, unmount } = render(<RevealCanvas />);
+    const first = getByTestId("first");
+    act(() => {
+      observers[0].intersect(first);
+    });
+
+    unmount();
+    first.dispatchEvent(new Event("transitionend", { bubbles: true }));
+
+    expect(first.classList.contains(SETTLED)).toBe(false);
+  });
+});

--- a/frontend/web/src/features/hostdashboard/website/tests/websitePublicQuoteService.test.js
+++ b/frontend/web/src/features/hostdashboard/website/tests/websitePublicQuoteService.test.js
@@ -1,0 +1,141 @@
+import { PROPERTY_API_BASE } from "../../hostproperty/constants";
+import {
+  WEBSITE_PUBLIC_QUOTE_CLIENT_ERROR_CODES,
+  WebsitePublicQuoteError,
+  requestPublicWebsiteQuote,
+} from "../services/websitePublicQuoteService";
+
+const QUOTE_REQUEST = {
+  siteId: "site-1",
+  checkIn: "2026-10-01",
+  checkOut: "2026-10-05",
+  guests: 2,
+  sessionId: "visitor-1",
+};
+
+const QUOTE_RESPONSE = {
+  quoteId: "quote_1",
+  siteId: "site-1",
+  propertyId: "property-1",
+  timezone: null,
+  checkIn: "2026-10-01",
+  checkOut: "2026-10-05",
+  nights: 4,
+  guestCount: 2,
+  availability: { isAvailable: true, bookableFrom: "2026-10-01", bookableUntil: "2026-10-31", minimumStay: 2, maximumStay: null },
+  priceBreakdown: { currency: "EUR", nightlyBaseTotal: 76000, cleaningFee: 5000, discounts: [], taxes: [], fees: [], total: 81000 },
+  policiesApplied: ["minimum_stay", "availability_window"],
+  expiresAt: "2026-10-01T10:30:00.000Z",
+  quoteToken: "qtok_abc",
+};
+
+const mockFetchResponse = ({ ok = true, status = 200, body = "" } = {}) => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok,
+    status,
+    text: () => Promise.resolve(typeof body === "string" ? body : JSON.stringify(body)),
+  });
+};
+
+const expectQuoteError = async (promise, code) => {
+  await expect(promise).rejects.toBeInstanceOf(WebsitePublicQuoteError);
+  await expect(promise).rejects.toMatchObject({ code });
+};
+
+describe("requestPublicWebsiteQuote", () => {
+  afterEach(() => {
+    delete global.fetch;
+    globalThis.localStorage.clear();
+  });
+
+  it("posts the design-pack request body without any auth header", async () => {
+    globalThis.localStorage.setItem("CognitoIdentityServiceProvider.abc.user.accessToken", "host-token");
+    mockFetchResponse({ body: QUOTE_RESPONSE });
+
+    await requestPublicWebsiteQuote(QUOTE_REQUEST);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [url, options] = global.fetch.mock.calls[0];
+    expect(url).toBe(`${PROPERTY_API_BASE}/website/public/quote`);
+    expect(options.method).toBe("POST");
+    expect(options.cache).toBe("no-store");
+    expect(options.headers).toEqual({ "Content-Type": "application/json" });
+    expect(JSON.parse(options.body)).toEqual({
+      siteId: "site-1",
+      checkIn: "2026-10-01",
+      checkOut: "2026-10-05",
+      guests: 2,
+      currency: "EUR",
+      session: { sessionId: "visitor-1", source: "standalone_site" },
+    });
+  });
+
+  it("returns the normalized quote on success", async () => {
+    mockFetchResponse({ body: QUOTE_RESPONSE });
+
+    const quote = await requestPublicWebsiteQuote(QUOTE_REQUEST);
+
+    expect(quote).toMatchObject({
+      quoteId: "quote_1",
+      nights: 4,
+      guestCount: 2,
+      priceBreakdown: { total: 81000, nightlyBaseTotal: 76000, cleaningFee: 5000, currency: "EUR" },
+      expiresAt: "2026-10-01T10:30:00.000Z",
+      quoteToken: "qtok_abc",
+    });
+  });
+
+  it("surfaces the endpoint's error code, message, status and requestId", async () => {
+    mockFetchResponse({
+      ok: false,
+      status: 409,
+      body: { error: { code: "unavailable_dates", message: "The selected dates are not available.", requestId: "req-9" } },
+    });
+
+    const promise = requestPublicWebsiteQuote(QUOTE_REQUEST);
+    await expectQuoteError(promise, "unavailable_dates");
+    await expect(promise).rejects.toMatchObject({
+      status: 409,
+      message: "The selected dates are not available.",
+      requestId: "req-9",
+    });
+  });
+
+  it("maps an API Gateway throttle response to rate_limited", async () => {
+    mockFetchResponse({ ok: false, status: 429, body: { message: "Too Many Requests" } });
+
+    await expectQuoteError(requestPublicWebsiteQuote(QUOTE_REQUEST), WEBSITE_PUBLIC_QUOTE_CLIENT_ERROR_CODES.RATE_LIMITED);
+  });
+
+  it("maps a non-JSON failure body to unexpected_response", async () => {
+    mockFetchResponse({ ok: false, status: 502, body: "<html>Bad Gateway</html>" });
+
+    await expectQuoteError(
+      requestPublicWebsiteQuote(QUOTE_REQUEST),
+      WEBSITE_PUBLIC_QUOTE_CLIENT_ERROR_CODES.UNEXPECTED_RESPONSE
+    );
+  });
+
+  it("maps a success body that is not a quote to unexpected_response", async () => {
+    mockFetchResponse({ body: { hello: "world" } });
+
+    await expectQuoteError(
+      requestPublicWebsiteQuote(QUOTE_REQUEST),
+      WEBSITE_PUBLIC_QUOTE_CLIENT_ERROR_CODES.UNEXPECTED_RESPONSE
+    );
+  });
+
+  it("maps a network failure to network_error", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+
+    await expectQuoteError(requestPublicWebsiteQuote(QUOTE_REQUEST), WEBSITE_PUBLIC_QUOTE_CLIENT_ERROR_CODES.NETWORK_ERROR);
+  });
+
+  it("lets an abort propagate untouched so callers can ignore it", async () => {
+    const abortError = new Error("aborted");
+    abortError.name = "AbortError";
+    global.fetch = jest.fn().mockRejectedValue(abortError);
+
+    await expect(requestPublicWebsiteQuote(QUOTE_REQUEST)).rejects.toBe(abortError);
+  });
+});

--- a/frontend/web/src/features/hostdashboard/website/websiteEditorConfig.js
+++ b/frontend/web/src/features/hostdashboard/website/websiteEditorConfig.js
@@ -239,6 +239,11 @@ export const TEMPLATE_VISIBILITY_FIELD_MAP = Object.freeze({
       "Show contact footer",
       "Controls the contact footer section at the bottom of the page."
     ),
+    createVisibilityField(
+      "quotePanel",
+      "Show booking panel",
+      "Lets guests pick dates and see a live price. Appears on your published site only, and needs the availability calendar."
+    ),
     createVisibilityField("chatWidget", "Show WhatsApp widget", WHATSAPP_WIDGET_DESCRIPTION),
   ],
   [TRUST_SIGNALS_TEMPLATE_KEY]: [
@@ -257,6 +262,11 @@ export const TEMPLATE_VISIBILITY_FIELD_MAP = Object.freeze({
       "availabilityCalendar",
       "Show availability calendar",
       "Controls the imported availability snapshot section."
+    ),
+    createVisibilityField(
+      "quotePanel",
+      "Show booking panel",
+      "Lets guests pick dates and see a live price. Appears on your published site only, and needs the availability calendar."
     ),
     createVisibilityField("chatWidget", "Show WhatsApp widget", WHATSAPP_WIDGET_DESCRIPTION),
   ],
@@ -281,6 +291,11 @@ export const TEMPLATE_VISIBILITY_FIELD_MAP = Object.freeze({
       "availabilityCalendar",
       "Show availability calendar",
       "Controls the imported availability snapshot section."
+    ),
+    createVisibilityField(
+      "quotePanel",
+      "Show booking panel",
+      "Lets guests pick dates and see a live price. Appears on your published site only, and needs the availability calendar."
     ),
     createVisibilityField("chatWidget", "Show WhatsApp widget", WHATSAPP_WIDGET_DESCRIPTION),
   ],


### PR DESCRIPTION
## Close or Relate the Issue
[//]: # (Only if this should close the issue)
- Closes #

[//]: # (in the issue a reference will be added to this pr)
- Related Issue: #3038

## Proposed Changes
[//]: # (Add a detailed description of the changes here)
Description:

Adds the panel where a guest on a direct booking website picks dates, sets the number of guests, and gets a real price back from the server.

This uses the endpoint from #3168, which is now live in API Gateway. Tested end to end on a published site.

What it does:
* The hero button now works. It scrolls down to the calendar instead of doing nothing
* The existing availability calendar becomes selectable: first click is check-in, second is check-out. Blocked days can end a stay but not start one, since checkout is exclusive
* A panel next to the calendar holds the guest counter and the button. The price comes back split out into nights, cleaning fee and total, with the time it stays valid
* Changing the dates or the guest count greys out the price with a note to check again, instead of clearing it
* Every error code from the endpoint gets its own message. Date problems show at the dates, guest problems at the counter, and anything else as a panel message with a retry button

Where it does and doesn't show:
The panel only renders on the published live site, never in the editor or the draft preview. On top of that a host has to switch it on with a new toggle, and it defaults to off, so nothing changes for existing sites until someone opts in.

Client-side date filtering is convenience only. The server decides what's available and what it costs.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Optimization
- [ ] Documentation update

## Change Size
[//]: # (Indicate the size of this change.)
[//]: # (Clarify under Refactoring which parts are moved/unchanged code, so the reviewer doesn’t review old logic.)
- [x] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
- [ ] Big change (+-max 1000)
- [ ] Small change (less than 300)

## Refactoring
Refactors following files, but didn't change the code. This is to avoid reviewing old logic.

N/A. Nothing was moved or refactored, this is new code plus additions to existing files. The 65 deletions are lines that got replaced in place, mostly the visibility defaults map and the calendar call in the three templates.

## Evidence
- [x] Screenshots or screen recording added for UI changes
- [x] Before/after images added when relevant
- [x] Images clearly show the implemented change
- [x] Image quality is readable (no cropped or blurry evidence)


Quote panel on the live site with a real price from the endpoint:
<img width="2056" height="1207" alt="image" src="https://github.com/user-attachments/assets/c6e063e0-dcf2-4a15-8c77-89b32794b643" />

Same panel on mobile:
<img width="1503" height="1169" alt="image" src="https://github.com/user-attachments/assets/c7d3929d-d429-4f91-8901-3e36773d2ec3" />

Same panel on tablet:
<img width="1502" height="1165" alt="image" src="https://github.com/user-attachments/assets/805091d4-efc8-4047-8771-67b959886412" />


## Responsiveness
- [x] UI checked on mobile
- [x] UI checked on tablet
- [x] UI checked on desktop
- [x] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages
- [ ] NPM Packages installed
- [ ] NPM Packages removed
- [ ] NPM Packages updated
- [ ] Checked for vulnerabilities using "npm audit"

## Checklist
[//]: # (All boxes must be checked before merging.)
- [ ] Pull request has at least 2 reviewers assigned
- [x] PR title is descriptive and includes issue number
- [x] Conventions
  - [x] No config files have been added (Amplify config, cache files)
  - [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  - [x} No global styling (see [#1691](https://github.com/domits1/Domits/issues/1691))
  - [x] No `console.log` left in code
  - [x] No commented-out code remains
- [x] Testing
  - [x] Code tested locally
  - [x] Jest tests are included
  - [x] Jest tests are passing

One thing worth flagging that came up while testing: you can publish a direct booking website for a listing that's still a draft. The quote then correctly returns a 422, but the guest just sees a generic "can't book right now". Might be worth an issue on the publish check.

## Keep or delete my branch
- [x] Delete my branch after merge
- [ ] Keep my branch  
