### PR TITLE
#3038 Add direct booking website columns to the booking table

### DIFF
--- a/backend/ORM/migrations/20260904_booking_direct_booking_website_columns.js
+++ b/backend/ORM/migrations/20260904_booking_direct_booking_website_columns.js
@@ -1,0 +1,141 @@
+export class BookingDirectBookingWebsiteColumns20260904 {
+  async up(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE test.booking
+      ADD COLUMN IF NOT EXISTS booking_source VARCHAR(255);
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE test.booking
+      ADD COLUMN IF NOT EXISTS site_id VARCHAR(255);
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE test.booking
+      ADD COLUMN IF NOT EXISTS guest_email VARCHAR(255);
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE test.booking
+      ADD COLUMN IF NOT EXISTS public_booking_ref VARCHAR(255);
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE test.booking
+      ADD COLUMN IF NOT EXISTS idempotency_key VARCHAR(255);
+    `);
+
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX ASYNC booking_public_booking_ref_unique_test
+      ON test.booking (public_booking_ref);
+    `);
+
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX ASYNC booking_idempotency_key_unique_test
+      ON test.booking (idempotency_key);
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE main.booking
+      ADD COLUMN IF NOT EXISTS booking_source VARCHAR(255);
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE main.booking
+      ADD COLUMN IF NOT EXISTS site_id VARCHAR(255);
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE main.booking
+      ADD COLUMN IF NOT EXISTS guest_email VARCHAR(255);
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE main.booking
+      ADD COLUMN IF NOT EXISTS public_booking_ref VARCHAR(255);
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE main.booking
+      ADD COLUMN IF NOT EXISTS idempotency_key VARCHAR(255);
+    `);
+
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX ASYNC booking_public_booking_ref_unique
+      ON main.booking (public_booking_ref);
+    `);
+
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX ASYNC booking_idempotency_key_unique
+      ON main.booking (idempotency_key);
+    `);
+  }
+
+  async down(queryRunner) {
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS main.booking_idempotency_key_unique;
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS main.booking_public_booking_ref_unique;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE main.booking
+      DROP COLUMN IF EXISTS idempotency_key;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE main.booking
+      DROP COLUMN IF EXISTS public_booking_ref;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE main.booking
+      DROP COLUMN IF EXISTS guest_email;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE main.booking
+      DROP COLUMN IF EXISTS site_id;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE main.booking
+      DROP COLUMN IF EXISTS booking_source;
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS test.booking_idempotency_key_unique_test;
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS test.booking_public_booking_ref_unique_test;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE test.booking
+      DROP COLUMN IF EXISTS idempotency_key;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE test.booking
+      DROP COLUMN IF EXISTS public_booking_ref;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE test.booking
+      DROP COLUMN IF EXISTS guest_email;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE test.booking
+      DROP COLUMN IF EXISTS site_id;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE test.booking
+      DROP COLUMN IF EXISTS booking_source;
+    `);
+  }
+}

