### PR TITLE
test(cm): add conflict detection and ical sync scenario tests #2266

### DIFF
--- a/backend/test/General-Bookings-CRUD-Bookings-develop/externalCalendarService.conflict.test.js
+++ b/backend/test/General-Bookings-CRUD-Bookings-develop/externalCalendarService.conflict.test.js
@@ -1,0 +1,125 @@
+const mockListSources = jest.fn();
+const mockUpsertSource = jest.fn();
+jest.mock("../../functions/General-Bookings-CRUD-Bookings-develop/data/externalCalendarRepository.js", () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    listSources: mockListSources,
+    upsertSource: mockUpsertSource,
+  })),
+}));
+
+const mockFetchExternalCalendar = jest.fn();
+jest.mock("../../functions/.shared/icalTransport.js", () => ({
+  __esModule: true,
+  buildSourceUpsertPayload: jest.fn((args) => args),
+  fetchExternalCalendar: (...args) => mockFetchExternalCalendar(...args),
+}));
+
+const ExternalCalendarService =
+  require("../../functions/General-Bookings-CRUD-Bookings-develop/business/externalCalendarService.js").default;
+const ConflictException =
+  require("../../functions/General-Bookings-CRUD-Bookings-develop/util/exception/ConflictException.js").default;
+const ServiceUnavailableException =
+  require("../../functions/General-Bookings-CRUD-Bookings-develop/util/exception/ServiceUnavailableException.js").default;
+
+const BASE_RANGE = {
+  arrivalMs: Date.parse("2026-06-15T00:00:00.000Z"),
+  departureMs: Date.parse("2026-06-17T00:00:00.000Z"),
+};
+
+const buildEvent = (dtstart, dtend) => ({ Dtstart: dtstart, Dtend: dtend });
+
+describe("ExternalCalendarService cross-channel double-booking guard", () => {
+  let consoleErrorSpy;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe("blocks dates across channels", () => {
+    it.each([
+      {
+        description: "no external calendar sources are registered",
+        sources: [],
+        responsesByUrl: {},
+        shouldReject: false,
+        expectedFetchCalls: 0,
+      },
+      {
+        description: "the only source's blocked dates don't overlap the requested range",
+        sources: [{ sourceId: "airbnb", calendarUrl: "https://airbnb.example/a.ics" }],
+        responsesByUrl: {
+          "https://airbnb.example/a.ics": { events: [buildEvent("20260701", "20260703")], meta: {} },
+        },
+        shouldReject: false,
+        expectedFetchCalls: 1,
+      },
+      {
+        description: "a single source blocks a requested date",
+        sources: [{ sourceId: "airbnb", calendarUrl: "https://airbnb.example/a.ics" }],
+        responsesByUrl: {
+          "https://airbnb.example/a.ics": { events: [buildEvent("20260615", "20260616")], meta: {} },
+        },
+        shouldReject: true,
+        expectedFetchCalls: 1,
+      },
+      {
+        description: "only the second of two sources blocks the requested range",
+        sources: [
+          { sourceId: "airbnb", calendarUrl: "https://airbnb.example/a.ics" },
+          { sourceId: "booking", calendarUrl: "https://booking.example/b.ics" },
+        ],
+        responsesByUrl: {
+          "https://airbnb.example/a.ics": { events: [buildEvent("20260701", "20260703")], meta: {} },
+          "https://booking.example/b.ics": { events: [buildEvent("20260615", "20260616")], meta: {} },
+        },
+        shouldReject: true,
+        expectedFetchCalls: 2,
+      },
+      {
+        description: "sources missing a sourceId or calendarUrl are skipped without fetching",
+        sources: [
+          { sourceId: "", calendarUrl: "https://airbnb.example/a.ics" },
+          { sourceId: "booking", calendarUrl: "" },
+        ],
+        responsesByUrl: {},
+        shouldReject: false,
+        expectedFetchCalls: 0,
+      },
+    ])("$description", async ({ sources, responsesByUrl, shouldReject, expectedFetchCalls }) => {
+      mockListSources.mockResolvedValue(sources);
+      mockFetchExternalCalendar.mockImplementation(({ calendarUrl }) => Promise.resolve(responsesByUrl[calendarUrl]));
+      const service = new ExternalCalendarService();
+
+      const assertion = service.ensureNoExternalConflict({ propertyId: "property-1", ...BASE_RANGE });
+
+      if (shouldReject) {
+        await expect(assertion).rejects.toThrow(ConflictException);
+      } else {
+        await expect(assertion).resolves.toBe(undefined);
+      }
+      expect(mockFetchExternalCalendar).toHaveBeenCalledTimes(expectedFetchCalls);
+      expect(mockUpsertSource).toHaveBeenCalledTimes(expectedFetchCalls);
+    });
+  });
+
+  describe("resilience when a source can't be refreshed", () => {
+    test("throws ServiceUnavailableException and skips the upsert when the calendar fetch fails", async () => {
+      const sources = [{ sourceId: "airbnb", calendarUrl: "https://airbnb.example/a.ics" }];
+      mockListSources.mockResolvedValue(sources);
+      mockFetchExternalCalendar.mockRejectedValue(new Error("network down"));
+      const service = new ExternalCalendarService();
+
+      await expect(service.ensureNoExternalConflict({ propertyId: "property-1", ...BASE_RANGE })).rejects.toThrow(
+        ServiceUnavailableException
+      );
+
+      expect(mockUpsertSource).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/test/General-Bookings-CRUD-Bookings-develop/reservationRepository.conflict.test.js
+++ b/backend/test/General-Bookings-CRUD-Bookings-develop/reservationRepository.conflict.test.js
@@ -45,7 +45,7 @@ describe("ReservationRepository same-channel double-booking guard", () => {
         shouldReject: true,
       },
       {
-        description: "an overlapping booking in a non-blocking status (Cancelled, Declined, Inquiry or Failed)",
+        description: "resolves when the query reports no conflicting bookings",
         conflictCount: 0,
         excludeBookingId: null,
         shouldReject: false,

--- a/backend/test/General-Bookings-CRUD-Bookings-develop/reservationRepository.conflict.test.js
+++ b/backend/test/General-Bookings-CRUD-Bookings-develop/reservationRepository.conflict.test.js
@@ -1,0 +1,119 @@
+jest.mock("database", () => ({
+  __esModule: true,
+  default: { getInstance: jest.fn() },
+}));
+
+const Database = require("database").default;
+const ReservationRepository =
+  require("../../functions/General-Bookings-CRUD-Bookings-develop/data/reservationRepository.js").default;
+const ConflictException =
+  require("../../functions/General-Bookings-CRUD-Bookings-develop/util/exception/ConflictException.js").default;
+
+const MIN_CHECK_IN_OUT_GAP_MS = 60 * 60 * 1000;
+
+const createQueryChain = (conflictCount) => {
+  const chain = {};
+  ["where", "andWhere"].forEach((method) => {
+    chain[method] = jest.fn(() => chain);
+  });
+  chain.getCount = jest.fn(async () => conflictCount);
+  return chain;
+};
+
+const mockRepositoryWithChain = (chain) => {
+  const repository = { createQueryBuilder: jest.fn(() => chain) };
+  Database.getInstance.mockResolvedValue({ getRepository: jest.fn(() => repository) });
+};
+
+const BASE_REQUEST = {
+  propertyId: "property-1",
+  arrivalDateMs: Date.parse("2026-06-15T14:00:00.000Z"),
+  departureDateMs: Date.parse("2026-06-17T11:00:00.000Z"),
+};
+
+describe("ReservationRepository same-channel double-booking guard", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("scenario coverage by booking status and self-conflict exclusion", () => {
+    it.each([
+      {
+        description: "an overlapping booking in a blocking status, including an exact duplicate reservation attempt",
+        conflictCount: 1,
+        excludeBookingId: null,
+        shouldReject: true,
+      },
+      {
+        description: "an overlapping booking in a non-blocking status (Cancelled, Declined, Inquiry or Failed)",
+        conflictCount: 0,
+        excludeBookingId: null,
+        shouldReject: false,
+      },
+      {
+        description: "editing the same booking that already occupies the dates",
+        conflictCount: 0,
+        excludeBookingId: "booking-1",
+        shouldReject: false,
+      },
+    ])("$description", async ({ conflictCount, excludeBookingId, shouldReject }) => {
+      const chain = createQueryChain(conflictCount);
+      mockRepositoryWithChain(chain);
+      const repository = new ReservationRepository();
+
+      const assertion = repository.assertNoBookingConflict({ ...BASE_REQUEST, excludeBookingId });
+
+      if (shouldReject) {
+        await expect(assertion).rejects.toThrow(ConflictException);
+      } else {
+        await expect(assertion).resolves.toBe(undefined);
+      }
+
+      const andWhereQueries = chain.andWhere.mock.calls.map((call) => call[0]);
+      if (excludeBookingId) {
+        expect(chain.andWhere).toHaveBeenCalledWith("booking.id != :excludeBookingId", { excludeBookingId });
+      } else {
+        expect(andWhereQueries).not.toContain("booking.id != :excludeBookingId");
+      }
+    });
+  });
+
+  test("scopes the conflict query to the requested property", async () => {
+    const chain = createQueryChain(0);
+    mockRepositoryWithChain(chain);
+    const repository = new ReservationRepository();
+
+    await repository.assertNoBookingConflict(BASE_REQUEST);
+
+    expect(chain.where).toHaveBeenCalledWith("booking.property_id = :property_id", {
+      property_id: BASE_REQUEST.propertyId,
+    });
+  });
+
+  test("excludes bookings in non-blocking statuses from the conflict query", async () => {
+    const chain = createQueryChain(0);
+    mockRepositoryWithChain(chain);
+    const repository = new ReservationRepository();
+
+    await repository.assertNoBookingConflict(BASE_REQUEST);
+
+    expect(chain.andWhere).toHaveBeenCalledWith("booking.status NOT IN (:...excludedStatuses)", {
+      excludedStatuses: ["Failed", "Declined", "Inquiry", "Cancelled", "Canceled"],
+    });
+  });
+
+  test("applies the check-in/out buffer gap to the requested arrival and departure dates", async () => {
+    const chain = createQueryChain(0);
+    mockRepositoryWithChain(chain);
+    const repository = new ReservationRepository();
+
+    await repository.assertNoBookingConflict(BASE_REQUEST);
+
+    expect(chain.andWhere).toHaveBeenCalledWith("booking.arrivaldate < :bufferedDepartureDate", {
+      bufferedDepartureDate: BASE_REQUEST.departureDateMs + MIN_CHECK_IN_OUT_GAP_MS,
+    });
+    expect(chain.andWhere).toHaveBeenCalledWith("booking.departuredate > :bufferedArrivalDate", {
+      bufferedArrivalDate: BASE_REQUEST.arrivalDateMs - MIN_CHECK_IN_OUT_GAP_MS,
+    });
+  });
+});

--- a/backend/test/Ical-sync-scheduler/service.conflict.test.js
+++ b/backend/test/Ical-sync-scheduler/service.conflict.test.js
@@ -1,0 +1,120 @@
+const mockListSources = jest.fn();
+const mockUpsertSource = jest.fn();
+jest.mock("../../functions/Ical-sync-scheduler/data/repository.js", () => ({
+  __esModule: true,
+  Repository: jest.fn().mockImplementation(() => ({
+    listSources: mockListSources,
+    upsertSource: mockUpsertSource,
+  })),
+}));
+
+const mockFetchExternalCalendar = jest.fn();
+jest.mock("../../functions/.shared/icalTransport.js", () => ({
+  __esModule: true,
+  buildSourceUpsertPayload: jest.fn((args) => args),
+  fetchExternalCalendar: (...args) => mockFetchExternalCalendar(...args),
+}));
+
+const { Service } = require("../../functions/Ical-sync-scheduler/business/service/service.js");
+
+const MINUTES = 60 * 1000;
+const buildSource = (overrides = {}) => ({
+  propertyId: "property-1",
+  sourceId: "airbnb",
+  calendarUrl: "https://airbnb.example/a.ics",
+  lastSyncAt: null,
+  ...overrides,
+});
+
+describe("Ical-sync-scheduler Service automatic sync reliability", () => {
+  let consoleErrorSpy;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockFetchExternalCalendar.mockResolvedValue({ events: [], meta: {} });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe("scenario coverage for sync due rules", () => {
+    it.each([
+      {
+        description: "a source with no lastSyncAt is due",
+        lastSyncAt: null,
+        expectedDue: true,
+      },
+      {
+        description: "a source with an unparseable lastSyncAt is due (fails open)",
+        lastSyncAt: "not-a-date",
+        expectedDue: true,
+      },
+      {
+        description: "a source last synced before the interval cutoff is due",
+        lastSyncAt: new Date(Date.now() - 20 * MINUTES).toISOString(),
+        expectedDue: true,
+      },
+      {
+        description: "a source last synced after the interval cutoff is not due",
+        lastSyncAt: new Date(Date.now() - 1 * MINUTES).toISOString(),
+        expectedDue: false,
+      },
+    ])("$description", async ({ lastSyncAt, expectedDue }) => {
+      mockListSources.mockResolvedValue([buildSource({ lastSyncAt })]);
+      const service = new Service();
+
+      const result = await service.runScheduledSync({ syncIntervalMinutes: 10 });
+
+      expect(result.due).toBe(expectedDue ? 1 : 0);
+      expect(mockFetchExternalCalendar).toHaveBeenCalledTimes(expectedDue ? 1 : 0);
+      expect(mockUpsertSource).toHaveBeenCalledTimes(expectedDue ? 1 : 0);
+    });
+  });
+
+  test("force sync bypasses the due-filter for sources not yet due", async () => {
+    const notDueSource = buildSource({ lastSyncAt: new Date(Date.now() - 1 * MINUTES).toISOString() });
+    mockListSources.mockResolvedValue([notDueSource]);
+    const service = new Service();
+
+    const result = await service.runScheduledSync({ syncIntervalMinutes: 10, force: true });
+
+    expect(result.due).toBe(1);
+    expect(mockFetchExternalCalendar).toHaveBeenCalledTimes(1);
+    expect(mockUpsertSource).toHaveBeenCalledTimes(1);
+  });
+
+  test("one source's fetch failure does not block the rest of the batch", async () => {
+    const healthySource = buildSource({ sourceId: "airbnb" });
+    const brokenSource = buildSource({ sourceId: "booking", calendarUrl: "https://booking.example/b.ics" });
+    mockListSources.mockResolvedValue([healthySource, brokenSource]);
+    mockFetchExternalCalendar.mockImplementation(({ calendarUrl }) =>
+      calendarUrl === "https://booking.example/b.ics"
+        ? Promise.reject(new Error("network down"))
+        : Promise.resolve({ events: [], meta: {} })
+    );
+    const service = new Service();
+
+    const result = await service.runScheduledSync({ force: true });
+
+    expect(result.ok).toBe(true);
+    expect(result.succeeded).toBe(1);
+    expect(result.failed).toBe(1);
+    expect(mockFetchExternalCalendar).toHaveBeenCalledTimes(2);
+    expect(mockUpsertSource).toHaveBeenCalledTimes(1);
+  });
+
+  test("a source missing propertyId, sourceId or calendarUrl is skipped without fetching", async () => {
+    const malformedSource = buildSource({ calendarUrl: "" });
+    mockListSources.mockResolvedValue([malformedSource]);
+    const service = new Service();
+
+    const result = await service.runScheduledSync({ force: true });
+
+    expect(mockFetchExternalCalendar).not.toHaveBeenCalled();
+    expect(mockUpsertSource).not.toHaveBeenCalled();
+    expect(result.succeeded).toBe(1);
+    expect(result.failed).toBe(0);
+  });
+});


### PR DESCRIPTION
## Close or Relate the Issue
[//]: # (Only if this should close the issue)
- Closes #

[//]: # (in the issue a reference will be added to this pr)
- Related Issue: #2266 

## Proposed Changes
[//]: # (Add a detailed description of the changes here)
Description:
Adds scenario test coverage for double-booking and calendar-conflict prevention, anchored to Issue 
[#2266](https://github.com/domits1/Domits/issues/2266)
 acceptance criteria section 2 ("Bookings on any channel instantly block dates on all others"; "Detect and resolve calendar conflicts automatically") and section 4 ("Differentiate between confirmed, pending, and canceled bookings"; "Modify or cancel bookings without self-conflict"; "Detect duplicate reservations and flag them"). No production code changed — tests only, covering three previously-untested/under-tested paths:

reservationRepository.conflict.test.js — same-channel double-booking guard (ReservationRepository.assertNoBookingConflict). Covers blocking vs. non-blocking booking statuses, duplicate-reservation detection, excludeBookingId self-conflict exclusion, property-scoping of the conflict query, and the check-in/out buffer gap.
externalCalendarService.conflict.test.js — cross-channel (iCal) double-booking guard (ExternalCalendarService.ensureNoExternalConflict). Covers no-sources pass-through, non-overlapping vs. overlapping blocked dates, aggregation across multiple external sources, malformed-source skipping, and ServiceUnavailableException resilience when a calendar fetch fails.
service.conflict.test.js — the Ical-sync-scheduler background job that keeps the iCal blocked-dates cache fresh for (2) above. First-ever test coverage for this function (no test/Ical-sync-scheduler directory existed before). Covers due/not-due sync scheduling, the force override, partial-failure resilience (one broken source doesn't block the batch), and the same malformed-source guard.

All three files went through the eng-review skill gate before commit; each found (and had fixed) a coverage gap around asserting the underlying repository write actually happens on the success path, not just the reject/resolve outcome.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Optimization
- [ ] Documentation update

## Change Size
[//]: # (Indicate the size of this change.)
[//]: # (Clarify under Refactoring which parts are moved/unchanged code, so the reviewer doesn’t review old logic.)
- [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
- [x ] Big change (+-max 1000)
- [ ] Small change (less than 300)

## Refactoring
Refactors following files, but didn't change the code. This is to avoid reviewing old logic.
- src/features/example.xx

## Evidence
- [ ] Screenshots or screen recording added for UI changes
- [ ] Before/after images added when relevant
- [ ] Images clearly show the implemented change
- [ ] Image quality is readable (no cropped or blurry evidence)

## Responsiveness
- [ ] UI checked on mobile
- [ ] UI checked on tablet
- [ ] UI checked on desktop
- [ ] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages
- [ ] NPM Packages installed
- [ ] NPM Packages removed
- [ ] NPM Packages updated
- [ ] Checked for vulnerabilities using "npm audit"

## Checklist
[//]: # (All boxes must be checked before merging.)
- [x ] Pull request has at least 2 reviewers assigned
- [ x] PR title is descriptive and includes issue number
- [ x] Conventions
  - [x ] No config files have been added (Amplify config, cache files)
  - [x ] No hardcoded sensitive data (e.g., API-keys/passwords)
  - [x ] No global styling (see [#1691](https://github.com/domits1/Domits/issues/1691))
  - [x ] No `console.log` left in code
  - [x ] No commented-out code remains
- [x ] Testing
  - [x ] Code tested locally
  - [ x] Jest tests are included
  - [ x] Jest tests are passing

## Keep or delete my branch
- [x] Delete my branch after merge
- [ ] Keep my branch  
