### PR TITLE
fix(inbox): fix guest pre-booking messaging auth (#767)

### DIFF
--- a/backend/functions/UnifiedMessaging/business/messageService.authorization.test.js
+++ b/backend/functions/UnifiedMessaging/business/messageService.authorization.test.js
@@ -15,6 +15,7 @@ const mockBookingRepository = {
   getBookingById: jest.fn(),
   findBookingsForGuestHost: jest.fn(),
   findBookingsForGuestHostProperty: jest.fn(),
+  hostOwnsProperty: jest.fn(),
 };
 
 jest.mock("../data/messageRepository.js", () => ({
@@ -245,11 +246,82 @@ describe("MessageService authorization and booking scoping", () => {
     expect(mockMessageRepository.createMessage).not.toHaveBeenCalled();
   });
 
-  test("requires bookingId when a guest starts a new conversation", async () => {
+  test("rejects a guest starting a new conversation without propertyId", async () => {
     await expect(service.sendMessage({ recipientId: "host-1", content: "Hello" }, guestAuth)).rejects.toMatchObject({
       statusCode: 400,
       code: "BAD_REQUEST",
     });
+    expect(mockBookingRepository.hostOwnsProperty).not.toHaveBeenCalled();
+  });
+
+  test("allows a guest to start a pre-booking conversation when the property belongs to the recipient host", async () => {
+    mockBookingRepository.hostOwnsProperty.mockResolvedValue(true);
+    mockThreadRepository.findThread.mockResolvedValue(null);
+    mockThreadRepository.createThread.mockResolvedValue(thread({ bookingId: null }));
+    mockMessageRepository.createMessage.mockImplementation(async (row) => ({ id: "message-1", ...row }));
+
+    const result = await service.sendMessage(
+      { recipientId: "host-1", propertyId: "property-1", content: "Hi, is this available?" },
+      guestAuth
+    );
+
+    expect(result.statusCode).toBe(201);
+    expect(mockBookingRepository.hostOwnsProperty).toHaveBeenCalledWith("host-1", "property-1");
+    expect(mockThreadRepository.createThread).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hostId: "host-1",
+        guestId: "guest-1",
+        propertyId: "property-1",
+        bookingId: null,
+      })
+    );
+  });
+
+  test("rejects a guest pre-booking conversation when the property belongs to a different host", async () => {
+    mockBookingRepository.hostOwnsProperty.mockResolvedValue(false);
+
+    await expect(
+      service.sendMessage({ recipientId: "host-1", propertyId: "property-1", content: "Hi" }, guestAuth)
+    ).rejects.toMatchObject({ statusCode: 400, code: "BAD_REQUEST" });
+    expect(mockThreadRepository.createThread).not.toHaveBeenCalled();
+  });
+
+  test("rejects a spoofed guestId on a guest pre-booking conversation", async () => {
+    mockBookingRepository.hostOwnsProperty.mockResolvedValue(true);
+
+    await expect(
+      service.sendMessage(
+        { recipientId: "host-1", propertyId: "property-1", guestId: "someone-else", content: "Hi" },
+        guestAuth
+      )
+    ).rejects.toMatchObject({ statusCode: 403, code: "FORBIDDEN" });
+    expect(mockThreadRepository.createThread).not.toHaveBeenCalled();
+  });
+
+  test("rejects a spoofed hostId on a guest pre-booking conversation", async () => {
+    mockBookingRepository.hostOwnsProperty.mockResolvedValue(true);
+
+    await expect(
+      service.sendMessage(
+        { recipientId: "host-1", propertyId: "property-1", hostId: "some-other-host", content: "Hi" },
+        guestAuth
+      )
+    ).rejects.toMatchObject({ statusCode: 403, code: "FORBIDDEN" });
+    expect(mockThreadRepository.createThread).not.toHaveBeenCalled();
+  });
+
+  test("allows a host to start a new conversation without a booking", async () => {
+    mockThreadRepository.findThread.mockResolvedValue(null);
+    mockThreadRepository.createThread.mockResolvedValue(thread({ bookingId: null }));
+    mockMessageRepository.createMessage.mockImplementation(async (row) => ({ id: "message-1", ...row }));
+
+    const result = await service.sendMessage({ recipientId: "guest-1", content: "Welcome!" }, hostAuth);
+
+    expect(result.statusCode).toBe(201);
+    expect(mockBookingRepository.hostOwnsProperty).not.toHaveBeenCalled();
+    expect(mockThreadRepository.createThread).toHaveBeenCalledWith(
+      expect.objectContaining({ hostId: "host-1", guestId: "guest-1", bookingId: null })
+    );
   });
 
   test("creates guest reservation conversations from booking ownership and stores bookingId", async () => {

--- a/backend/functions/UnifiedMessaging/business/messageService.js
+++ b/backend/functions/UnifiedMessaging/business/messageService.js
@@ -302,18 +302,40 @@ class MessageService {
     };
   }
 
-  resolveHostMessageContext(payload, authenticatedUser, senderId) {
+  async resolveHostMessageContext(payload, authenticatedUser, senderId) {
     const recipientId = payload.recipientId;
-
-    if (!authenticatedUser.isHost) {
-      throw badRequest("bookingId is required to start a guest conversation.");
-    }
 
     if (!recipientId || idsEqual(recipientId, senderId)) {
       throw badRequest("recipientId is required.");
     }
 
-    this.assertConsistentOptionalId(payload.hostId, senderId, "hostId");
+    if (authenticatedUser.isHost) {
+      this.assertConsistentOptionalId(payload.hostId, senderId, "hostId");
+      return {
+        senderId,
+        recipientId,
+        threadId: null,
+        resolvedPayload: {
+          ...payload,
+          senderId,
+          recipientId,
+          hostId: senderId,
+          guestId: payload.guestId || recipientId,
+          propertyId: payload.propertyId ?? null,
+          bookingId: null,
+          platform: payload.platform || "DOMITS",
+        },
+      };
+    }
+
+    if (!payload.propertyId) {
+      throw badRequest("propertyId is required to start a conversation without a booking.");
+    }
+    if (!(await this.bookingRepository.hostOwnsProperty(recipientId, payload.propertyId))) {
+      throw badRequest("propertyId does not belong to the specified host.");
+    }
+    this.assertConsistentOptionalId(payload.guestId, senderId, "guestId");
+    this.assertConsistentOptionalId(payload.hostId, recipientId, "hostId");
     return {
       senderId,
       recipientId,
@@ -322,9 +344,9 @@ class MessageService {
         ...payload,
         senderId,
         recipientId,
-        hostId: senderId,
-        guestId: payload.guestId || recipientId,
-        propertyId: payload.propertyId ?? null,
+        hostId: recipientId,
+        guestId: senderId,
+        propertyId: payload.propertyId,
         bookingId: null,
         platform: payload.platform || "DOMITS",
       },
@@ -342,7 +364,7 @@ class MessageService {
       return await this.resolveBookingMessageContext(payload, senderId);
     }
 
-    return this.resolveHostMessageContext(payload, authenticatedUser, senderId);
+    return await this.resolveHostMessageContext(payload, authenticatedUser, senderId);
   }
 
   async sendMessage(payload, authenticatedUser) {

--- a/backend/functions/UnifiedMessaging/data/bookingRepository.js
+++ b/backend/functions/UnifiedMessaging/data/bookingRepository.js
@@ -1,5 +1,6 @@
 import Database from "../.shared/integrations/ORM/index.js";
 import { Booking } from "database/models/Booking";
+import { Property } from "database/models/Property";
 
 const normalizeBooking = (booking) => {
   if (!booking) return null;
@@ -49,6 +50,14 @@ class BookingRepository {
       .getMany();
 
     return bookings.map(normalizeBooking).filter(Boolean);
+  }
+
+  async hostOwnsProperty(hostId, propertyId) {
+    if (!hostId || !propertyId) return false;
+
+    const client = await Database.getInstance();
+    const count = await client.getRepository(Property).count({ where: { id: propertyId, hostid: hostId } });
+    return count === 1;
   }
 }
 

--- a/frontend/web/src/features/bookingengine/listingdetails/views/bookingContainer.js
+++ b/frontend/web/src/features/bookingengine/listingdetails/views/bookingContainer.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
-import { Auth } from "aws-amplify";
 import DateSelectionContainer from "./dateSelectionContainer";
 import GuestSelectionContainer from "./guestSelectionContainer";
 import Pricing from "../components/pricing";
@@ -21,16 +20,12 @@ import { UserProvider } from "../../../hostdashboard/hostmessages/context/AuthCo
 import { WebSocketProvider } from "../../../hostdashboard/hostmessages/context/webSocketContext";
 import { useAuth } from "../../../hostdashboard/hostmessages/hooks/useAuth";
 import ChatScreen from "../../../../components/messages/ChatScreen";
+import { getIdToken } from "../../../../services/getAccessToken";
 
 import "../../../../components/messages/messagesV2.scss";
 
 const UNIFIED_MESSAGING_API = "https://54s3llwby8.execute-api.eu-north-1.amazonaws.com/default";
 const NO_AVAILABILITY_MESSAGE = "This property has no availability for the selected dates.";
-
-const getIdToken = async () => {
-  const session = await Auth.currentSession();
-  return session.getIdToken().getJwtToken();
-};
 
 const MessageHostModalInner = ({ onClose, hostId, hostName, hostImage, propertyId }) => {
   const { userId } = useAuth();

--- a/frontend/web/src/features/hostdashboard/hostmessages/context/AuthContext.jsx
+++ b/frontend/web/src/features/hostdashboard/hostmessages/context/AuthContext.jsx
@@ -1,10 +1,6 @@
 import React, { createContext, useState, useEffect, useContext } from "react";
 import { Auth } from "aws-amplify";
-
-const getIdToken = async () => {
-  const session = await Auth.currentSession();
-  return session.getIdToken().getJwtToken();
-};
+import { getIdToken } from "../../../../services/getAccessToken";
 
 const UserContext = createContext();
 export const useUser = () => useContext(UserContext);

--- a/frontend/web/src/features/hostdashboard/hostmessages/hooks/useFetchContacts.js
+++ b/frontend/web/src/features/hostdashboard/hostmessages/hooks/useFetchContacts.js
@@ -1,16 +1,10 @@
 import { useState, useEffect, useCallback } from "react";
-import { Auth } from "aws-amplify";
 import fetchBookingDetailsAndAccommodation from "../utils/FetchBookingDetails";
 import {
   fetchUserProfileById,
   getEmptyUserProfile,
 } from "../../services/fetchUserProfileById";
-import { getAccessToken } from "../../../../services/getAccessToken";
-
-const getIdToken = async () => {
-  const session = await Auth.currentSession();
-  return session.getIdToken().getJwtToken();
-};
+import { getAccessToken, getIdToken } from "../../../../services/getAccessToken";
 
 const UNIFIED_API = "https://54s3llwby8.execute-api.eu-north-1.amazonaws.com/default";
 

--- a/frontend/web/src/features/hostdashboard/hostmessages/hooks/useFetchContacts.test.js
+++ b/frontend/web/src/features/hostdashboard/hostmessages/hooks/useFetchContacts.test.js
@@ -6,20 +6,14 @@ import React from "react";
 import PropTypes from "prop-types";
 import "@testing-library/jest-dom";
 import { render, screen, waitFor } from "@testing-library/react";
-import { Auth } from "aws-amplify";
 import useFetchContacts from "./useFetchContacts";
-import { getAccessToken } from "../../../../services/getAccessToken";
+import { getAccessToken, getIdToken } from "../../../../services/getAccessToken";
 import { fetchUserProfileById, getEmptyUserProfile } from "../../services/fetchUserProfileById";
 import fetchBookingDetailsAndAccommodation from "../utils/FetchBookingDetails";
 
-jest.mock("aws-amplify", () => ({
-  Auth: {
-    currentSession: jest.fn(),
-  },
-}));
-
 jest.mock("../../../../services/getAccessToken", () => ({
   getAccessToken: jest.fn(),
+  getIdToken: jest.fn(),
 }));
 
 jest.mock("../../services/fetchUserProfileById", () => ({
@@ -70,9 +64,7 @@ const okJson = (payload) => ({
 describe("useFetchContacts history merging", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    Auth.currentSession.mockResolvedValue({
-      getIdToken: () => ({ getJwtToken: () => "host-token-1" }),
-    });
+    getIdToken.mockResolvedValue("host-token-1");
     getAccessToken.mockReturnValue("host-access-token-1");
     fetchUserProfileById.mockImplementation(async (userId) => ({
       ...getEmptyUserProfile(userId),

--- a/frontend/web/src/features/hostdashboard/hostmessages/hooks/useFetchMessages.js
+++ b/frontend/web/src/features/hostdashboard/hostmessages/hooks/useFetchMessages.js
@@ -1,6 +1,11 @@
 import { useState, useCallback, useRef, useEffect, useContext } from "react";
+import { Auth } from "aws-amplify";
 import { WebSocketContext } from "../context/webSocketContext";
-import { getAccessToken } from "../../../../services/getAccessToken";
+
+const getIdToken = async () => {
+  const session = await Auth.currentSession();
+  return session.getIdToken().getJwtToken();
+};
 
 const UNIFIED_API = "https://54s3llwby8.execute-api.eu-north-1.amazonaws.com/default";
 
@@ -236,7 +241,7 @@ export const useFetchMessages = (userId) => {
 
       let token = null;
       try {
-        token = requireToken(options.accessToken || getAccessToken());
+        token = requireToken(options.accessToken || (await getIdToken()));
       } catch (authError) {
         setError(authError);
         setMessagesByRecipient((prev) => ({ ...prev, [recipientId]: prev[recipientId] || [] }));

--- a/frontend/web/src/features/hostdashboard/hostmessages/hooks/useFetchMessages.js
+++ b/frontend/web/src/features/hostdashboard/hostmessages/hooks/useFetchMessages.js
@@ -1,11 +1,6 @@
 import { useState, useCallback, useRef, useEffect, useContext } from "react";
-import { Auth } from "aws-amplify";
 import { WebSocketContext } from "../context/webSocketContext";
-
-const getIdToken = async () => {
-  const session = await Auth.currentSession();
-  return session.getIdToken().getJwtToken();
-};
+import { getIdToken } from "../../../../services/getAccessToken";
 
 const UNIFIED_API = "https://54s3llwby8.execute-api.eu-north-1.amazonaws.com/default";
 

--- a/frontend/web/src/features/hostdashboard/hostmessages/hooks/useFetchMessages.test.js
+++ b/frontend/web/src/features/hostdashboard/hostmessages/hooks/useFetchMessages.test.js
@@ -7,11 +7,13 @@ import PropTypes from "prop-types";
 import "@testing-library/jest-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import { WebSocketContext } from "../context/webSocketContext";
+import { Auth } from "aws-amplify";
 import useFetchMessages from "./useFetchMessages";
-import { getAccessToken } from "../../../../services/getAccessToken";
 
-jest.mock("../../../../services/getAccessToken", () => ({
-  getAccessToken: jest.fn(),
+jest.mock("aws-amplify", () => ({
+  Auth: {
+    currentSession: jest.fn(),
+  },
 }));
 
 const Harness = ({ accessToken = null }) => {
@@ -46,7 +48,9 @@ describe("useFetchMessages protected REST calls", () => {
   });
 
   test("does not call protected endpoints when token retrieval fails", async () => {
-    getAccessToken.mockReturnValue(null);
+    Auth.currentSession.mockResolvedValue({
+      getIdToken: () => ({ getJwtToken: () => "" }),
+    });
 
     renderHarness(null);
 
@@ -57,7 +61,6 @@ describe("useFetchMessages protected REST calls", () => {
   });
 
   test("does not fetch /messages when /threads rejects authorization", async () => {
-    getAccessToken.mockReturnValue("access-token-1");
     globalThis.fetch.mockResolvedValue({
       ok: false,
       status: 403,
@@ -72,5 +75,25 @@ describe("useFetchMessages protected REST calls", () => {
 
     expect(globalThis.fetch.mock.calls[0][0]).toContain("/threads");
     expect(globalThis.fetch.mock.calls[0][1].headers.Authorization).toBe("Bearer access-token-1");
+  });
+
+  test("falls back to the Cognito ID token for /threads when no accessToken option is passed", async () => {
+    Auth.currentSession.mockResolvedValue({
+      getIdToken: () => ({ getJwtToken: () => "id-token-1" }),
+    });
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [],
+    });
+
+    renderHarness(null);
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    expect(globalThis.fetch.mock.calls[0][0]).toContain("/threads");
+    expect(globalThis.fetch.mock.calls[0][1].headers.Authorization).toBe("Bearer id-token-1");
   });
 });

--- a/frontend/web/src/features/hostdashboard/hostmessages/services/automationService.js
+++ b/frontend/web/src/features/hostdashboard/hostmessages/services/automationService.js
@@ -1,4 +1,4 @@
-import { Auth } from "aws-amplify";
+import { getIdToken } from "../../../../services/getAccessToken";
 
 const AUTOMATED_MESSAGING_FALLBACK_API = "https://54s3llwby8.execute-api.eu-north-1.amazonaws.com/default";
 const KNOWN_WRONG_AUTOMATED_MESSAGING_API_ID = "543s1lwby8";
@@ -29,13 +29,8 @@ const requireToken = (token) => {
   return normalized;
 };
 
-const getIdToken = async () => {
-  const session = await Auth.currentSession();
-  return requireToken(session.getIdToken().getJwtToken());
-};
-
 const request = async (path, { method = "GET", body } = {}) => {
-  const idToken = await getIdToken();
+  const idToken = requireToken(await getIdToken());
   const response = await fetch(`${API_BASE}/automations${path}`, {
     method,
     headers: {

--- a/frontend/web/src/services/getAccessToken.js
+++ b/frontend/web/src/services/getAccessToken.js
@@ -1,3 +1,5 @@
+import { Auth } from "aws-amplify";
+
 // Service to get accesstoken of loggedin user from localstorage
 export function getAccessToken() {
     const keys = Object.keys(localStorage).filter(
@@ -19,6 +21,11 @@ export function getAccessToken() {
 
     return keys.length === 1 ? localStorage.getItem(keys[0]) : null;
 
+    }
+
+    export async function getIdToken() {
+        const session = await Auth.currentSession();
+        return session.getIdToken().getJwtToken();
     }
 
     export function getCognitoUserId() {


### PR DESCRIPTION
## Close or Relate the Issue
[//]: # (Only if this should close the issue)
- Closes #

[//]: # (in the issue a reference will be added to this pr)
- Related Issue: #767

## Proposed Changes
[//]: # (Add a detailed description of the changes here)
Description:
Fixes the remaining Unified Messaging issues found during guest-to-host testing.

- Uses the Cognito ID token for Unified Messaging `/threads` and `/messages` requests.
- Allows guests to start a pre-booking conversation without a bookingId.
- Uses the real propertyId, hostId, and authenticated guestId.
- Verifies that the property belongs to the recipient host.
- Rejects spoofed hostId and guestId values.
- Keeps existing booking-based and host-initiated conversations unchanged.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Optimization
- [ ] Documentation update

## Change Size
- [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
- [ ] Big change (+-max 1000)
- [x] Small change (less than 300)

## Refactoring
N/A

## Evidence
- [ ] Screenshots or screen recording added for UI changes
- [ ] Before/after images added when relevant
- [ ] Images clearly show the implemented change
- [ ] Image quality is readable (no cropped or blurry evidence)

N/A - no UI design changes.

## Responsiveness
- [ ] UI checked on mobile
- [ ] UI checked on tablet
- [x] UI checked on desktop
- [x] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages
- [ ] NPM Packages installed
- [ ] NPM Packages removed
- [ ] NPM Packages updated
- [ ] Checked for vulnerabilities using "npm audit"

N/A - no npm package changes.

## Checklist
- [ ] Pull request has at least 2 reviewers assigned
- [x] PR title is descriptive and includes issue number
- [x] Conventions
  - [x] No config files have been added (Amplify config, cache files)
  - [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  - [x] No global styling (see [#1691](https://github.com/domits1/Domits/issues/1691))
  - [x] No `console.log` left in code
  - [x] No commented-out code remains
- [x] Testing
  - [x] Code tested locally
  - [x] Jest tests are included
  - [x] Jest tests are passing

## Keep or delete my branch
- [x] Delete my branch after merge
- [ ] Keep my branch