--- a/backend/ORM/migrations/20260904_booking_direct_booking_website_columns.sql
+++ b/backend/ORM/migrations/20260904_booking_direct_booking_website_columns.sql
@@ -1,0 +1,238 @@
+-- 2026-09-04 booking direct booking website columns (schemas: test, main)
+-- Purpose:
+-- 1) Add the columns a booking request from a direct booking website needs:
+--    booking_source, site_id, guest_email, public_booking_ref, idempotency_key.
+-- 2) Enforce uniqueness of public_booking_ref and idempotency_key.
+--
+-- Column semantics (all nullable; NULL means "marketplace booking, unchanged"):
+-- - booking_source     VARCHAR(255)  'STANDALONE_SITE' for direct booking website requests.
+--                                    255 rather than an enum-sized width for the same
+--                                    reason as public_booking_ref below.
+-- - site_id            VARCHAR(255)  standalone_site.id the request came from.
+-- - guest_email        VARCHAR(255)  contact for anonymous guests (no Cognito guestid).
+-- - public_booking_ref VARCHAR(255)  public-safe reference returned to the guest.
+--                                    Width matches the other varchars: DSQL has no
+--                                    ALTER COLUMN TYPE, so widening later would mean
+--                                    dropping and recreating the column. The ref
+--                                    format is decided in PR 5.
+-- - idempotency_key    VARCHAR(255)  client-supplied Idempotency-Key header value.
+--
+-- Prerequisite: 20260904_booking_test_schema_reconcile.sql applied first, so that
+-- test.booking matches the entity before it gains new columns.
+--
+-- Aurora DSQL rules that apply to this runbook:
+-- - One DDL statement per transaction, never DDL and DML together. Run each
+--   statement on its own in psql autocommit mode. Do NOT wrap blocks in BEGIN.
+-- - ADD COLUMN is a catalog change: no rewrite, no lock. Columns are nullable with
+--   no DEFAULT and no NOT NULL (DSQL cannot SET NOT NULL on an existing table).
+-- - Uniqueness is a CREATE UNIQUE INDEX ASYNC. It returns a job_id immediately and
+--   does not block the table. Monitor sys.jobs; wait with sys.wait_for_job.
+--   If a build fails, the index stays INVALID and STILL enforces uniqueness on
+--   writes until dropped. Drop it, fix the data, create it again.
+-- - NULLS DISTINCT is the default and is required here: every existing marketplace
+--   row has NULL in both new key columns. Never add NULLS NOT DISTINCT.
+-- - Each DDL commit and each index activation bumps the cluster-wide catalog
+--   version; sessions with a stale catalog (warm Lambdas) fail once with
+--   SQLSTATE 40001 / OC001 and succeed on retry. Run in a quiet window.
+-- - Limits checked: booking has 19 active columns (limit 255, 24 after this),
+--   2 indexes on main (limit 24, 4 after this), index keys are single
+--   VARCHAR(255) columns (limit 1 KiB), no backfill (3000-row transaction limit
+--   does not apply).
+--
+-- Order of operations for the whole change:
+-- 1) Pre-flight below, both schemas.
+-- 2) UP on test, wait for both index jobs, verify.
+-- 3) UP on main, wait for both index jobs, verify.
+-- 4) Smoke test on test (and on main only if the team agrees; it rolls back).
+-- 5) Only then merge the PR that changes backend/ORM/models/Booking.js; the merge
+--    triggers a global Lambda redeploy and every Booking read selects the new
+--    columns from that moment on.
+
+-- =========================
+-- Pre-flight (read-only)
+-- =========================
+-- Expect: no rows in either schema.
+SELECT table_schema, column_name
+FROM information_schema.columns
+WHERE table_name = 'booking'
+  AND table_schema IN ('main', 'test')
+  AND column_name IN ('booking_source', 'site_id', 'guest_email', 'public_booking_ref', 'idempotency_key')
+ORDER BY table_schema, column_name;
+
+-- Expect: test and main both report 19 columns (reconcile applied).
+SELECT table_schema, COUNT(*) AS column_count
+FROM information_schema.columns
+WHERE table_name = 'booking' AND table_schema IN ('main', 'test')
+GROUP BY table_schema
+ORDER BY table_schema;
+
+-- Expect: no in-flight jobs on booking before starting.
+SELECT job_id, status, job_type, object_name, update_time
+FROM sys.jobs
+WHERE object_name LIKE '%booking%';
+
+-- =========================
+-- Migration SQL (UP) - schema test
+-- One statement per transaction.
+-- =========================
+ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS booking_source VARCHAR(255);
+
+ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS site_id VARCHAR(255);
+
+ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS guest_email VARCHAR(255);
+
+ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS public_booking_ref VARCHAR(255);
+
+ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS idempotency_key VARCHAR(255);
+
+-- Each CREATE INDEX ASYNC prints a job_id. Wait for each before continuing.
+CREATE UNIQUE INDEX ASYNC booking_public_booking_ref_unique_test ON test.booking (public_booking_ref);
+-- SELECT sys.wait_for_job('<job_id printed above>');
+
+CREATE UNIQUE INDEX ASYNC booking_idempotency_key_unique_test ON test.booking (idempotency_key);
+-- SELECT sys.wait_for_job('<job_id printed above>');
+
+-- =========================
+-- Migration SQL (UP) - schema main
+-- One statement per transaction. Quiet window.
+-- =========================
+ALTER TABLE main.booking ADD COLUMN IF NOT EXISTS booking_source VARCHAR(255);
+
+ALTER TABLE main.booking ADD COLUMN IF NOT EXISTS site_id VARCHAR(255);
+
+ALTER TABLE main.booking ADD COLUMN IF NOT EXISTS guest_email VARCHAR(255);
+
+ALTER TABLE main.booking ADD COLUMN IF NOT EXISTS public_booking_ref VARCHAR(255);
+
+ALTER TABLE main.booking ADD COLUMN IF NOT EXISTS idempotency_key VARCHAR(255);
+
+CREATE UNIQUE INDEX ASYNC booking_public_booking_ref_unique ON main.booking (public_booking_ref);
+-- SELECT sys.wait_for_job('<job_id printed above>');
+
+CREATE UNIQUE INDEX ASYNC booking_idempotency_key_unique ON main.booking (idempotency_key);
+-- SELECT sys.wait_for_job('<job_id printed above>');
+
+-- =========================
+-- Verification SQL
+-- =========================
+-- Expect: 5 rows per schema, all is_nullable = 'YES', column_default NULL.
+SELECT table_schema, column_name, data_type, character_maximum_length, is_nullable, column_default
+FROM information_schema.columns
+WHERE table_name = 'booking'
+  AND table_schema IN ('main', 'test')
+  AND column_name IN ('booking_source', 'site_id', 'guest_email', 'public_booking_ref', 'idempotency_key')
+ORDER BY table_schema, column_name;
+
+-- Expect: both index jobs per schema with status = 'completed'
+-- (sys.jobs forgets finished jobs after ~30 minutes; run this soon after).
+SELECT job_id, status, details, job_type, object_name, update_time
+FROM sys.jobs
+WHERE object_name LIKE '%booking_public_booking_ref_unique%'
+   OR object_name LIKE '%booking_idempotency_key_unique%'
+ORDER BY update_time;
+
+-- Expect: indisunique = t and indisvalid = t for all four indexes.
+SELECT n.nspname AS schema_name, c.relname AS index_name, i.indisunique, i.indisvalid
+FROM pg_index i
+JOIN pg_class c ON c.oid = i.indexrelid
+JOIN pg_class t ON t.oid = i.indrelid
+JOIN pg_namespace n ON n.oid = t.relnamespace
+WHERE t.relname = 'booking'
+  AND n.nspname IN ('main', 'test')
+  AND c.relname LIKE 'booking_%_unique%'
+ORDER BY schema_name, index_name;
+
+-- Expect: the index definitions with no NULLS NOT DISTINCT clause.
+SELECT schemaname, indexname, indexdef
+FROM pg_indexes
+WHERE tablename = 'booking'
+  AND schemaname IN ('main', 'test')
+  AND indexname LIKE 'booking_%_unique%'
+ORDER BY schemaname, indexname;
+
+-- =========================
+-- Rollback SQL (DOWN) - reverse order, one statement per transaction
+-- DROP INDEX also cancels an in-progress build. DROP COLUMN does not reclaim
+-- space and the dropped attribute still counts toward the 1600-column lifetime limit.
+-- =========================
+DROP INDEX IF EXISTS main.booking_idempotency_key_unique;
+
+DROP INDEX IF EXISTS main.booking_public_booking_ref_unique;
+
+ALTER TABLE main.booking DROP COLUMN IF EXISTS idempotency_key;
+
+ALTER TABLE main.booking DROP COLUMN IF EXISTS public_booking_ref;
+
+ALTER TABLE main.booking DROP COLUMN IF EXISTS guest_email;
+
+ALTER TABLE main.booking DROP COLUMN IF EXISTS site_id;
+
+ALTER TABLE main.booking DROP COLUMN IF EXISTS booking_source;
+
+DROP INDEX IF EXISTS test.booking_idempotency_key_unique_test;
+
+DROP INDEX IF EXISTS test.booking_public_booking_ref_unique_test;
+
+ALTER TABLE test.booking DROP COLUMN IF EXISTS idempotency_key;
+
+ALTER TABLE test.booking DROP COLUMN IF EXISTS public_booking_ref;
+
+ALTER TABLE test.booking DROP COLUMN IF EXISTS guest_email;
+
+ALTER TABLE test.booking DROP COLUMN IF EXISTS site_id;
+
+ALTER TABLE test.booking DROP COLUMN IF EXISTS booking_source;
+
+-- =========================
+-- Smoke Test SQL - schema test
+-- DML only, after the index jobs report completed.
+-- =========================
+
+-- 1) A direct booking website request row round-trips, and an ordinary
+--    marketplace row with NULL in every new column coexists with it.
+--    Run in a transaction and ROLLBACK to avoid permanent test rows.
+BEGIN;
+
+INSERT INTO test.booking
+  (id, arrivaldate, departuredate, createdat, guestid, guests, hostid, latepayment, paymentid,
+   property_id, status, guestname, hostname,
+   booking_source, site_id, guest_email, public_booking_ref, idempotency_key)
+VALUES
+  ('smoke-dbw-1', 1791936000000, 1792281600000, 1788912000000, 'smoke-guest', 2, 'smoke-host', FALSE,
+   'FAILED: ', 'smoke-property', 'Inquiry', 'Smoke Guest', 'WIP-Host',
+   'STANDALONE_SITE', 'smoke-site', 'guest@example.com', 'dbw-smoke-0001', 'idem-smoke-0001');
+
+INSERT INTO test.booking
+  (id, arrivaldate, departuredate, createdat, guestid, guests, hostid, latepayment, paymentid,
+   property_id, status, guestname, hostname)
+VALUES
+  ('smoke-marketplace-1', 1791936000000, 1792281600000, 1788912000000, 'smoke-guest', 2, 'smoke-host', FALSE,
+   'FAILED: ', 'smoke-property', 'Inquiry', 'Smoke Guest', 'WIP-Host');
+
+SELECT id, booking_source, site_id, guest_email, public_booking_ref, idempotency_key
+FROM test.booking
+WHERE id IN ('smoke-dbw-1', 'smoke-marketplace-1')
+ORDER BY id;
+
+ROLLBACK;
+
+-- 2) Uniqueness is enforced: the second INSERT must fail with a duplicate key
+--    error on booking_idempotency_key_unique_test. The transaction is then
+--    aborted; ROLLBACK ends it.
+BEGIN;
+
+INSERT INTO test.booking
+  (id, arrivaldate, departuredate, createdat, guestid, guests, hostid, latepayment, paymentid,
+   property_id, status, guestname, hostname, idempotency_key)
+VALUES
+  ('smoke-dup-1', 1791936000000, 1792281600000, 1788912000000, 'smoke-guest', 2, 'smoke-host', FALSE,
+   'FAILED: ', 'smoke-property', 'Inquiry', 'Smoke Guest', 'WIP-Host', 'idem-smoke-dup');
+
+INSERT INTO test.booking
+  (id, arrivaldate, departuredate, createdat, guestid, guests, hostid, latepayment, paymentid,
+   property_id, status, guestname, hostname, idempotency_key)
+VALUES
+  ('smoke-dup-2', 1791936000000, 1792281600000, 1788912000000, 'smoke-guest', 2, 'smoke-host', FALSE,
+   'FAILED: ', 'smoke-property', 'Inquiry', 'Smoke Guest', 'WIP-Host', 'idem-smoke-dup');
+
+ROLLBACK;

--- a/backend/ORM/migrations/20260904_booking_direct_booking_website_columns.sql
+++ b/backend/ORM/migrations/20260904_booking_direct_booking_website_columns.sql
@@ -1,57 +1,3 @@
--- 2026-09-04 booking direct booking website columns (schemas: test, main)
--- Purpose:
--- 1) Add the columns a booking request from a direct booking website needs:
---    booking_source, site_id, guest_email, public_booking_ref, idempotency_key.
--- 2) Enforce uniqueness of public_booking_ref and idempotency_key.
---
--- Column semantics (all nullable; NULL means "marketplace booking, unchanged"):
--- - booking_source     VARCHAR(255)  'STANDALONE_SITE' for direct booking website requests.
---                                    255 rather than an enum-sized width for the same
---                                    reason as public_booking_ref below.
--- - site_id            VARCHAR(255)  standalone_site.id the request came from.
--- - guest_email        VARCHAR(255)  contact for anonymous guests (no Cognito guestid).
--- - public_booking_ref VARCHAR(255)  public-safe reference returned to the guest.
---                                    Width matches the other varchars: DSQL has no
---                                    ALTER COLUMN TYPE, so widening later would mean
---                                    dropping and recreating the column. The ref
---                                    format is decided in PR 5.
--- - idempotency_key    VARCHAR(255)  client-supplied Idempotency-Key header value.
---
--- Prerequisite: 20260904_booking_test_schema_reconcile.sql applied first, so that
--- test.booking matches the entity before it gains new columns.
---
--- Aurora DSQL rules that apply to this runbook:
--- - One DDL statement per transaction, never DDL and DML together. Run each
---   statement on its own in psql autocommit mode. Do NOT wrap blocks in BEGIN.
--- - ADD COLUMN is a catalog change: no rewrite, no lock. Columns are nullable with
---   no DEFAULT and no NOT NULL (DSQL cannot SET NOT NULL on an existing table).
--- - Uniqueness is a CREATE UNIQUE INDEX ASYNC. It returns a job_id immediately and
---   does not block the table. Monitor sys.jobs; wait with sys.wait_for_job.
---   If a build fails, the index stays INVALID and STILL enforces uniqueness on
---   writes until dropped. Drop it, fix the data, create it again.
--- - NULLS DISTINCT is the default and is required here: every existing marketplace
---   row has NULL in both new key columns. Never add NULLS NOT DISTINCT.
--- - Each DDL commit and each index activation bumps the cluster-wide catalog
---   version; sessions with a stale catalog (warm Lambdas) fail once with
---   SQLSTATE 40001 / OC001 and succeed on retry. Run in a quiet window.
--- - Limits checked: booking has 19 active columns (limit 255, 24 after this),
---   2 indexes on main (limit 24, 4 after this), index keys are single
---   VARCHAR(255) columns (limit 1 KiB), no backfill (3000-row transaction limit
---   does not apply).
---
--- Order of operations for the whole change:
--- 1) Pre-flight below, both schemas.
--- 2) UP on test, wait for both index jobs, verify.
--- 3) UP on main, wait for both index jobs, verify.
--- 4) Smoke test on test (and on main only if the team agrees; it rolls back).
--- 5) Only then merge the PR that changes backend/ORM/models/Booking.js; the merge
---    triggers a global Lambda redeploy and every Booking read selects the new
---    columns from that moment on.
-
--- =========================
--- Pre-flight (read-only)
--- =========================
--- Expect: no rows in either schema.
 SELECT table_schema, column_name
 FROM information_schema.columns
 WHERE table_name = 'booking'
@@ -59,22 +5,16 @@ WHERE table_name = 'booking'
   AND column_name IN ('booking_source', 'site_id', 'guest_email', 'public_booking_ref', 'idempotency_key')
 ORDER BY table_schema, column_name;
 
--- Expect: test and main both report 19 columns (reconcile applied).
 SELECT table_schema, COUNT(*) AS column_count
 FROM information_schema.columns
 WHERE table_name = 'booking' AND table_schema IN ('main', 'test')
 GROUP BY table_schema
 ORDER BY table_schema;
 
--- Expect: no in-flight jobs on booking before starting.
 SELECT job_id, status, job_type, object_name, update_time
 FROM sys.jobs
 WHERE object_name LIKE '%booking%';
 
--- =========================
--- Migration SQL (UP) - schema test
--- One statement per transaction.
--- =========================
 ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS booking_source VARCHAR(255);
 
 ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS site_id VARCHAR(255);
@@ -85,17 +25,15 @@ ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS public_booking_ref VARCHAR(255
 
 ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS idempotency_key VARCHAR(255);
 
--- Each CREATE INDEX ASYNC prints a job_id. Wait for each before continuing.
 CREATE UNIQUE INDEX ASYNC booking_public_booking_ref_unique_test ON test.booking (public_booking_ref);
--- SELECT sys.wait_for_job('<job_id printed above>');
 
 CREATE UNIQUE INDEX ASYNC booking_idempotency_key_unique_test ON test.booking (idempotency_key);
--- SELECT sys.wait_for_job('<job_id printed above>');
 
--- =========================
--- Migration SQL (UP) - schema main
--- One statement per transaction. Quiet window.
--- =========================
+SELECT job_id, status, details, job_type, object_name, update_time
+FROM sys.jobs
+WHERE object_name LIKE 'test.booking_%_unique_test'
+ORDER BY update_time;
+
 ALTER TABLE main.booking ADD COLUMN IF NOT EXISTS booking_source VARCHAR(255);
 
 ALTER TABLE main.booking ADD COLUMN IF NOT EXISTS site_id VARCHAR(255);
@@ -107,15 +45,14 @@ ALTER TABLE main.booking ADD COLUMN IF NOT EXISTS public_booking_ref VARCHAR(255
 ALTER TABLE main.booking ADD COLUMN IF NOT EXISTS idempotency_key VARCHAR(255);
 
 CREATE UNIQUE INDEX ASYNC booking_public_booking_ref_unique ON main.booking (public_booking_ref);
--- SELECT sys.wait_for_job('<job_id printed above>');
 
 CREATE UNIQUE INDEX ASYNC booking_idempotency_key_unique ON main.booking (idempotency_key);
--- SELECT sys.wait_for_job('<job_id printed above>');
 
--- =========================
--- Verification SQL
--- =========================
--- Expect: 5 rows per schema, all is_nullable = 'YES', column_default NULL.
+SELECT job_id, status, details, job_type, object_name, update_time
+FROM sys.jobs
+WHERE object_name LIKE 'main.booking_%_unique'
+ORDER BY update_time;
+
 SELECT table_schema, column_name, data_type, character_maximum_length, is_nullable, column_default
 FROM information_schema.columns
 WHERE table_name = 'booking'
@@ -123,15 +60,6 @@ WHERE table_name = 'booking'
   AND column_name IN ('booking_source', 'site_id', 'guest_email', 'public_booking_ref', 'idempotency_key')
 ORDER BY table_schema, column_name;
 
--- Expect: both index jobs per schema with status = 'completed'
--- (sys.jobs forgets finished jobs after ~30 minutes; run this soon after).
-SELECT job_id, status, details, job_type, object_name, update_time
-FROM sys.jobs
-WHERE object_name LIKE '%booking_public_booking_ref_unique%'
-   OR object_name LIKE '%booking_idempotency_key_unique%'
-ORDER BY update_time;
-
--- Expect: indisunique = t and indisvalid = t for all four indexes.
 SELECT n.nspname AS schema_name, c.relname AS index_name, i.indisunique, i.indisvalid
 FROM pg_index i
 JOIN pg_class c ON c.oid = i.indexrelid
@@ -142,7 +70,6 @@ WHERE t.relname = 'booking'
   AND c.relname LIKE 'booking_%_unique%'
 ORDER BY schema_name, index_name;
 
--- Expect: the index definitions with no NULLS NOT DISTINCT clause.
 SELECT schemaname, indexname, indexdef
 FROM pg_indexes
 WHERE tablename = 'booking'
@@ -150,11 +77,49 @@ WHERE tablename = 'booking'
   AND indexname LIKE 'booking_%_unique%'
 ORDER BY schemaname, indexname;
 
--- =========================
--- Rollback SQL (DOWN) - reverse order, one statement per transaction
--- DROP INDEX also cancels an in-progress build. DROP COLUMN does not reclaim
--- space and the dropped attribute still counts toward the 1600-column lifetime limit.
--- =========================
+BEGIN;
+
+INSERT INTO test.booking
+  (id, arrivaldate, departuredate, createdat, guestid, guests, hostid, latepayment, paymentid,
+   property_id, status, guestname, hostname,
+   booking_source, site_id, guest_email, public_booking_ref, idempotency_key)
+VALUES
+  ('smoke-dbw-1', 1791936000000, 1792281600000, 1788912000000, 'smoke-guest', 2, 'smoke-host', FALSE,
+   'FAILED: ', 'smoke-property', 'Inquiry', 'Smoke Guest', 'WIP-Host',
+   'STANDALONE_SITE', 'smoke-site', 'guest@example.com', 'dbw-smoke-0001', 'idem-smoke-0001');
+
+INSERT INTO test.booking
+  (id, arrivaldate, departuredate, createdat, guestid, guests, hostid, latepayment, paymentid,
+   property_id, status, guestname, hostname)
+VALUES
+  ('smoke-marketplace-1', 1791936000000, 1792281600000, 1788912000000, 'smoke-guest', 2, 'smoke-host', FALSE,
+   'FAILED: ', 'smoke-property', 'Inquiry', 'Smoke Guest', 'WIP-Host');
+
+SELECT id, booking_source, site_id, guest_email, public_booking_ref, idempotency_key
+FROM test.booking
+WHERE id IN ('smoke-dbw-1', 'smoke-marketplace-1')
+ORDER BY id;
+
+ROLLBACK;
+
+BEGIN;
+
+INSERT INTO test.booking
+  (id, arrivaldate, departuredate, createdat, guestid, guests, hostid, latepayment, paymentid,
+   property_id, status, guestname, hostname, idempotency_key)
+VALUES
+  ('smoke-dup-1', 1791936000000, 1792281600000, 1788912000000, 'smoke-guest', 2, 'smoke-host', FALSE,
+   'FAILED: ', 'smoke-property', 'Inquiry', 'Smoke Guest', 'WIP-Host', 'idem-smoke-dup');
+
+INSERT INTO test.booking
+  (id, arrivaldate, departuredate, createdat, guestid, guests, hostid, latepayment, paymentid,
+   property_id, status, guestname, hostname, idempotency_key)
+VALUES
+  ('smoke-dup-2', 1791936000000, 1792281600000, 1788912000000, 'smoke-guest', 2, 'smoke-host', FALSE,
+   'FAILED: ', 'smoke-property', 'Inquiry', 'Smoke Guest', 'WIP-Host', 'idem-smoke-dup');
+
+ROLLBACK;
+
 DROP INDEX IF EXISTS main.booking_idempotency_key_unique;
 
 DROP INDEX IF EXISTS main.booking_public_booking_ref_unique;
@@ -182,57 +147,3 @@ ALTER TABLE test.booking DROP COLUMN IF EXISTS guest_email;
 ALTER TABLE test.booking DROP COLUMN IF EXISTS site_id;
 
 ALTER TABLE test.booking DROP COLUMN IF EXISTS booking_source;
-
--- =========================
--- Smoke Test SQL - schema test
--- DML only, after the index jobs report completed.
--- =========================
-
--- 1) A direct booking website request row round-trips, and an ordinary
---    marketplace row with NULL in every new column coexists with it.
---    Run in a transaction and ROLLBACK to avoid permanent test rows.
-BEGIN;
-
-INSERT INTO test.booking
-  (id, arrivaldate, departuredate, createdat, guestid, guests, hostid, latepayment, paymentid,
-   property_id, status, guestname, hostname,
-   booking_source, site_id, guest_email, public_booking_ref, idempotency_key)
-VALUES
-  ('smoke-dbw-1', 1791936000000, 1792281600000, 1788912000000, 'smoke-guest', 2, 'smoke-host', FALSE,
-   'FAILED: ', 'smoke-property', 'Inquiry', 'Smoke Guest', 'WIP-Host',
-   'STANDALONE_SITE', 'smoke-site', 'guest@example.com', 'dbw-smoke-0001', 'idem-smoke-0001');
-
-INSERT INTO test.booking
-  (id, arrivaldate, departuredate, createdat, guestid, guests, hostid, latepayment, paymentid,
-   property_id, status, guestname, hostname)
-VALUES
-  ('smoke-marketplace-1', 1791936000000, 1792281600000, 1788912000000, 'smoke-guest', 2, 'smoke-host', FALSE,
-   'FAILED: ', 'smoke-property', 'Inquiry', 'Smoke Guest', 'WIP-Host');
-
-SELECT id, booking_source, site_id, guest_email, public_booking_ref, idempotency_key
-FROM test.booking
-WHERE id IN ('smoke-dbw-1', 'smoke-marketplace-1')
-ORDER BY id;
-
-ROLLBACK;
-
--- 2) Uniqueness is enforced: the second INSERT must fail with a duplicate key
---    error on booking_idempotency_key_unique_test. The transaction is then
---    aborted; ROLLBACK ends it.
-BEGIN;
-
-INSERT INTO test.booking
-  (id, arrivaldate, departuredate, createdat, guestid, guests, hostid, latepayment, paymentid,
-   property_id, status, guestname, hostname, idempotency_key)
-VALUES
-  ('smoke-dup-1', 1791936000000, 1792281600000, 1788912000000, 'smoke-guest', 2, 'smoke-host', FALSE,
-   'FAILED: ', 'smoke-property', 'Inquiry', 'Smoke Guest', 'WIP-Host', 'idem-smoke-dup');
-
-INSERT INTO test.booking
-  (id, arrivaldate, departuredate, createdat, guestid, guests, hostid, latepayment, paymentid,
-   property_id, status, guestname, hostname, idempotency_key)
-VALUES
-  ('smoke-dup-2', 1791936000000, 1792281600000, 1788912000000, 'smoke-guest', 2, 'smoke-host', FALSE,
-   'FAILED: ', 'smoke-property', 'Inquiry', 'Smoke Guest', 'WIP-Host', 'idem-smoke-dup');
-
-ROLLBACK;

--- a/backend/ORM/migrations/20260904_booking_direct_booking_website_columns.sql
+++ b/backend/ORM/migrations/20260904_booking_direct_booking_website_columns.sql
@@ -3,13 +3,13 @@ FROM information_schema.columns
 WHERE table_name = 'booking'
   AND table_schema IN ('main', 'test')
   AND column_name IN ('booking_source', 'site_id', 'guest_email', 'public_booking_ref', 'idempotency_key')
-ORDER BY table_schema, column_name;
+ORDER BY table_schema ASC, column_name ASC;
 
 SELECT table_schema, COUNT(*) AS column_count
 FROM information_schema.columns
 WHERE table_name = 'booking' AND table_schema IN ('main', 'test')
 GROUP BY table_schema
-ORDER BY table_schema;
+ORDER BY table_schema ASC;
 
 SELECT job_id, status, job_type, object_name, update_time
 FROM sys.jobs
@@ -32,7 +32,7 @@ CREATE UNIQUE INDEX ASYNC booking_idempotency_key_unique_test ON test.booking (i
 SELECT job_id, status, details, job_type, object_name, update_time
 FROM sys.jobs
 WHERE object_name LIKE 'test.booking_%_unique_test'
-ORDER BY update_time;
+ORDER BY update_time ASC;
 
 ALTER TABLE main.booking ADD COLUMN IF NOT EXISTS booking_source VARCHAR(255);
 
@@ -51,14 +51,14 @@ CREATE UNIQUE INDEX ASYNC booking_idempotency_key_unique ON main.booking (idempo
 SELECT job_id, status, details, job_type, object_name, update_time
 FROM sys.jobs
 WHERE object_name LIKE 'main.booking_%_unique'
-ORDER BY update_time;
+ORDER BY update_time ASC;
 
 SELECT table_schema, column_name, data_type, character_maximum_length, is_nullable, column_default
 FROM information_schema.columns
 WHERE table_name = 'booking'
   AND table_schema IN ('main', 'test')
   AND column_name IN ('booking_source', 'site_id', 'guest_email', 'public_booking_ref', 'idempotency_key')
-ORDER BY table_schema, column_name;
+ORDER BY table_schema ASC, column_name ASC;
 
 SELECT n.nspname AS schema_name, c.relname AS index_name, i.indisunique, i.indisvalid
 FROM pg_index i
@@ -68,14 +68,14 @@ JOIN pg_namespace n ON n.oid = t.relnamespace
 WHERE t.relname = 'booking'
   AND n.nspname IN ('main', 'test')
   AND c.relname LIKE 'booking_%_unique%'
-ORDER BY schema_name, index_name;
+ORDER BY schema_name ASC, index_name ASC;
 
 SELECT schemaname, indexname, indexdef
 FROM pg_indexes
 WHERE tablename = 'booking'
   AND schemaname IN ('main', 'test')
   AND indexname LIKE 'booking_%_unique%'
-ORDER BY schemaname, indexname;
+ORDER BY schemaname ASC, indexname ASC;
 
 BEGIN;
 
@@ -98,7 +98,7 @@ VALUES
 SELECT id, booking_source, site_id, guest_email, public_booking_ref, idempotency_key
 FROM test.booking
 WHERE id IN ('smoke-dbw-1', 'smoke-marketplace-1')
-ORDER BY id;
+ORDER BY id ASC;
 
 ROLLBACK;
 

--- a/backend/ORM/migrations/20260904_booking_test_schema_reconcile.js
+++ b/backend/ORM/migrations/20260904_booking_test_schema_reconcile.js
@@ -1,0 +1,64 @@
+// Reconciles test.booking with the Booking entity.
+//
+// Found during the 2026-09-04 catalog read for the direct booking website columns:
+// 20260520_booking_refund_fields.js records refunded_amount, stripe_refund_id and
+// refund_error as applied to both main.booking and test.booking, but test.booking
+// never received them. total_price has been on main.booking and in the entity
+// since 2026-05-28 (commit 96a91eb2f) with no migration record for either schema,
+// and is missing from test.booking as well. main.booking has 19 columns,
+// test.booking has 15. Any TypeORM read of the Booking entity with TEST=true fails
+// with "column does not exist" until this is applied.
+//
+// The same catalog read showed no column_default on any of the four columns on
+// main.booking: the DEFAULT 0 recorded by the May migration was never applied
+// there either. Neither schema has defaults on these columns.
+//
+// Applied to test.booking and verified on 2026-09-04.
+// Every statement is its own Aurora DSQL transaction (one DDL per transaction).
+// Columns are added nullable with no DEFAULT; see the companion .sql runbook for
+// the verification, rollback and smoke test.
+export class BookingTestSchemaReconcile20260904 {
+  async up(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE test.booking
+      ADD COLUMN IF NOT EXISTS refunded_amount BIGINT;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE test.booking
+      ADD COLUMN IF NOT EXISTS stripe_refund_id VARCHAR(255);
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE test.booking
+      ADD COLUMN IF NOT EXISTS refund_error TEXT;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE test.booking
+      ADD COLUMN IF NOT EXISTS total_price DOUBLE PRECISION;
+    `);
+  }
+
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE test.booking
+      DROP COLUMN IF EXISTS total_price;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE test.booking
+      DROP COLUMN IF EXISTS refund_error;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE test.booking
+      DROP COLUMN IF EXISTS stripe_refund_id;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE test.booking
+      DROP COLUMN IF EXISTS refunded_amount;
+    `);
+  }
+}

--- a/backend/ORM/migrations/20260904_booking_test_schema_reconcile.js
+++ b/backend/ORM/migrations/20260904_booking_test_schema_reconcile.js
@@ -1,22 +1,3 @@
-// Reconciles test.booking with the Booking entity.
-//
-// Found during the 2026-09-04 catalog read for the direct booking website columns:
-// 20260520_booking_refund_fields.js records refunded_amount, stripe_refund_id and
-// refund_error as applied to both main.booking and test.booking, but test.booking
-// never received them. total_price has been on main.booking and in the entity
-// since 2026-05-28 (commit 96a91eb2f) with no migration record for either schema,
-// and is missing from test.booking as well. main.booking has 19 columns,
-// test.booking has 15. Any TypeORM read of the Booking entity with TEST=true fails
-// with "column does not exist" until this is applied.
-//
-// The same catalog read showed no column_default on any of the four columns on
-// main.booking: the DEFAULT 0 recorded by the May migration was never applied
-// there either. Neither schema has defaults on these columns.
-//
-// Applied to test.booking and verified on 2026-09-04.
-// Every statement is its own Aurora DSQL transaction (one DDL per transaction).
-// Columns are added nullable with no DEFAULT; see the companion .sql runbook for
-// the verification, rollback and smoke test.
 export class BookingTestSchemaReconcile20260904 {
   async up(queryRunner) {
     await queryRunner.query(`

--- a/backend/ORM/migrations/20260904_booking_test_schema_reconcile.sql
+++ b/backend/ORM/migrations/20260904_booking_test_schema_reconcile.sql
@@ -3,7 +3,7 @@ FROM information_schema.columns
 WHERE table_name = 'booking'
   AND table_schema IN ('main', 'test')
   AND column_name IN ('refunded_amount', 'stripe_refund_id', 'refund_error', 'total_price')
-ORDER BY table_schema, column_name;
+ORDER BY table_schema ASC, column_name ASC;
 
 ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS refunded_amount BIGINT;
 
@@ -17,7 +17,7 @@ SELECT table_schema, COUNT(*) AS column_count
 FROM information_schema.columns
 WHERE table_name = 'booking' AND table_schema IN ('main', 'test')
 GROUP BY table_schema
-ORDER BY table_schema;
+ORDER BY table_schema ASC;
 
 SELECT m.column_name
 FROM information_schema.columns m
@@ -29,7 +29,7 @@ SELECT column_name, data_type, is_nullable, column_default
 FROM information_schema.columns
 WHERE table_schema = 'test' AND table_name = 'booking'
   AND column_name IN ('refunded_amount', 'stripe_refund_id', 'refund_error', 'total_price')
-ORDER BY column_name;
+ORDER BY column_name ASC;
 
 BEGIN;
 

--- a/backend/ORM/migrations/20260904_booking_test_schema_reconcile.sql
+++ b/backend/ORM/migrations/20260904_booking_test_schema_reconcile.sql
@@ -1,0 +1,122 @@
+-- 2026-09-04 booking test-schema reconcile (schema: test)
+-- Status: APPLIED and verified on 2026-09-04. test.booking has 19 columns matching
+-- main.booking, the LEFT JOIN verification returns no rows, all four columns are
+-- nullable, and the smoke test inserted and rolled back cleanly.
+-- Purpose:
+-- 1) Bring test.booking in line with the Booking entity (backend/ORM/models/Booking.js).
+-- 2) Record what the catalog read found so the migration history is honest.
+--
+-- Findings (catalog read 2026-09-04):
+-- - main.booking: 19 columns. test.booking: 15 columns.
+-- - 20260520_booking_refund_fields.js claims refunded_amount, stripe_refund_id and
+--   refund_error were added to BOTH schemas. test.booking never received them.
+-- - total_price exists on main.booking and in the entity (since commit 96a91eb2f,
+--   2026-05-28) but has no migration record and is absent from test.booking.
+-- - Consequence today: every TypeORM read of Booking with TEST=true fails with
+--   "column ... does not exist" because the entity selects every mapped column.
+-- - The pre-flight on 2026-09-04 showed column_default NULL for all four columns
+--   on main.booking, including refunded_amount. The DEFAULT 0 written in
+--   20260520_booking_refund_fields.js was therefore never applied to main either;
+--   neither schema has a default on these columns. The entity's default: 0 on
+--   refunded_amount and total_price is TypeORM metadata only.
+--
+-- Aurora DSQL rules that apply to this runbook:
+-- - One DDL statement per transaction, and never DDL and DML together. Run each
+--   statement on its own in psql autocommit mode. Do NOT wrap the UP block in BEGIN.
+-- - ADD COLUMN is a catalog change: no table rewrite, no lock. Columns are added
+--   nullable with no DEFAULT (DSQL's ADD COLUMN grammar carries no constraints, and
+--   SET NOT NULL is not available on existing tables).
+-- - Every DDL commit bumps the cluster-wide catalog version. Sessions holding a
+--   stale catalog (including warm Lambdas) fail their next statement with
+--   SQLSTATE 40001 / OC001 and succeed on retry. Run in a quiet window, back to
+--   back with 20260904_booking_direct_booking_website_columns.sql.
+
+-- =========================
+-- Pre-flight (read-only)
+-- =========================
+-- Expect: the four columns absent from test, present on main.
+SELECT table_schema, column_name, data_type, is_nullable, column_default
+FROM information_schema.columns
+WHERE table_name = 'booking'
+  AND table_schema IN ('main', 'test')
+  AND column_name IN ('refunded_amount', 'stripe_refund_id', 'refund_error', 'total_price')
+ORDER BY table_schema, column_name;
+
+-- =========================
+-- Migration SQL (UP) - schema test
+-- One statement per transaction.
+-- =========================
+ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS refunded_amount BIGINT;
+
+ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS stripe_refund_id VARCHAR(255);
+
+ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS refund_error TEXT;
+
+ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS total_price DOUBLE PRECISION;
+
+-- =========================
+-- Default parity - SKIPPED (outcome recorded 2026-09-04)
+-- =========================
+-- This step existed in case main.booking.refunded_amount carried the DEFAULT 0 from
+-- the May migration. The pre-flight showed no column_default on any of the four
+-- columns on main, so there was nothing to mirror and no SET DEFAULT was run.
+-- test and main now match: all four columns nullable, no defaults, in both schemas.
+
+-- =========================
+-- Verification SQL
+-- =========================
+-- Expect: 19 rows for main and 19 rows for test, same column names.
+SELECT table_schema, COUNT(*) AS column_count
+FROM information_schema.columns
+WHERE table_name = 'booking' AND table_schema IN ('main', 'test')
+GROUP BY table_schema
+ORDER BY table_schema;
+
+-- Expect: no rows (every main column exists on test).
+SELECT m.column_name
+FROM information_schema.columns m
+LEFT JOIN information_schema.columns t
+  ON t.table_schema = 'test' AND t.table_name = 'booking' AND t.column_name = m.column_name
+WHERE m.table_schema = 'main' AND m.table_name = 'booking' AND t.column_name IS NULL;
+
+-- Expect: is_nullable = 'YES' for all four on test.
+SELECT column_name, data_type, is_nullable, column_default
+FROM information_schema.columns
+WHERE table_schema = 'test' AND table_name = 'booking'
+  AND column_name IN ('refunded_amount', 'stripe_refund_id', 'refund_error', 'total_price')
+ORDER BY column_name;
+
+-- =========================
+-- Rollback SQL (DOWN) - schema test
+-- One statement per transaction. DROP COLUMN does not reclaim space and the
+-- dropped attribute still counts toward the table's 1600-column lifetime limit.
+-- =========================
+ALTER TABLE test.booking DROP COLUMN IF EXISTS total_price;
+
+ALTER TABLE test.booking DROP COLUMN IF EXISTS refund_error;
+
+ALTER TABLE test.booking DROP COLUMN IF EXISTS stripe_refund_id;
+
+ALTER TABLE test.booking DROP COLUMN IF EXISTS refunded_amount;
+
+-- =========================
+-- Smoke Test SQL - schema test
+-- Run in a transaction and ROLLBACK to avoid permanent test rows.
+-- DML only; keep it separate from the DDL above.
+-- =========================
+BEGIN;
+
+INSERT INTO test.booking
+  (id, arrivaldate, departuredate, createdat, guestid, guests, hostid, latepayment, paymentid,
+   property_id, status, guestname, hostname,
+   refunded_amount, stripe_refund_id, refund_error, total_price)
+VALUES
+  ('smoke-reconcile-1', 1791936000000, 1792281600000, 1788912000000, 'smoke-guest', 2, 'smoke-host', FALSE,
+   'FAILED: ', 'smoke-property', 'Inquiry', 'Smoke Guest', 'WIP-Host',
+   0, NULL, NULL, 810.00);
+
+SELECT id, refunded_amount, stripe_refund_id, refund_error, total_price
+FROM test.booking
+WHERE id = 'smoke-reconcile-1';
+
+ROLLBACK;

--- a/backend/ORM/migrations/20260904_booking_test_schema_reconcile.sql
+++ b/backend/ORM/migrations/20260904_booking_test_schema_reconcile.sql
@@ -1,40 +1,3 @@
--- 2026-09-04 booking test-schema reconcile (schema: test)
--- Status: APPLIED and verified on 2026-09-04. test.booking has 19 columns matching
--- main.booking, the LEFT JOIN verification returns no rows, all four columns are
--- nullable, and the smoke test inserted and rolled back cleanly.
--- Purpose:
--- 1) Bring test.booking in line with the Booking entity (backend/ORM/models/Booking.js).
--- 2) Record what the catalog read found so the migration history is honest.
---
--- Findings (catalog read 2026-09-04):
--- - main.booking: 19 columns. test.booking: 15 columns.
--- - 20260520_booking_refund_fields.js claims refunded_amount, stripe_refund_id and
---   refund_error were added to BOTH schemas. test.booking never received them.
--- - total_price exists on main.booking and in the entity (since commit 96a91eb2f,
---   2026-05-28) but has no migration record and is absent from test.booking.
--- - Consequence today: every TypeORM read of Booking with TEST=true fails with
---   "column ... does not exist" because the entity selects every mapped column.
--- - The pre-flight on 2026-09-04 showed column_default NULL for all four columns
---   on main.booking, including refunded_amount. The DEFAULT 0 written in
---   20260520_booking_refund_fields.js was therefore never applied to main either;
---   neither schema has a default on these columns. The entity's default: 0 on
---   refunded_amount and total_price is TypeORM metadata only.
---
--- Aurora DSQL rules that apply to this runbook:
--- - One DDL statement per transaction, and never DDL and DML together. Run each
---   statement on its own in psql autocommit mode. Do NOT wrap the UP block in BEGIN.
--- - ADD COLUMN is a catalog change: no table rewrite, no lock. Columns are added
---   nullable with no DEFAULT (DSQL's ADD COLUMN grammar carries no constraints, and
---   SET NOT NULL is not available on existing tables).
--- - Every DDL commit bumps the cluster-wide catalog version. Sessions holding a
---   stale catalog (including warm Lambdas) fail their next statement with
---   SQLSTATE 40001 / OC001 and succeed on retry. Run in a quiet window, back to
---   back with 20260904_booking_direct_booking_website_columns.sql.
-
--- =========================
--- Pre-flight (read-only)
--- =========================
--- Expect: the four columns absent from test, present on main.
 SELECT table_schema, column_name, data_type, is_nullable, column_default
 FROM information_schema.columns
 WHERE table_name = 'booking'
@@ -42,10 +5,6 @@ WHERE table_name = 'booking'
   AND column_name IN ('refunded_amount', 'stripe_refund_id', 'refund_error', 'total_price')
 ORDER BY table_schema, column_name;
 
--- =========================
--- Migration SQL (UP) - schema test
--- One statement per transaction.
--- =========================
 ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS refunded_amount BIGINT;
 
 ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS stripe_refund_id VARCHAR(255);
@@ -54,56 +13,24 @@ ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS refund_error TEXT;
 
 ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS total_price DOUBLE PRECISION;
 
--- =========================
--- Default parity - SKIPPED (outcome recorded 2026-09-04)
--- =========================
--- This step existed in case main.booking.refunded_amount carried the DEFAULT 0 from
--- the May migration. The pre-flight showed no column_default on any of the four
--- columns on main, so there was nothing to mirror and no SET DEFAULT was run.
--- test and main now match: all four columns nullable, no defaults, in both schemas.
-
--- =========================
--- Verification SQL
--- =========================
--- Expect: 19 rows for main and 19 rows for test, same column names.
 SELECT table_schema, COUNT(*) AS column_count
 FROM information_schema.columns
 WHERE table_name = 'booking' AND table_schema IN ('main', 'test')
 GROUP BY table_schema
 ORDER BY table_schema;
 
--- Expect: no rows (every main column exists on test).
 SELECT m.column_name
 FROM information_schema.columns m
 LEFT JOIN information_schema.columns t
   ON t.table_schema = 'test' AND t.table_name = 'booking' AND t.column_name = m.column_name
 WHERE m.table_schema = 'main' AND m.table_name = 'booking' AND t.column_name IS NULL;
 
--- Expect: is_nullable = 'YES' for all four on test.
 SELECT column_name, data_type, is_nullable, column_default
 FROM information_schema.columns
 WHERE table_schema = 'test' AND table_name = 'booking'
   AND column_name IN ('refunded_amount', 'stripe_refund_id', 'refund_error', 'total_price')
 ORDER BY column_name;
 
--- =========================
--- Rollback SQL (DOWN) - schema test
--- One statement per transaction. DROP COLUMN does not reclaim space and the
--- dropped attribute still counts toward the table's 1600-column lifetime limit.
--- =========================
-ALTER TABLE test.booking DROP COLUMN IF EXISTS total_price;
-
-ALTER TABLE test.booking DROP COLUMN IF EXISTS refund_error;
-
-ALTER TABLE test.booking DROP COLUMN IF EXISTS stripe_refund_id;
-
-ALTER TABLE test.booking DROP COLUMN IF EXISTS refunded_amount;
-
--- =========================
--- Smoke Test SQL - schema test
--- Run in a transaction and ROLLBACK to avoid permanent test rows.
--- DML only; keep it separate from the DDL above.
--- =========================
 BEGIN;
 
 INSERT INTO test.booking
@@ -120,3 +47,11 @@ FROM test.booking
 WHERE id = 'smoke-reconcile-1';
 
 ROLLBACK;
+
+ALTER TABLE test.booking DROP COLUMN IF EXISTS total_price;
+
+ALTER TABLE test.booking DROP COLUMN IF EXISTS refund_error;
+
+ALTER TABLE test.booking DROP COLUMN IF EXISTS stripe_refund_id;
+
+ALTER TABLE test.booking DROP COLUMN IF EXISTS refunded_amount;

--- a/backend/ORM/models/Booking.js
+++ b/backend/ORM/models/Booking.js
@@ -102,5 +102,30 @@ export const Booking = new EntitySchema({
       name: "refund_error",
       nullable: true,
     },
+    booking_source: {
+      type: "varchar",
+      name: "booking_source",
+      nullable: true,
+    },
+    site_id: {
+      type: "varchar",
+      name: "site_id",
+      nullable: true,
+    },
+    guest_email: {
+      type: "varchar",
+      name: "guest_email",
+      nullable: true,
+    },
+    public_booking_ref: {
+      type: "varchar",
+      name: "public_booking_ref",
+      nullable: true,
+    },
+    idempotency_key: {
+      type: "varchar",
+      name: "idempotency_key",
+      nullable: true,
+    },
   },
 });

--- a/backend/ORM/schema.psql
+++ b/backend/ORM/schema.psql
@@ -105,12 +105,21 @@ CREATE TABLE IF NOT EXISTS main.booking (
   hostName VARCHAR(255) NOT NULL,
   guestName VARCHAR(255) NOT NULL,
   cancellation_policy VARCHAR(50),
-  refunded_amount BIGINT DEFAULT 0,
+  bookingtype VARCHAR,
+  refunded_amount BIGINT,
   stripe_refund_id VARCHAR(255),
   refund_error TEXT,
+  total_price DOUBLE PRECISION,
+  booking_source VARCHAR(255),
+  site_id VARCHAR(255),
+  guest_email VARCHAR(255),
+  public_booking_ref VARCHAR(255),
+  idempotency_key VARCHAR(255),
   PRIMARY KEY (id)
 );
 CREATE UNIQUE INDEX ASYNC id_UNIQUE_booking ON main.booking (id);
+CREATE UNIQUE INDEX ASYNC booking_public_booking_ref_unique ON main.booking (public_booking_ref);
+CREATE UNIQUE INDEX ASYNC booking_idempotency_key_unique ON main.booking (idempotency_key);
 
 -- -----------------------------------------------------
 -- Table main.faq
@@ -493,6 +502,15 @@ CREATE TABLE IF NOT EXISTS test.booking (
 CREATE UNIQUE INDEX ASYNC id_UNIQUE_booking_test ON test.booking (id);
 
 ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS cancellation_policy VARCHAR(50);
-ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS refunded_amount BIGINT DEFAULT 0;
+ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS bookingtype VARCHAR;
+ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS refunded_amount BIGINT;
 ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS stripe_refund_id VARCHAR(255);
 ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS refund_error TEXT;
+ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS total_price DOUBLE PRECISION;
+ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS booking_source VARCHAR(255);
+ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS site_id VARCHAR(255);
+ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS guest_email VARCHAR(255);
+ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS public_booking_ref VARCHAR(255);
+ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS idempotency_key VARCHAR(255);
+CREATE UNIQUE INDEX ASYNC booking_public_booking_ref_unique_test ON test.booking (public_booking_ref);
+CREATE UNIQUE INDEX ASYNC booking_idempotency_key_unique_test ON test.booking (idempotency_key);

--- a/backend/test/ORM/bookingEntity.test.js
+++ b/backend/test/ORM/bookingEntity.test.js
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "@jest/globals";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { DataSource } from "typeorm";
+import { Booking } from "database/models/Booking";
+
+const CATALOG_COLUMNS = [
+  "id",
+  "arrivaldate",
+  "departuredate",
+  "createdat",
+  "guestid",
+  "guests",
+  "hostid",
+  "latepayment",
+  "paymentid",
+  "property_id",
+  "status",
+  "guestname",
+  "hostname",
+  "cancellation_policy",
+  "bookingtype",
+  "refunded_amount",
+  "stripe_refund_id",
+  "refund_error",
+  "total_price",
+  "booking_source",
+  "site_id",
+  "guest_email",
+  "public_booking_ref",
+  "idempotency_key",
+];
+
+const CATALOG_NOT_NULL_COLUMNS = [
+  "id",
+  "arrivaldate",
+  "departuredate",
+  "createdat",
+  "guestid",
+  "guests",
+  "hostid",
+  "latepayment",
+  "paymentid",
+  "property_id",
+  "status",
+  "guestname",
+  "hostname",
+];
+
+const DIRECT_BOOKING_WEBSITE_COLUMNS = ["booking_source", "site_id", "guest_email", "public_booking_ref", "idempotency_key"];
+
+const sorted = (values) => [...values].sort((left, right) => left.localeCompare(right));
+
+const loadBookingMetadata = async () => {
+  const dataSource = new DataSource({
+    type: "postgres",
+    host: "localhost",
+    username: "test",
+    password: "test",
+    database: "test",
+    entities: [Booking],
+  });
+  await dataSource.buildMetadatas();
+  return dataSource.getMetadata(Booking);
+};
+
+const loadSchemaSql = () => readFileSync(path.join(process.cwd(), "ORM", "schema.psql"), "utf8");
+
+const extractCreateTableColumns = (sql, qualifiedTable) => {
+  const escapedTable = qualifiedTable.replaceAll(".", "\\.");
+  const match = new RegExp(`CREATE TABLE IF NOT EXISTS ${escapedTable} \\(([\\s\\S]*?)\\n\\);`).exec(sql);
+  if (!match) {
+    throw new Error(`No CREATE TABLE block found for ${qualifiedTable} in schema.psql`);
+  }
+  return match[1]
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("PRIMARY KEY"))
+    .map((line) => line.split(/\s+/)[0].toLowerCase());
+};
+
+const extractAddColumnNames = (sql, qualifiedTable) => {
+  const escapedTable = qualifiedTable.replaceAll(".", "\\.");
+  return [...sql.matchAll(new RegExp(`ALTER TABLE ${escapedTable} ADD COLUMN IF NOT EXISTS (\\w+)`, "g"))].map(
+    (match) => match[1].toLowerCase()
+  );
+};
+
+describe("Booking entity", () => {
+  it("maps exactly the columns present on the booking table", async () => {
+    const metadata = await loadBookingMetadata();
+    expect(metadata.tableName).toBe("booking");
+    expect(sorted(metadata.columns.map((column) => column.databaseName))).toEqual(sorted(CATALOG_COLUMNS));
+  });
+
+  it("uses id as the only primary column", async () => {
+    const metadata = await loadBookingMetadata();
+    expect(metadata.primaryColumns.map((column) => column.databaseName)).toEqual(["id"]);
+  });
+
+  it("declares NOT NULL only where the table does", async () => {
+    const metadata = await loadBookingMetadata();
+    const notNullColumns = metadata.columns.filter((column) => !column.isNullable).map((column) => column.databaseName);
+    expect(sorted(notNullColumns)).toEqual(sorted(CATALOG_NOT_NULL_COLUMNS));
+  });
+
+  it("maps the direct booking website columns as nullable varchar with no default", async () => {
+    const metadata = await loadBookingMetadata();
+    DIRECT_BOOKING_WEBSITE_COLUMNS.forEach((columnName) => {
+      const column = metadata.findColumnWithDatabaseName(columnName);
+      expect(column).toBeDefined();
+      expect(column.type).toBe("varchar");
+      expect(column.isNullable).toBe(true);
+      expect(column.default).toBeUndefined();
+    });
+  });
+
+  it.todo("declares no column defaults that the booking table does not have (total_price, refunded_amount, bookingtype)");
+});
+
+describe("schema.psql booking blocks", () => {
+  it("declares the same columns as the entity for main.booking", async () => {
+    const metadata = await loadBookingMetadata();
+    const entityColumns = metadata.columns.map((column) => column.databaseName);
+    expect(sorted(extractCreateTableColumns(loadSchemaSql(), "main.booking"))).toEqual(sorted(entityColumns));
+  });
+
+  it("declares the same columns as the entity for test.booking, including appended ALTERs", async () => {
+    const metadata = await loadBookingMetadata();
+    const entityColumns = metadata.columns.map((column) => column.databaseName);
+    const sql = loadSchemaSql();
+    const testColumns = [...extractCreateTableColumns(sql, "test.booking"), ...extractAddColumnNames(sql, "test.booking")];
+    expect(sorted(testColumns)).toEqual(sorted(entityColumns));
+  });
+
+  it("declares the unique indexes on public_booking_ref and idempotency_key for both schemas", () => {
+    const sql = loadSchemaSql();
+    expect(sql).toMatch(/CREATE UNIQUE INDEX ASYNC booking_public_booking_ref_unique ON main\.booking \(public_booking_ref\);/);
+    expect(sql).toMatch(/CREATE UNIQUE INDEX ASYNC booking_idempotency_key_unique ON main\.booking \(idempotency_key\);/);
+    expect(sql).toMatch(
+      /CREATE UNIQUE INDEX ASYNC booking_public_booking_ref_unique_test ON test\.booking \(public_booking_ref\);/
+    );
+    expect(sql).toMatch(/CREATE UNIQUE INDEX ASYNC booking_idempotency_key_unique_test ON test\.booking \(idempotency_key\);/);
+  });
+});

--- a/docs/internal/tools/dsql_booking_columns_runbook.md
+++ b/docs/internal/tools/dsql_booking_columns_runbook.md
@@ -1,0 +1,70 @@
+# Booking table changes for direct booking websites (2026-09-04)
+
+Runbook for the two hand-applied migrations under `backend/ORM/migrations/`:
+
+- `20260904_booking_test_schema_reconcile.{js,sql}`
+- `20260904_booking_direct_booking_website_columns.{js,sql}`
+
+The `.js` files are the migration records (nothing in this repo executes them). The `.sql` files are the statements to run, kept free of comments by convention, so the run order, the Aurora DSQL rules and the findings live here instead.
+
+Connect using the documented path in [dsql_transitioning_docs.md](./dsql_transitioning_docs.md) (console → Aurora DSQL → cluster → Connect → Open in CloudShell). Confirm the cluster from the runtime's own configuration first: SSM parameters `/aurora/dsql/host` and `/aurora/dsql/region` in eu-north-1 (`backend/ORM/index.js:82-85`).
+
+## Aurora DSQL rules that shape these runbooks
+
+- One DDL statement per transaction, never DDL and DML in the same transaction. Run each statement on its own in psql autocommit mode; never wrap a block in `BEGIN`.
+- `ALTER TABLE ... ADD COLUMN` is a catalog change: no table rewrite, no lock. The `ADD COLUMN` grammar carries no constraints, and `SET NOT NULL` does not exist for existing tables, so every added column is nullable and stays nullable. `SET DEFAULT` applies to future writes only; existing rows keep NULL.
+- There is no `ALTER COLUMN ... TYPE`. A varchar width is permanent unless the column is dropped and recreated, which is why all new columns are `VARCHAR(255)`.
+- Uniqueness is `CREATE UNIQUE INDEX ASYNC`. It returns a `job_id` immediately and does not block the table. If a build fails, the index stays INVALID and still enforces uniqueness on writes until it is dropped. `NULLS DISTINCT` (the default) is required: every existing marketplace row has NULL in both indexed columns.
+- Every DDL commit and every index activation bumps the cluster-wide catalog version. Sessions holding a stale catalog, including warm Lambdas, fail their next statement once with SQLSTATE `40001` / `OC001` and succeed on retry. Run everything in one quiet window, back to back. This applies to DDL on the `test` schema too.
+- Limits checked: 24 active columns after this change (limit 255), 4 indexes on `booking` (limit 24), single `VARCHAR(255)` index keys (limit 1 KiB), no backfill (the 3,000-row transaction limit does not apply).
+- `DROP COLUMN` does not reclaim space, and the dropped attribute still counts toward the table's 1,600-column lifetime limit.
+
+## Part A: `20260904_booking_test_schema_reconcile.sql`
+
+Status: applied to `test.booking` and verified on 2026-09-04.
+
+Findings from the catalog read that motivated it:
+
+- `main.booking` had 19 columns, `test.booking` had 15.
+- `20260520_booking_refund_fields.js` records `refunded_amount`, `stripe_refund_id` and `refund_error` as added to both schemas; `test.booking` never received them.
+- `total_price` had been on `main.booking` and in the entity since commit `96a91eb2f` (2026-05-28) with no migration record for either schema, and was missing from `test.booking`.
+- No `column_default` existed on any of the four columns on `main.booking`, including `refunded_amount`, so the `DEFAULT 0` in the May migration was never applied there either. The reconcile therefore adds no defaults, and `schema.psql` no longer claims one.
+- Until applied, every TypeORM read of the Booking entity with `TEST=true` failed with `column ... does not exist`, because the entity selects every mapped column.
+
+Blocks in the file, in order:
+
+1. Pre-flight `SELECT` on `information_schema.columns`: expect the four columns present on `main`, absent on `test`.
+2. Four `ALTER TABLE test.booking ADD COLUMN IF NOT EXISTS` statements.
+3. Verification: both schemas report 19 columns; the `LEFT JOIN` query returns no rows; the four columns show `is_nullable = YES` on `test`.
+4. Smoke test: a single `BEGIN ... INSERT ... SELECT ... ROLLBACK` block; the row must round-trip and leave nothing behind.
+5. Rollback: four `DROP COLUMN IF EXISTS` statements. Last in the file; do not paste the file top to bottom.
+
+## Part B: `20260904_booking_direct_booking_website_columns.sql`
+
+Status: applied to both schemas and verified on 2026-09-04. Both tables have 24 columns and four valid unique indexes; existing bookings load correctly.
+
+Column semantics: NULL in every new column means "marketplace booking, unchanged". `booking_source` carries `STANDALONE_SITE` for direct booking website requests (PR 5). `public_booking_ref` and `idempotency_key` are unique per schema.
+
+Blocks in the file, in order:
+
+1. Pre-flight: the five columns absent in both schemas; both schemas at 19 columns (Part A applied); no in-flight `sys.jobs` rows for `booking`.
+2. `test` schema: five `ADD COLUMN IF NOT EXISTS`, then `CREATE UNIQUE INDEX ASYNC` on `public_booking_ref` and `idempotency_key` (names suffixed `_test`).
+3. Wait for the `test` index jobs: re-run the `sys.jobs` query filtered on `test.booking_%_unique_test` until both rows read `completed`. `sys.jobs` forgets finished jobs after about 30 minutes.
+4. `main` schema: the same five columns and two indexes.
+5. Wait for the `main` index jobs the same way, filtered on `main.booking_%_unique`.
+6. Verification: five rows per schema, all `is_nullable = YES`, no `column_default`; all four indexes `indisunique = t` and `indisvalid = t`; index definitions without `NULLS NOT DISTINCT`.
+7. Smoke test 1: a `BEGIN ... ROLLBACK` block inserting one direct booking website row and one marketplace row with NULLs; both must round-trip.
+8. Smoke test 2: a `BEGIN ... ROLLBACK` block whose second `INSERT` reuses an `idempotency_key`. The second `INSERT` must fail with a duplicate key error on the unique index; that failure is the passing result. `ROLLBACK` ends the aborted transaction.
+9. Rollback: `DROP INDEX` then `DROP COLUMN IF EXISTS`, `main` first, then `test`. Last in the file; do not paste the file top to bottom.
+
+## Order of operations for the whole change
+
+1. Part A pre-flight, UP, verification, smoke test.
+2. Part B pre-flight, `test` UP, wait, `main` UP, wait, verification, smoke tests.
+3. Only then merge the pull request that changes `backend/ORM/models/Booking.js`. Any change under `backend/ORM/` redeploys every Lambda, and every Booking read selects the new columns from that moment on. `backend/test/ORM/bookingEntity.test.js` fails if the entity or `schema.psql` drift from the verified table.
+
+## Deferred on purpose
+
+- The three defaults `Booking.js` declares that the database does not have (`total_price`, `refunded_amount`, `bookingtype`). Tracked as a separate issue; the entity test carries a todo for it.
+- `guestid` NOT NULL. DSQL cannot re-add NOT NULL, so relaxing it is a one-way decision left to PR 5.
+- `confirmation_token_hash`, deferred with the public confirmation endpoint.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,6 +14,9 @@ sonar.sourceEncoding=UTF-8
 # Exclude compiled output, dependencies, and generated files
 sonar.exclusions=**/index.css,**/index.css.map,**/node_modules/**,**/build/**,**/dist/**
 
+# ORM migration runbooks apply each change to both the main and test schemas, so they repeat statements by necessity; skip copy-paste detection only, all other rules still apply
+sonar.cpd.exclusions=backend/ORM/migrations/*.sql
+
 # Suppress S6747 (JSX unknown property) across the frontend — Sonar's JSX parser
 # misreads expression content and attribute values as property names (false positives)
 sonar.issue.ignore.multicriteria=e1,e2

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,9 +14,6 @@ sonar.sourceEncoding=UTF-8
 # Exclude compiled output, dependencies, and generated files
 sonar.exclusions=**/index.css,**/index.css.map,**/node_modules/**,**/build/**,**/dist/**
 
-# ORM migration runbooks apply each change to both the main and test schemas, so they repeat statements by necessity; skip copy-paste detection only, all other rules still apply
-sonar.cpd.exclusions=backend/ORM/migrations/*.sql
-
 # Suppress S6747 (JSX unknown property) across the frontend — Sonar's JSX parser
 # misreads expression content and attribute values as property names (false positives)
 sonar.issue.ignore.multicriteria=e1,e2


### PR DESCRIPTION
## Close or Relate the Issue
[//]: # (Only if this should close the issue)
- Closes #

[//]: # (in the issue a reference will be added to this pr)
- Related Issue: #3038

## Proposed Changes
[//]: # (Add a detailed description of the changes here)
Description:

Adds five columns to the booking table so a booking from a direct booking website can be stored, and fixes the model and schema.psql where they didn't match the actual database anymore.

**What I did to the database (already applied and checked before opening this PR)**

First I read the live catalog instead of trusting the files, and found a few things:

- test.booking was missing four columns that main.booking has: refunded_amount, stripe_refund_id, refund_error and total_price. The refund migration from May says it did both schemas, but test never got them. So anything running with TEST=true against that schema has been failing for months
- total_price isn't in any migration file at all, for either schema
- that same migration says refunded_amount gets DEFAULT 0, but the live column has no default. So that never happened either

I fixed test first with a separate migration record, then added the five new columns to both schemas plus two unique indexes on public_booking_ref and idempotency_key. Both tables are now at 24 columns, all four indexes report indisvalid = t, and existing bookings still load fine in the app.

There's no migration runner in this repo, so I applied the SQL by hand through the DSQL runbook in the docs. Each migration has a .js record and a .sql file with the statements. The run order, the DSQL rules and what each verification query should return are in docs/internal/tools/dsql_booking_columns_runbook.md, since comments aren't allowed in code here.

**Code changes**

- Booking.js: the five columns, all nullable, no defaults. Merging this redeploys every Lambda, which is fine now because the columns already exist
- schema.psql: brought in line with the catalog for both schemas. Added the five new columns and the two indexes, plus total_price and bookingtype which were live but never written down. bookingtype is recorded as unbounded VARCHAR because that's what the catalog shows, and I removed DEFAULT 0 from refunded_amount since it isn't actually there
- bookingEntity.test.js: a test that fails if the entity's columns drift from the real table, or if schema.psql drifts from the entity. Figured that was worth adding given what I ran into

**About the columns.** NULL means it's a normal marketplace booking. booking_source will hold STANDALONE_SITE once the booking endpoint exists. I made everything VARCHAR(255) on purpose: DSQL has no ALTER COLUMN TYPE, so if a column turns out too narrow later you'd have to drop and recreate it on a production table.

**Something I found but didn't fix here.** Booking.js declares three defaults that the database doesn't have: total_price and refunded_amount both say 0, bookingtype says "direct". They don't break anything at runtime, but the model and the database disagree. I left it out so this PR stays about one thing, and put an it.todo in the new test as a reminder.

**Not in here:** making guestid nullable. DSQL can't add NOT NULL back once you drop it, so that's a decision I'd rather make together with whoever builds the endpoint that needs it.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Optimization
- [x] Documentation update

## Change Size
[//]: # (Indicate the size of this change.)
[//]: # (Clarify under Refactoring which parts are moved/unchanged code, so the reviewer doesn’t review old logic.)
- [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
- [x] Big change (+-max 1000)
- [ ] Small change (less than 300)

## Refactoring
Refactors following files, but didn't change the code. This is to avoid reviewing old logic.
- N/A

## Evidence
No UI changes. The evidence is the verification queries in the .sql files: column counts before and after, a LEFT JOIN that proves both schemas match, pg_index.indisvalid on all four indexes, sys.jobs completed, and smoke inserts that rolled back cleanly. The doc lists what each one should return.

- [ ] Screenshots or screen recording added for UI changes
- [ ] Before/after images added when relevant
- [ ] Images clearly show the implemented change
- [ ] Image quality is readable (no cropped or blurry evidence)

## Responsiveness
- [ ] UI checked on mobile
- [ ] UI checked on tablet
- [ ] UI checked on desktop
- [ ] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages
- [ ] NPM Packages installed
- [ ] NPM Packages removed
- [ ] NPM Packages updated
- [ ] Checked for vulnerabilities using "npm audit"

## Checklist
[//]: # (All boxes must be checked before merging.)
- [x] Pull request has at least 2 reviewers assigned
- [x] PR title is descriptive and includes issue number
- [x] Conventions
  - [x] No config files have been added (Amplify config, cache files)
  - [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  - [x] No global styling (see [#1691](https://github.com/domits1/Domits/issues/1691))
  - [x] No `console.log` left in code
  - [x] No commented-out code remains
- [x] Testing
  - [x] Code tested locally
  - [x] Jest tests are included
  - [x] Jest tests are passing

## Keep or delete my branch
- [x] Delete my branch after merge
- [ ] Keep my branch  
