### PR TITLE
#3038 Add booking request form to direct booking websites

### DIFF
--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/BookingRequestForm.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/BookingRequestForm.jsx
@@ -1,0 +1,108 @@
+import React, { useId } from "react";
+import PropTypes from "prop-types";
+import styles from "./QuoteAvailabilitySection.module.scss";
+
+function ContactField({ id, label, type, autoComplete, value, error, disabled, onChange }) {
+  const errorId = `${id}-error`;
+
+  return (
+    <div className={styles.formField}>
+      <label htmlFor={id} className={styles.fieldLabel}>
+        {label}
+      </label>
+      <input
+        id={id}
+        className={`${styles.input} ${error ? styles.inputInvalid : ""}`.trim()}
+        type={type}
+        autoComplete={autoComplete}
+        value={value}
+        disabled={disabled}
+        aria-invalid={error ? "true" : undefined}
+        aria-describedby={error ? errorId : undefined}
+        onChange={(event) => onChange(event.target.value)}
+      />
+      {error ? (
+        <p id={errorId} className={styles.fieldError}>
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+ContactField.propTypes = {
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  autoComplete: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  error: PropTypes.string,
+  disabled: PropTypes.bool.isRequired,
+  onChange: PropTypes.func.isRequired,
+};
+
+export default function BookingRequestForm({
+  guest,
+  onGuestChange,
+  onSubmit,
+  isSubmitting = false,
+  fieldErrors = {},
+  formError = "",
+}) {
+  const fieldIdPrefix = useId();
+
+  return (
+    <form
+      className={styles.form}
+      noValidate
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmit();
+      }}>
+      <ContactField
+        id={`${fieldIdPrefix}-name`}
+        label="Your name"
+        type="text"
+        autoComplete="name"
+        value={guest?.name || ""}
+        error={fieldErrors?.name || ""}
+        disabled={isSubmitting}
+        onChange={(value) => onGuestChange("name", value)}
+      />
+      <ContactField
+        id={`${fieldIdPrefix}-email`}
+        label="Email address"
+        type="email"
+        autoComplete="email"
+        value={guest?.email || ""}
+        error={fieldErrors?.email || ""}
+        disabled={isSubmitting}
+        onChange={(value) => onGuestChange("email", value)}
+      />
+      {formError ? (
+        <p className={styles.fieldError} role="alert">
+          {formError}
+        </p>
+      ) : null}
+      <button type="submit" className={styles.action} disabled={isSubmitting}>
+        {isSubmitting ? "Sending…" : "Request to book"}
+      </button>
+      <p className={styles.hint}>Nothing is booked until the host confirms your request.</p>
+    </form>
+  );
+}
+
+BookingRequestForm.propTypes = {
+  guest: PropTypes.shape({
+    name: PropTypes.string,
+    email: PropTypes.string,
+  }).isRequired,
+  onGuestChange: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  isSubmitting: PropTypes.bool,
+  fieldErrors: PropTypes.shape({
+    name: PropTypes.string,
+    email: PropTypes.string,
+  }),
+  formError: PropTypes.string,
+};

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/BookingRequestSuccess.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/BookingRequestSuccess.jsx
@@ -7,7 +7,7 @@ const pluralizeGuests = (count) => `${count} ${count === 1 ? "guest" : "guests"}
 
 export default function BookingRequestSuccess({ result, guestEmail = "" }) {
   return (
-    <div className={styles.success} role="status">
+    <output className={styles.success}>
       <p className={styles.successTitle}>Request sent</p>
       <p className={styles.successLabel}>Booking reference</p>
       <p className={styles.successReference}>{result.publicBookingRef}</p>
@@ -23,7 +23,7 @@ export default function BookingRequestSuccess({ result, guestEmail = "" }) {
       </dl>
       <p className={styles.successNote}>The host still has to confirm your request — nothing is booked yet.</p>
       {guestEmail ? <p className={styles.hint}>{`We've sent a copy to ${guestEmail}.`}</p> : null}
-    </div>
+    </output>
   );
 }
 

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/BookingRequestSuccess.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/BookingRequestSuccess.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styles from "./QuoteAvailabilitySection.module.scss";
+import { formatMinorUnits } from "./quoteSelection";
+
+const pluralizeGuests = (count) => `${count} ${count === 1 ? "guest" : "guests"}`;
+
+export default function BookingRequestSuccess({ result, guestEmail = "" }) {
+  return (
+    <div className={styles.success} role="status">
+      <p className={styles.successTitle}>Request sent</p>
+      <p className={styles.successLabel}>Booking reference</p>
+      <p className={styles.successReference}>{result.publicBookingRef}</p>
+      <dl className={styles.breakdownList}>
+        <div className={styles.breakdownRow}>
+          <dt>Guests</dt>
+          <dd>{pluralizeGuests(result.guests)}</dd>
+        </div>
+        <div className={`${styles.breakdownRow} ${styles.breakdownTotal}`}>
+          <dt>Total</dt>
+          <dd>{formatMinorUnits(result.total, result.currency)}</dd>
+        </div>
+      </dl>
+      <p className={styles.successNote}>The host still has to confirm your request — nothing is booked yet.</p>
+      {guestEmail ? <p className={styles.hint}>{`We've sent a copy to ${guestEmail}.`}</p> : null}
+    </div>
+  );
+}
+
+BookingRequestSuccess.propTypes = {
+  result: PropTypes.shape({
+    publicBookingRef: PropTypes.string.isRequired,
+    guests: PropTypes.number.isRequired,
+    total: PropTypes.number.isRequired,
+    currency: PropTypes.string,
+  }).isRequired,
+  guestEmail: PropTypes.string,
+};

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/QuoteAvailabilitySection.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/QuoteAvailabilitySection.jsx
@@ -30,13 +30,8 @@ const resolveContactHref = (model) => {
 
 const toDateKeyList = (value) => (Array.isArray(value) ? value : []);
 
-const withoutField = (errors, field) => {
-  if (!errors?.[field]) {
-    return errors;
-  }
-  const { [field]: _removed, ...remainingErrors } = errors;
-  return remainingErrors;
-};
+const withoutField = (errors, field) =>
+  errors?.[field] ? Object.fromEntries(Object.entries(errors).filter(([key]) => key !== field)) : errors;
 
 export default function QuoteAvailabilitySection({
   model,

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/QuoteAvailabilitySection.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/QuoteAvailabilitySection.jsx
@@ -2,8 +2,10 @@ import React, { useCallback, useMemo, useState } from "react";
 import PropTypes from "prop-types";
 import styles from "./QuoteAvailabilitySection.module.scss";
 import QuotePanel from "./QuotePanel";
-import { useWebsiteQuote } from "./useWebsiteQuote";
+import { QUOTE_STATUS, useWebsiteQuote } from "./useWebsiteQuote";
+import { BOOKING_REQUEST_STATUS, useWebsiteBookingRequest } from "./useWebsiteBookingRequest";
 import { resolveQuoteErrorPresentation } from "./quoteErrorCopy";
+import { EMPTY_BOOKING_GUEST, validateBookingGuestContact } from "./bookingRequestContact";
 import { EMPTY_STAY_RANGE, getTodayDateKey, selectStayDate } from "./quoteSelection";
 import { TemplateAvailabilityCalendar } from "../templates/templateSharedSections";
 import { getOrCreateVisitorId } from "../../services/websiteVisitorId";
@@ -26,6 +28,16 @@ const resolveContactHref = (model) => {
   return whatsapp?.isAvailable && digits ? `https://wa.me/${digits}` : null;
 };
 
+const toDateKeyList = (value) => (Array.isArray(value) ? value : []);
+
+const withoutField = (errors, field) => {
+  if (!errors?.[field]) {
+    return errors;
+  }
+  const { [field]: _removed, ...remainingErrors } = errors;
+  return remainingErrors;
+};
+
 export default function QuoteAvailabilitySection({
   model,
   siteId,
@@ -41,34 +53,58 @@ export default function QuoteAvailabilitySection({
   const blockedDateKeys = useMemo(
     () =>
       new Set([
-        ...(Array.isArray(model?.availability?.externalBlockedDates) ? model.availability.externalBlockedDates : []),
-        ...(Array.isArray(model?.availability?.unavailableDateKeys) ? model.availability.unavailableDateKeys : []),
+        ...toDateKeyList(model?.availability?.externalBlockedDates),
+        ...toDateKeyList(model?.availability?.unavailableDateKeys),
       ]),
     [model?.availability]
   );
 
   const [range, setRange] = useState(EMPTY_STAY_RANGE);
-  const [guests, setGuests] = useState(() => (capacity ? Math.min(DEFAULT_GUEST_COUNT, capacity) : DEFAULT_GUEST_COUNT));
+  const [guests, setGuests] = useState(() =>
+    capacity ? Math.min(DEFAULT_GUEST_COUNT, capacity) : DEFAULT_GUEST_COUNT
+  );
+  const [guest, setGuest] = useState(EMPTY_BOOKING_GUEST);
+  const [guestErrors, setGuestErrors] = useState({});
   const { requestQuote, notifySelectionChanged, ...quoteState } = useWebsiteQuote({ siteId, sessionId });
+  const {
+    submitBookingRequest,
+    reset: resetBookingRequest,
+    ...bookingState
+  } = useWebsiteBookingRequest({
+    siteId,
+    sessionId,
+  });
+  const bookingSucceeded = bookingState.status === BOOKING_REQUEST_STATUS.SUCCESS;
+  const hasBookingError = bookingState.status === BOOKING_REQUEST_STATUS.ERROR;
+
+  const handleSelectionChanged = useCallback(() => {
+    notifySelectionChanged();
+    if (hasBookingError) {
+      resetBookingRequest();
+    }
+  }, [hasBookingError, notifySelectionChanged, resetBookingRequest]);
 
   const handleSelectDate = useCallback(
     (dateKey) => {
+      if (bookingSucceeded) {
+        return;
+      }
       const nextRange = selectStayDate({ range, dateKey, blockedDateKeys, todayKey });
       if (nextRange === range) {
         return;
       }
       setRange(nextRange);
-      notifySelectionChanged();
+      handleSelectionChanged();
     },
-    [blockedDateKeys, notifySelectionChanged, range, todayKey]
+    [blockedDateKeys, bookingSucceeded, handleSelectionChanged, range, todayKey]
   );
 
   const handleGuestsChange = useCallback(
     (nextGuests) => {
       setGuests(nextGuests);
-      notifySelectionChanged();
+      handleSelectionChanged();
     },
-    [notifySelectionChanged]
+    [handleSelectionChanged]
   );
 
   const handleRequestQuote = useCallback(async () => {
@@ -78,15 +114,35 @@ export default function QuoteAvailabilitySection({
     }
   }, [guests, range.checkIn, range.checkOut, requestQuote]);
 
+  const handleGuestChange = useCallback((field, value) => {
+    setGuest((currentGuest) => ({ ...currentGuest, [field]: value }));
+    setGuestErrors((currentErrors) => withoutField(currentErrors, field));
+  }, []);
+
+  const handleSubmitBookingRequest = useCallback(async () => {
+    const quote = quoteState.quote;
+    if (quoteState.status !== QUOTE_STATUS.SUCCESS || !quote) {
+      return;
+    }
+
+    const { guest: normalizedGuest, errors } = validateBookingGuestContact(guest);
+    setGuestErrors(errors);
+    if (Object.keys(errors).length > 0) {
+      return;
+    }
+
+    await submitBookingRequest({ quote, guest: normalizedGuest });
+  }, [guest, quoteState.quote, quoteState.status, submitBookingRequest]);
+
   const selection = useMemo(
     () => ({
-      selectable: true,
+      selectable: !bookingSucceeded,
       checkIn: range.checkIn,
       checkOut: range.checkOut,
       todayKey,
       onSelectDate: handleSelectDate,
     }),
-    [handleSelectDate, range.checkIn, range.checkOut, todayKey]
+    [bookingSucceeded, handleSelectDate, range.checkIn, range.checkOut, todayKey]
   );
 
   return (
@@ -112,6 +168,11 @@ export default function QuoteAvailabilitySection({
           quoteState={quoteState}
           onRequestQuote={handleRequestQuote}
           contactHref={resolveContactHref(model)}
+          bookingState={bookingState}
+          guest={guest}
+          guestErrors={guestErrors}
+          onGuestChange={handleGuestChange}
+          onSubmitBookingRequest={handleSubmitBookingRequest}
         />
       </div>
     </div>

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/QuoteAvailabilitySection.module.scss
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/QuoteAvailabilitySection.module.scss
@@ -243,3 +243,86 @@
   font-size: 0.82rem;
   color: var(--website-quote-muted);
 }
+
+.notice {
+  display: grid;
+  gap: 6px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(30, 49, 80, 0.06);
+}
+
+.noticeMessage {
+  margin: 0;
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.form {
+  display: grid;
+  gap: clamp(10px, 1.4vw, 14px);
+  padding-top: clamp(10px, 1.4vw, 14px);
+  border-top: 1px solid var(--website-quote-line);
+}
+
+.formField {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.input {
+  min-height: 44px;
+  padding: 0.55rem 0.85rem;
+  border: 1px solid var(--website-quote-line);
+  border-radius: 12px;
+  background: #ffffff;
+  color: var(--website-quote-ink);
+  font: inherit;
+}
+
+.input:focus-visible {
+  outline: 2px solid var(--website-quote-accent);
+  outline-offset: 2px;
+}
+
+.input:disabled {
+  opacity: 0.6;
+}
+
+.inputInvalid {
+  border-color: #9f3a2b;
+}
+
+.success {
+  display: grid;
+  gap: 8px;
+  padding: clamp(12px, 1.6vw, 16px);
+  border-radius: 14px;
+  background: rgba(30, 49, 80, 0.06);
+}
+
+.successTitle {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.successLabel {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--website-quote-muted);
+}
+
+.successReference {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+}
+
+.successNote {
+  margin: 0;
+  font-weight: 600;
+}

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/QuotePanel.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/QuotePanel.jsx
@@ -2,9 +2,21 @@ import React from "react";
 import PropTypes from "prop-types";
 import styles from "./QuoteAvailabilitySection.module.scss";
 import GuestCountField from "./GuestCountField";
+import BookingRequestForm from "./BookingRequestForm";
+import BookingRequestSuccess from "./BookingRequestSuccess";
 import { QUOTE_STALE_REASONS, QUOTE_STATUS } from "./useWebsiteQuote";
+import { BOOKING_REQUEST_STATUS } from "./useWebsiteBookingRequest";
 import { QUOTE_ERROR_SCOPES, resolveQuoteErrorPresentation } from "./quoteErrorCopy";
+import {
+  BOOKING_REQUEST_ERROR_SCOPES,
+  BOOKING_REQUEST_RECOVERY,
+  resolveBookingRequestErrorPresentation,
+} from "./bookingRequestErrorCopy";
+import { EMPTY_BOOKING_GUEST } from "./bookingRequestContact";
 import { countStayNights, formatMinorUnits, formatQuoteValidUntil, formatStayDate } from "./quoteSelection";
+
+const IDLE_BOOKING_STATE = Object.freeze({ status: BOOKING_REQUEST_STATUS.IDLE, result: null, error: null });
+const noop = () => {};
 
 const pluralizeNights = (count) => `${count} ${count === 1 ? "night" : "nights"}`;
 
@@ -103,6 +115,13 @@ QuotePanelAlert.propTypes = {
   onRetry: PropTypes.func.isRequired,
 };
 
+const toAlertPresentation = (bookingPresentation) => ({
+  message: bookingPresentation.message,
+  canRetry: bookingPresentation.recovery === BOOKING_REQUEST_RECOVERY.RETRY,
+  showContact: false,
+  showReference: bookingPresentation.showReference,
+});
+
 export default function QuotePanel({
   range,
   guests,
@@ -112,22 +131,41 @@ export default function QuotePanel({
   quoteState,
   onRequestQuote,
   contactHref = null,
+  bookingState = IDLE_BOOKING_STATE,
+  guest = EMPTY_BOOKING_GUEST,
+  guestErrors = {},
+  onGuestChange = noop,
+  onSubmitBookingRequest = noop,
 }) {
   const checkIn = range?.checkIn || null;
   const checkOut = range?.checkOut || null;
   const nights = countStayNights(checkIn, checkOut);
   const isLoading = quoteState.status === QUOTE_STATUS.LOADING;
   const isStale = quoteState.status === QUOTE_STATUS.STALE;
-  const showBreakdown = Boolean(quoteState.quote) && (quoteState.status === QUOTE_STATUS.SUCCESS || isStale);
+  const isQuoted = quoteState.status === QUOTE_STATUS.SUCCESS && Boolean(quoteState.quote);
+  const showBreakdown = Boolean(quoteState.quote) && (isQuoted || isStale);
+
+  const isSubmitting = bookingState.status === BOOKING_REQUEST_STATUS.SUBMITTING;
+  const bookingSucceeded = bookingState.status === BOOKING_REQUEST_STATUS.SUCCESS && Boolean(bookingState.result);
 
   const errorPresentation =
     quoteState.status === QUOTE_STATUS.ERROR ? resolveQuoteErrorPresentation(quoteState.error) : null;
+  const bookingPresentation =
+    bookingState.status === BOOKING_REQUEST_STATUS.ERROR
+      ? resolveBookingRequestErrorPresentation(bookingState.error)
+      : null;
+
   const datesError = errorPresentation?.scope === QUOTE_ERROR_SCOPES.DATES ? errorPresentation.message : "";
   const guestsError = errorPresentation?.scope === QUOTE_ERROR_SCOPES.GUESTS ? errorPresentation.message : "";
   const panelError = errorPresentation?.scope === QUOTE_ERROR_SCOPES.PANEL ? errorPresentation : null;
+  const bookingPanelError =
+    bookingPresentation?.scope === BOOKING_REQUEST_ERROR_SCOPES.PANEL ? bookingPresentation : null;
+  const bookingContactError =
+    bookingPresentation?.scope === BOOKING_REQUEST_ERROR_SCOPES.CONTACT ? bookingPresentation.message : "";
 
-  const showAction = !panelError?.hideAction;
-  const canRequestQuote = nights > 0 && guests >= 1 && !isLoading;
+  const hideAction = Boolean(panelError?.hideAction || bookingPanelError?.hideAction);
+  const canRequestQuote = nights > 0 && guests >= 1 && !isLoading && !isSubmitting;
+  const showRequestForm = isQuoted && !hideAction;
 
   return (
     <aside className={styles.panel} aria-labelledby="website-quote-panel-title">
@@ -138,7 +176,9 @@ export default function QuotePanel({
       <div className={styles.stayBlock}>
         <p className={styles.staySummary}>{resolveStaySummary({ checkIn, checkOut })}</p>
         {nights > 0 ? <p className={styles.stayNights}>{pluralizeNights(nights)}</p> : null}
-        {minimumStay > 0 ? <p className={styles.hint}>{`Minimum stay: ${pluralizeNights(minimumStay)}`}</p> : null}
+        {minimumStay > 0 && !bookingSucceeded ? (
+          <p className={styles.hint}>{`Minimum stay: ${pluralizeNights(minimumStay)}`}</p>
+        ) : null}
         {datesError ? (
           <p className={styles.fieldError} role="alert">
             {datesError}
@@ -146,32 +186,58 @@ export default function QuotePanel({
         ) : null}
       </div>
 
-      <GuestCountField
-        value={guests}
-        onChange={onGuestsChange}
-        max={capacity}
-        disabled={isLoading}
-        errorMessage={guestsError}
-      />
+      {bookingSucceeded ? (
+        <BookingRequestSuccess result={bookingState.result} guestEmail={guest?.email || ""} />
+      ) : (
+        <>
+          <GuestCountField
+            value={guests}
+            onChange={onGuestsChange}
+            max={capacity}
+            disabled={isLoading || isSubmitting}
+            errorMessage={guestsError}
+          />
 
-      {showAction ? (
-        <button type="button" className={styles.action} onClick={onRequestQuote} disabled={!canRequestQuote}>
-          {isLoading ? "Checking…" : "Check availability"}
-        </button>
-      ) : null}
+          {hideAction ? null : (
+            <button type="button" className={styles.action} onClick={onRequestQuote} disabled={!canRequestQuote}>
+              {isLoading ? "Checking…" : "Check availability"}
+            </button>
+          )}
 
-      {panelError ? (
-        <QuotePanelAlert
-          presentation={panelError}
-          requestId={quoteState.error?.requestId || ""}
-          contactHref={contactHref}
-          onRetry={onRequestQuote}
-        />
-      ) : null}
+          {panelError ? (
+            <QuotePanelAlert
+              presentation={panelError}
+              requestId={quoteState.error?.requestId || ""}
+              contactHref={contactHref}
+              onRetry={onRequestQuote}
+            />
+          ) : null}
 
-      {showBreakdown ? (
-        <QuoteBreakdown quote={quoteState.quote} isStale={isStale} staleReason={quoteState.staleReason} />
-      ) : null}
+          {showBreakdown ? (
+            <QuoteBreakdown quote={quoteState.quote} isStale={isStale} staleReason={quoteState.staleReason} />
+          ) : null}
+
+          {bookingPanelError ? (
+            <QuotePanelAlert
+              presentation={toAlertPresentation(bookingPanelError)}
+              requestId={bookingState.error?.requestId || ""}
+              contactHref={contactHref}
+              onRetry={onSubmitBookingRequest}
+            />
+          ) : null}
+
+          {showRequestForm ? (
+            <BookingRequestForm
+              guest={guest}
+              onGuestChange={onGuestChange}
+              onSubmit={onSubmitBookingRequest}
+              isSubmitting={isSubmitting}
+              fieldErrors={guestErrors}
+              formError={bookingContactError}
+            />
+          ) : null}
+        </>
+      )}
     </aside>
   );
 }
@@ -197,4 +263,23 @@ QuotePanel.propTypes = {
   }).isRequired,
   onRequestQuote: PropTypes.func.isRequired,
   contactHref: PropTypes.string,
+  bookingState: PropTypes.shape({
+    status: PropTypes.oneOf(Object.values(BOOKING_REQUEST_STATUS)).isRequired,
+    result: PropTypes.shape({}),
+    error: PropTypes.shape({
+      code: PropTypes.string,
+      message: PropTypes.string,
+      requestId: PropTypes.string,
+    }),
+  }),
+  guest: PropTypes.shape({
+    name: PropTypes.string,
+    email: PropTypes.string,
+  }),
+  guestErrors: PropTypes.shape({
+    name: PropTypes.string,
+    email: PropTypes.string,
+  }),
+  onGuestChange: PropTypes.func,
+  onSubmitBookingRequest: PropTypes.func,
 };

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/QuotePanel.jsx
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/QuotePanel.jsx
@@ -33,6 +33,40 @@ const resolveStaySummary = ({ checkIn, checkOut }) => {
 const resolveStaleNotice = (staleReason) =>
   staleReason === QUOTE_STALE_REASONS.EXPIRED ? "Price expired — check again" : "Selection changed — check again";
 
+const deriveQuoteView = (quoteState) => {
+  const isLoading = quoteState.status === QUOTE_STATUS.LOADING;
+  const isStale = quoteState.status === QUOTE_STATUS.STALE;
+  const isQuoted = quoteState.status === QUOTE_STATUS.SUCCESS && Boolean(quoteState.quote);
+  const showBreakdown = Boolean(quoteState.quote) && (isQuoted || isStale);
+  const errorPresentation =
+    quoteState.status === QUOTE_STATUS.ERROR ? resolveQuoteErrorPresentation(quoteState.error) : null;
+
+  return {
+    isLoading,
+    isStale,
+    isQuoted,
+    showBreakdown,
+    datesError: errorPresentation?.scope === QUOTE_ERROR_SCOPES.DATES ? errorPresentation.message : "",
+    guestsError: errorPresentation?.scope === QUOTE_ERROR_SCOPES.GUESTS ? errorPresentation.message : "",
+    panelError: errorPresentation?.scope === QUOTE_ERROR_SCOPES.PANEL ? errorPresentation : null,
+  };
+};
+
+const deriveBookingView = (bookingState) => {
+  const bookingPresentation =
+    bookingState.status === BOOKING_REQUEST_STATUS.ERROR
+      ? resolveBookingRequestErrorPresentation(bookingState.error)
+      : null;
+
+  return {
+    isSubmitting: bookingState.status === BOOKING_REQUEST_STATUS.SUBMITTING,
+    bookingSucceeded: bookingState.status === BOOKING_REQUEST_STATUS.SUCCESS && Boolean(bookingState.result),
+    bookingPanelError: bookingPresentation?.scope === BOOKING_REQUEST_ERROR_SCOPES.PANEL ? bookingPresentation : null,
+    bookingContactError:
+      bookingPresentation?.scope === BOOKING_REQUEST_ERROR_SCOPES.CONTACT ? bookingPresentation.message : "",
+  };
+};
+
 function QuoteBreakdown({ quote, isStale, staleReason }) {
   const { priceBreakdown, nights } = quote;
   const nightlyRate = nights > 0 ? Math.round(priceBreakdown.nightlyBaseTotal / nights) : null;
@@ -122,6 +156,160 @@ const toAlertPresentation = (bookingPresentation) => ({
   showReference: bookingPresentation.showReference,
 });
 
+function StayBlock({ checkIn, checkOut, nights, minimumStay, bookingSucceeded, datesError }) {
+  return (
+    <div className={styles.stayBlock}>
+      <p className={styles.staySummary}>{resolveStaySummary({ checkIn, checkOut })}</p>
+      {nights > 0 ? <p className={styles.stayNights}>{pluralizeNights(nights)}</p> : null}
+      {minimumStay > 0 && !bookingSucceeded ? (
+        <p className={styles.hint}>{`Minimum stay: ${pluralizeNights(minimumStay)}`}</p>
+      ) : null}
+      {datesError ? (
+        <p className={styles.fieldError} role="alert">
+          {datesError}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+StayBlock.propTypes = {
+  checkIn: PropTypes.string,
+  checkOut: PropTypes.string,
+  nights: PropTypes.number.isRequired,
+  minimumStay: PropTypes.number,
+  bookingSucceeded: PropTypes.bool.isRequired,
+  datesError: PropTypes.string.isRequired,
+};
+
+function QuotePanelBody({
+  guests,
+  onGuestsChange,
+  capacity,
+  quoteState,
+  quoteView,
+  onRequestQuote,
+  contactHref,
+  bookingState,
+  bookingView,
+  guest,
+  guestErrors,
+  onGuestChange,
+  onSubmitBookingRequest,
+  hideAction,
+  canRequestQuote,
+  showRequestForm,
+}) {
+  const { isLoading, isStale, showBreakdown, guestsError, panelError } = quoteView;
+  const { isSubmitting, bookingPanelError, bookingContactError } = bookingView;
+
+  return (
+    <>
+      <GuestCountField
+        value={guests}
+        onChange={onGuestsChange}
+        max={capacity}
+        disabled={isLoading || isSubmitting}
+        errorMessage={guestsError}
+      />
+
+      {hideAction ? null : (
+        <button type="button" className={styles.action} onClick={onRequestQuote} disabled={!canRequestQuote}>
+          {isLoading ? "Checking…" : "Check availability"}
+        </button>
+      )}
+
+      {panelError ? (
+        <QuotePanelAlert
+          presentation={panelError}
+          requestId={quoteState.error?.requestId || ""}
+          contactHref={contactHref}
+          onRetry={onRequestQuote}
+        />
+      ) : null}
+
+      {showBreakdown ? (
+        <QuoteBreakdown quote={quoteState.quote} isStale={isStale} staleReason={quoteState.staleReason} />
+      ) : null}
+
+      {bookingPanelError ? (
+        <QuotePanelAlert
+          presentation={toAlertPresentation(bookingPanelError)}
+          requestId={bookingState.error?.requestId || ""}
+          contactHref={contactHref}
+          onRetry={onSubmitBookingRequest}
+        />
+      ) : null}
+
+      {showRequestForm ? (
+        <BookingRequestForm
+          guest={guest}
+          onGuestChange={onGuestChange}
+          onSubmit={onSubmitBookingRequest}
+          isSubmitting={isSubmitting}
+          fieldErrors={guestErrors}
+          formError={bookingContactError}
+        />
+      ) : null}
+    </>
+  );
+}
+
+const quoteStatePropType = PropTypes.shape({
+  status: PropTypes.oneOf(Object.values(QUOTE_STATUS)).isRequired,
+  quote: PropTypes.shape({}),
+  error: PropTypes.shape({
+    code: PropTypes.string,
+    message: PropTypes.string,
+    requestId: PropTypes.string,
+  }),
+  staleReason: PropTypes.string,
+});
+
+const bookingStatePropType = PropTypes.shape({
+  status: PropTypes.oneOf(Object.values(BOOKING_REQUEST_STATUS)).isRequired,
+  result: PropTypes.shape({}),
+  error: PropTypes.shape({
+    code: PropTypes.string,
+    message: PropTypes.string,
+    requestId: PropTypes.string,
+  }),
+});
+
+const guestPropType = PropTypes.shape({
+  name: PropTypes.string,
+  email: PropTypes.string,
+});
+
+QuotePanelBody.propTypes = {
+  guests: PropTypes.number.isRequired,
+  onGuestsChange: PropTypes.func.isRequired,
+  capacity: PropTypes.number,
+  quoteState: quoteStatePropType.isRequired,
+  quoteView: PropTypes.shape({
+    isLoading: PropTypes.bool.isRequired,
+    isStale: PropTypes.bool.isRequired,
+    showBreakdown: PropTypes.bool.isRequired,
+    guestsError: PropTypes.string.isRequired,
+    panelError: PropTypes.shape({}),
+  }).isRequired,
+  onRequestQuote: PropTypes.func.isRequired,
+  contactHref: PropTypes.string,
+  bookingState: bookingStatePropType.isRequired,
+  bookingView: PropTypes.shape({
+    isSubmitting: PropTypes.bool.isRequired,
+    bookingPanelError: PropTypes.shape({}),
+    bookingContactError: PropTypes.string.isRequired,
+  }).isRequired,
+  guest: guestPropType.isRequired,
+  guestErrors: guestPropType.isRequired,
+  onGuestChange: PropTypes.func.isRequired,
+  onSubmitBookingRequest: PropTypes.func.isRequired,
+  hideAction: PropTypes.bool.isRequired,
+  canRequestQuote: PropTypes.bool.isRequired,
+  showRequestForm: PropTypes.bool.isRequired,
+};
+
 export default function QuotePanel({
   range,
   guests,
@@ -140,32 +328,12 @@ export default function QuotePanel({
   const checkIn = range?.checkIn || null;
   const checkOut = range?.checkOut || null;
   const nights = countStayNights(checkIn, checkOut);
-  const isLoading = quoteState.status === QUOTE_STATUS.LOADING;
-  const isStale = quoteState.status === QUOTE_STATUS.STALE;
-  const isQuoted = quoteState.status === QUOTE_STATUS.SUCCESS && Boolean(quoteState.quote);
-  const showBreakdown = Boolean(quoteState.quote) && (isQuoted || isStale);
+  const quoteView = deriveQuoteView(quoteState);
+  const bookingView = deriveBookingView(bookingState);
 
-  const isSubmitting = bookingState.status === BOOKING_REQUEST_STATUS.SUBMITTING;
-  const bookingSucceeded = bookingState.status === BOOKING_REQUEST_STATUS.SUCCESS && Boolean(bookingState.result);
-
-  const errorPresentation =
-    quoteState.status === QUOTE_STATUS.ERROR ? resolveQuoteErrorPresentation(quoteState.error) : null;
-  const bookingPresentation =
-    bookingState.status === BOOKING_REQUEST_STATUS.ERROR
-      ? resolveBookingRequestErrorPresentation(bookingState.error)
-      : null;
-
-  const datesError = errorPresentation?.scope === QUOTE_ERROR_SCOPES.DATES ? errorPresentation.message : "";
-  const guestsError = errorPresentation?.scope === QUOTE_ERROR_SCOPES.GUESTS ? errorPresentation.message : "";
-  const panelError = errorPresentation?.scope === QUOTE_ERROR_SCOPES.PANEL ? errorPresentation : null;
-  const bookingPanelError =
-    bookingPresentation?.scope === BOOKING_REQUEST_ERROR_SCOPES.PANEL ? bookingPresentation : null;
-  const bookingContactError =
-    bookingPresentation?.scope === BOOKING_REQUEST_ERROR_SCOPES.CONTACT ? bookingPresentation.message : "";
-
-  const hideAction = Boolean(panelError?.hideAction || bookingPanelError?.hideAction);
-  const canRequestQuote = nights > 0 && guests >= 1 && !isLoading && !isSubmitting;
-  const showRequestForm = isQuoted && !hideAction;
+  const hideAction = Boolean(quoteView.panelError?.hideAction || bookingView.bookingPanelError?.hideAction);
+  const canRequestQuote = nights > 0 && guests >= 1 && !quoteView.isLoading && !bookingView.isSubmitting;
+  const showRequestForm = quoteView.isQuoted && !hideAction;
 
   return (
     <aside className={styles.panel} aria-labelledby="website-quote-panel-title">
@@ -173,70 +341,36 @@ export default function QuotePanel({
         Check availability &amp; price
       </h3>
 
-      <div className={styles.stayBlock}>
-        <p className={styles.staySummary}>{resolveStaySummary({ checkIn, checkOut })}</p>
-        {nights > 0 ? <p className={styles.stayNights}>{pluralizeNights(nights)}</p> : null}
-        {minimumStay > 0 && !bookingSucceeded ? (
-          <p className={styles.hint}>{`Minimum stay: ${pluralizeNights(minimumStay)}`}</p>
-        ) : null}
-        {datesError ? (
-          <p className={styles.fieldError} role="alert">
-            {datesError}
-          </p>
-        ) : null}
-      </div>
+      <StayBlock
+        checkIn={checkIn}
+        checkOut={checkOut}
+        nights={nights}
+        minimumStay={minimumStay}
+        bookingSucceeded={bookingView.bookingSucceeded}
+        datesError={quoteView.datesError}
+      />
 
-      {bookingSucceeded ? (
+      {bookingView.bookingSucceeded ? (
         <BookingRequestSuccess result={bookingState.result} guestEmail={guest?.email || ""} />
       ) : (
-        <>
-          <GuestCountField
-            value={guests}
-            onChange={onGuestsChange}
-            max={capacity}
-            disabled={isLoading || isSubmitting}
-            errorMessage={guestsError}
-          />
-
-          {hideAction ? null : (
-            <button type="button" className={styles.action} onClick={onRequestQuote} disabled={!canRequestQuote}>
-              {isLoading ? "Checking…" : "Check availability"}
-            </button>
-          )}
-
-          {panelError ? (
-            <QuotePanelAlert
-              presentation={panelError}
-              requestId={quoteState.error?.requestId || ""}
-              contactHref={contactHref}
-              onRetry={onRequestQuote}
-            />
-          ) : null}
-
-          {showBreakdown ? (
-            <QuoteBreakdown quote={quoteState.quote} isStale={isStale} staleReason={quoteState.staleReason} />
-          ) : null}
-
-          {bookingPanelError ? (
-            <QuotePanelAlert
-              presentation={toAlertPresentation(bookingPanelError)}
-              requestId={bookingState.error?.requestId || ""}
-              contactHref={contactHref}
-              onRetry={onSubmitBookingRequest}
-            />
-          ) : null}
-
-          {showRequestForm ? (
-            <BookingRequestForm
-              guest={guest}
-              onGuestChange={onGuestChange}
-              onSubmit={onSubmitBookingRequest}
-              isSubmitting={isSubmitting}
-              fieldErrors={guestErrors}
-              formError={bookingContactError}
-            />
-          ) : null}
-        </>
+        <QuotePanelBody
+          guests={guests}
+          onGuestsChange={onGuestsChange}
+          capacity={capacity}
+          quoteState={quoteState}
+          quoteView={quoteView}
+          onRequestQuote={onRequestQuote}
+          contactHref={contactHref}
+          bookingState={bookingState}
+          bookingView={bookingView}
+          guest={guest}
+          guestErrors={guestErrors}
+          onGuestChange={onGuestChange}
+          onSubmitBookingRequest={onSubmitBookingRequest}
+          hideAction={hideAction}
+          canRequestQuote={canRequestQuote}
+          showRequestForm={showRequestForm}
+        />
       )}
     </aside>
   );
@@ -251,35 +385,12 @@ QuotePanel.propTypes = {
   onGuestsChange: PropTypes.func.isRequired,
   capacity: PropTypes.number,
   minimumStay: PropTypes.number,
-  quoteState: PropTypes.shape({
-    status: PropTypes.oneOf(Object.values(QUOTE_STATUS)).isRequired,
-    quote: PropTypes.shape({}),
-    error: PropTypes.shape({
-      code: PropTypes.string,
-      message: PropTypes.string,
-      requestId: PropTypes.string,
-    }),
-    staleReason: PropTypes.string,
-  }).isRequired,
+  quoteState: quoteStatePropType.isRequired,
   onRequestQuote: PropTypes.func.isRequired,
   contactHref: PropTypes.string,
-  bookingState: PropTypes.shape({
-    status: PropTypes.oneOf(Object.values(BOOKING_REQUEST_STATUS)).isRequired,
-    result: PropTypes.shape({}),
-    error: PropTypes.shape({
-      code: PropTypes.string,
-      message: PropTypes.string,
-      requestId: PropTypes.string,
-    }),
-  }),
-  guest: PropTypes.shape({
-    name: PropTypes.string,
-    email: PropTypes.string,
-  }),
-  guestErrors: PropTypes.shape({
-    name: PropTypes.string,
-    email: PropTypes.string,
-  }),
+  bookingState: bookingStatePropType,
+  guest: guestPropType,
+  guestErrors: guestPropType,
   onGuestChange: PropTypes.func,
   onSubmitBookingRequest: PropTypes.func,
 };

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/bookingRequestContact.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/bookingRequestContact.js
@@ -1,0 +1,27 @@
+export const BOOKING_GUEST_EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const MAX_CONTACT_FIELD_LENGTH = 255;
+
+export const BOOKING_GUEST_CONTACT_MESSAGES = Object.freeze({
+  name: "Please enter your name.",
+  email: "Please enter a valid email address.",
+});
+
+export const EMPTY_BOOKING_GUEST = Object.freeze({ name: "", email: "" });
+
+export const validateBookingGuestContact = (guest) => {
+  const name = String(guest?.name || "").trim();
+  const email = String(guest?.email || "")
+    .trim()
+    .toLowerCase();
+  const errors = {};
+
+  if (!name || name.length > MAX_CONTACT_FIELD_LENGTH) {
+    errors.name = BOOKING_GUEST_CONTACT_MESSAGES.name;
+  }
+  if (!email || email.length > MAX_CONTACT_FIELD_LENGTH || !BOOKING_GUEST_EMAIL_PATTERN.test(email)) {
+    errors.email = BOOKING_GUEST_CONTACT_MESSAGES.email;
+  }
+
+  return { guest: { name, email }, errors };
+};

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/bookingRequestContact.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/bookingRequestContact.js
@@ -1,4 +1,4 @@
-export const BOOKING_GUEST_EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+export const BOOKING_GUEST_EMAIL_PATTERN = /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/;
 
 const MAX_CONTACT_FIELD_LENGTH = 255;
 

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/bookingRequestErrorCopy.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/bookingRequestErrorCopy.js
@@ -1,0 +1,47 @@
+export const BOOKING_REQUEST_ERROR_SCOPES = Object.freeze({
+  CONTACT: "contact",
+  PANEL: "panel",
+});
+
+export const BOOKING_REQUEST_RECOVERY = Object.freeze({
+  NONE: "none",
+  RETRY: "retry",
+});
+
+const SITE_LIFECYCLE_CODES = new Set(["site_not_found", "site_not_published", "site_suspended"]);
+
+const presentation = ({
+  scope,
+  message,
+  recovery = BOOKING_REQUEST_RECOVERY.NONE,
+  hideAction = false,
+  showReference = false,
+}) => ({ scope, message, recovery, hideAction, showReference });
+
+export const resolveBookingRequestErrorPresentation = (error) => {
+  const code = String(error?.code || "");
+  const serverMessage = String(error?.message || "").trim();
+  const hasReference = Boolean(String(error?.requestId || "").trim());
+
+  if (code === "invalid_guest_contact") {
+    return presentation({
+      scope: BOOKING_REQUEST_ERROR_SCOPES.CONTACT,
+      message: serverMessage || "Please enter your name and a valid email address.",
+    });
+  }
+
+  if (SITE_LIFECYCLE_CODES.has(code)) {
+    return presentation({
+      scope: BOOKING_REQUEST_ERROR_SCOPES.PANEL,
+      message: "Online booking isn't available for this site right now.",
+      hideAction: true,
+    });
+  }
+
+  return presentation({
+    scope: BOOKING_REQUEST_ERROR_SCOPES.PANEL,
+    message: "We couldn't send your request. Please try again.",
+    recovery: BOOKING_REQUEST_RECOVERY.RETRY,
+    showReference: hasReference,
+  });
+};

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/bookingRequestIdempotency.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/bookingRequestIdempotency.js
@@ -1,0 +1,77 @@
+const STORAGE_KEY_PREFIX = "domits_direct_booking_website_booking_request:";
+
+const memoryRecords = new Map();
+
+const cleanText = (value) => String(value || "").trim();
+
+export const resolveBookingIdempotencyStorageKey = (siteId) => `${STORAGE_KEY_PREFIX}${cleanText(siteId)}`;
+
+const createFallbackUuid = () => {
+  const bytes = new Uint8Array(16);
+  if (globalThis.crypto?.getRandomValues) {
+    globalThis.crypto.getRandomValues(bytes);
+  } else {
+    for (let index = 0; index < bytes.length; index += 1) {
+      bytes[index] = Math.floor(Math.random() * 256);
+    }
+  }
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+};
+
+const createIdempotencyKey = () =>
+  globalThis.crypto?.randomUUID ? globalThis.crypto.randomUUID() : createFallbackUuid();
+
+const isUsableRecord = (record, quoteId) =>
+  Boolean(record) && record.quoteId === quoteId && Boolean(cleanText(record.idempotencyKey));
+
+const readStoredRecord = (storageKey) => {
+  try {
+    const rawRecord = globalThis.localStorage?.getItem(storageKey);
+    return rawRecord ? JSON.parse(rawRecord) : null;
+  } catch {
+    return null;
+  }
+};
+
+const writeStoredRecord = (storageKey, record) => {
+  try {
+    globalThis.localStorage?.setItem(storageKey, JSON.stringify(record));
+  } catch {
+    return;
+  }
+};
+
+export const getOrCreateBookingIdempotencyKey = ({ siteId, quoteId }) => {
+  const storageKey = resolveBookingIdempotencyStorageKey(siteId);
+  const normalizedQuoteId = cleanText(quoteId);
+
+  const storedRecord = readStoredRecord(storageKey);
+  if (isUsableRecord(storedRecord, normalizedQuoteId)) {
+    memoryRecords.set(storageKey, storedRecord);
+    return storedRecord.idempotencyKey;
+  }
+
+  const memoryRecord = memoryRecords.get(storageKey);
+  if (isUsableRecord(memoryRecord, normalizedQuoteId)) {
+    writeStoredRecord(storageKey, memoryRecord);
+    return memoryRecord.idempotencyKey;
+  }
+
+  const nextRecord = { quoteId: normalizedQuoteId, idempotencyKey: createIdempotencyKey(), createdAt: Date.now() };
+  memoryRecords.set(storageKey, nextRecord);
+  writeStoredRecord(storageKey, nextRecord);
+  return nextRecord.idempotencyKey;
+};
+
+export const clearBookingIdempotencyKey = (siteId) => {
+  const storageKey = resolveBookingIdempotencyStorageKey(siteId);
+  memoryRecords.delete(storageKey);
+  try {
+    globalThis.localStorage?.removeItem(storageKey);
+  } catch {
+    return;
+  }
+};

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/bookingRequestIdempotency.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/bookingRequestIdempotency.js
@@ -7,14 +7,7 @@ const cleanText = (value) => String(value || "").trim();
 export const resolveBookingIdempotencyStorageKey = (siteId) => `${STORAGE_KEY_PREFIX}${cleanText(siteId)}`;
 
 const createFallbackUuid = () => {
-  const bytes = new Uint8Array(16);
-  if (globalThis.crypto?.getRandomValues) {
-    globalThis.crypto.getRandomValues(bytes);
-  } else {
-    for (let index = 0; index < bytes.length; index += 1) {
-      bytes[index] = Math.floor(Math.random() * 256);
-    }
-  }
+  const bytes = globalThis.crypto.getRandomValues(new Uint8Array(16));
   bytes[6] = (bytes[6] & 0x0f) | 0x40;
   bytes[8] = (bytes[8] & 0x3f) | 0x80;
   const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
@@ -22,7 +15,7 @@ const createFallbackUuid = () => {
 };
 
 const createIdempotencyKey = () =>
-  globalThis.crypto?.randomUUID ? globalThis.crypto.randomUUID() : createFallbackUuid();
+  typeof globalThis.crypto.randomUUID === "function" ? globalThis.crypto.randomUUID() : createFallbackUuid();
 
 const isUsableRecord = (record, quoteId) =>
   Boolean(record) && record.quoteId === quoteId && Boolean(cleanText(record.idempotencyKey));

--- a/frontend/web/src/features/hostdashboard/website/rendering/booking/useWebsiteBookingRequest.js
+++ b/frontend/web/src/features/hostdashboard/website/rendering/booking/useWebsiteBookingRequest.js
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  WEBSITE_PUBLIC_BOOKING_CLIENT_ERROR_CODES,
+  WebsitePublicBookingError,
+  requestPublicSiteBooking,
+} from "../../services/websitePublicBookingService";
+import { clearBookingIdempotencyKey, getOrCreateBookingIdempotencyKey } from "./bookingRequestIdempotency";
+
+export const BOOKING_REQUEST_STATUS = Object.freeze({
+  IDLE: "idle",
+  SUBMITTING: "submitting",
+  SUCCESS: "success",
+  ERROR: "error",
+});
+
+const IDEMPOTENCY_KEY_REUSED_CODE = "idempotency_key_reused";
+
+const INITIAL_STATE = Object.freeze({
+  status: BOOKING_REQUEST_STATUS.IDLE,
+  result: null,
+  error: null,
+});
+
+const toBookingError = (error) =>
+  error instanceof WebsitePublicBookingError
+    ? error
+    : new WebsitePublicBookingError({ code: WEBSITE_PUBLIC_BOOKING_CLIENT_ERROR_CODES.UNEXPECTED_RESPONSE });
+
+export const useWebsiteBookingRequest = ({ siteId, sessionId }) => {
+  const [state, setState] = useState(INITIAL_STATE);
+  const abortControllerRef = useRef(null);
+
+  const submitBookingRequest = useCallback(
+    async ({ quote, guest }) => {
+      abortControllerRef.current?.abort();
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
+      setState({ status: BOOKING_REQUEST_STATUS.SUBMITTING, result: null, error: null });
+
+      const send = (idempotencyKey) =>
+        requestPublicSiteBooking({
+          siteId,
+          quoteToken: quote.quoteToken,
+          guest,
+          sessionId,
+          idempotencyKey,
+          signal: abortController.signal,
+        });
+
+      try {
+        let result;
+        try {
+          result = await send(getOrCreateBookingIdempotencyKey({ siteId, quoteId: quote.quoteId }));
+        } catch (error) {
+          if (error?.code !== IDEMPOTENCY_KEY_REUSED_CODE) {
+            throw error;
+          }
+          clearBookingIdempotencyKey(siteId);
+          result = await send(getOrCreateBookingIdempotencyKey({ siteId, quoteId: quote.quoteId }));
+        }
+
+        if (abortController.signal.aborted) {
+          return { ok: false, aborted: true };
+        }
+        clearBookingIdempotencyKey(siteId);
+        setState({ status: BOOKING_REQUEST_STATUS.SUCCESS, result, error: null });
+        return { ok: true, result };
+      } catch (error) {
+        if (abortController.signal.aborted || error?.name === "AbortError") {
+          return { ok: false, aborted: true };
+        }
+        const bookingError = toBookingError(error);
+        setState({ status: BOOKING_REQUEST_STATUS.ERROR, result: null, error: bookingError });
+        return { ok: false, error: bookingError };
+      }
+    },
+    [sessionId, siteId]
+  );
+
+  const reset = useCallback(() => {
+    abortControllerRef.current?.abort();
+    setState(INITIAL_STATE);
+  }, []);
+
+  useEffect(() => () => abortControllerRef.current?.abort(), []);
+
+  return { ...state, submitBookingRequest, reset };
+};

--- a/frontend/web/src/features/hostdashboard/website/services/websitePublicBookingService.js
+++ b/frontend/web/src/features/hostdashboard/website/services/websitePublicBookingService.js
@@ -1,9 +1,17 @@
 const DEFAULT_BOOKINGS_API_BASE = "https://92a7z9y2m5.execute-api.eu-north-1.amazonaws.com/development";
 const BOOKING_SESSION_SOURCE = "standalone_site";
 
-export const DIRECT_BOOKING_WEBSITE_BOOKINGS_API_BASE = String(
+const stripTrailingSlashes = (value) => {
+  let normalized = String(value || "");
+  while (normalized.endsWith("/")) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized;
+};
+
+export const DIRECT_BOOKING_WEBSITE_BOOKINGS_API_BASE = stripTrailingSlashes(
   process.env.REACT_APP_DIRECT_BOOKING_WEBSITE_BOOKINGS_API_BASE || DEFAULT_BOOKINGS_API_BASE
-).replace(/\/+$/, "");
+);
 
 export const WEBSITE_PUBLIC_BOOKING_CLIENT_ERROR_CODES = Object.freeze({
   NETWORK_ERROR: "network_error",

--- a/frontend/web/src/features/hostdashboard/website/services/websitePublicBookingService.js
+++ b/frontend/web/src/features/hostdashboard/website/services/websitePublicBookingService.js
@@ -1,0 +1,117 @@
+const DEFAULT_BOOKINGS_API_BASE = "https://92a7z9y2m5.execute-api.eu-north-1.amazonaws.com/development";
+const BOOKING_SESSION_SOURCE = "standalone_site";
+
+export const DIRECT_BOOKING_WEBSITE_BOOKINGS_API_BASE = String(
+  process.env.REACT_APP_DIRECT_BOOKING_WEBSITE_BOOKINGS_API_BASE || DEFAULT_BOOKINGS_API_BASE
+).replace(/\/+$/, "");
+
+export const WEBSITE_PUBLIC_BOOKING_CLIENT_ERROR_CODES = Object.freeze({
+  NETWORK_ERROR: "network_error",
+  RATE_LIMITED: "rate_limited",
+  UNEXPECTED_RESPONSE: "unexpected_response",
+});
+
+export class WebsitePublicBookingError extends Error {
+  constructor({ code, message = "", status = 0, requestId = "" }) {
+    super(message);
+    this.name = "WebsitePublicBookingError";
+    this.code = code;
+    this.status = status;
+    this.requestId = requestId;
+  }
+}
+
+export const buildPublicSiteBookingsUrl = (siteId) =>
+  `${DIRECT_BOOKING_WEBSITE_BOOKINGS_API_BASE}/public/sites/${encodeURIComponent(String(siteId || "").trim())}/bookings`;
+
+const parseJsonSafely = (rawBody) => {
+  try {
+    return rawBody ? JSON.parse(rawBody) : null;
+  } catch {
+    return null;
+  }
+};
+
+const unexpectedResponse = (status) =>
+  new WebsitePublicBookingError({
+    code: WEBSITE_PUBLIC_BOOKING_CLIENT_ERROR_CODES.UNEXPECTED_RESPONSE,
+    message: "The booking service returned an unexpected response.",
+    status,
+  });
+
+const normalizePublicSiteBooking = (payload) => {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const publicBookingRef = String(payload.publicBookingRef || "").trim();
+  const total = Number(payload.total);
+  if (!publicBookingRef || !Number.isFinite(total)) {
+    return null;
+  }
+
+  return {
+    publicBookingRef,
+    status: String(payload.status || ""),
+    siteId: String(payload.siteId || ""),
+    checkIn: String(payload.checkIn || ""),
+    checkOut: String(payload.checkOut || ""),
+    guests: Number.isFinite(Number(payload.guests)) ? Number(payload.guests) : 0,
+    total,
+    currency: String(payload.currency || "EUR"),
+  };
+};
+
+export const requestPublicSiteBooking = async ({ siteId, quoteToken, guest, sessionId, idempotencyKey, signal }) => {
+  let response;
+  try {
+    response = await fetch(buildPublicSiteBookingsUrl(siteId), {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Idempotency-Key": idempotencyKey },
+      cache: "no-store",
+      signal,
+      body: JSON.stringify({
+        quoteToken,
+        guest: { name: guest?.name, email: guest?.email },
+        session: { sessionId, source: BOOKING_SESSION_SOURCE },
+      }),
+    });
+  } catch (error) {
+    if (error?.name === "AbortError") {
+      throw error;
+    }
+    throw new WebsitePublicBookingError({
+      code: WEBSITE_PUBLIC_BOOKING_CLIENT_ERROR_CODES.NETWORK_ERROR,
+      message: "The booking request could not reach the server.",
+    });
+  }
+
+  const payload = parseJsonSafely(await response.text());
+
+  if (!response.ok) {
+    const errorBody = payload?.error;
+    if (errorBody?.code) {
+      throw new WebsitePublicBookingError({
+        code: String(errorBody.code),
+        message: String(errorBody.message || ""),
+        status: response.status,
+        requestId: String(errorBody.requestId || ""),
+      });
+    }
+    if (response.status === 429) {
+      throw new WebsitePublicBookingError({
+        code: WEBSITE_PUBLIC_BOOKING_CLIENT_ERROR_CODES.RATE_LIMITED,
+        message: "Too many booking requests.",
+        status: response.status,
+      });
+    }
+    throw unexpectedResponse(response.status);
+  }
+
+  const booking = normalizePublicSiteBooking(payload);
+  if (!booking) {
+    throw unexpectedResponse(response.status);
+  }
+
+  return booking;
+};

--- a/frontend/web/src/features/hostdashboard/website/tests/BookingRequestForm.test.jsx
+++ b/frontend/web/src/features/hostdashboard/website/tests/BookingRequestForm.test.jsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import BookingRequestForm from "../rendering/booking/BookingRequestForm";
+
+const renderForm = (props = {}) => {
+  const onGuestChange = jest.fn();
+  const onSubmit = jest.fn();
+  const utils = render(
+    <BookingRequestForm
+      guest={{ name: "", email: "" }}
+      onGuestChange={onGuestChange}
+      onSubmit={onSubmit}
+      isSubmitting={false}
+      fieldErrors={{}}
+      formError=""
+      {...props}
+    />
+  );
+  return { ...utils, onGuestChange, onSubmit };
+};
+
+describe("BookingRequestForm", () => {
+  it("collects a name and an email and submits without reloading the page", () => {
+    const { onGuestChange, onSubmit } = renderForm({ guest: { name: "Guest Name", email: "guest@example.com" } });
+
+    fireEvent.change(screen.getByLabelText("Your name"), { target: { value: "Guest Name Two" } });
+    expect(onGuestChange).toHaveBeenCalledWith("name", "Guest Name Two");
+
+    fireEvent.change(screen.getByLabelText("Email address"), { target: { value: "two@example.com" } });
+    expect(onGuestChange).toHaveBeenCalledWith("email", "two@example.com");
+
+    fireEvent.click(screen.getByRole("button", { name: "Request to book" }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("says the host still has to confirm before anything is booked", () => {
+    renderForm();
+    expect(screen.getByText(/nothing is booked until the host confirms/i)).toBeInTheDocument();
+  });
+
+  it("shows field errors next to their inputs and links them for screen readers", () => {
+    renderForm({ fieldErrors: { name: "Please enter your name.", email: "Please enter a valid email address." } });
+
+    expect(screen.getByLabelText("Your name")).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByLabelText("Your name")).toHaveAccessibleDescription("Please enter your name.");
+    expect(screen.getByLabelText("Email address")).toHaveAccessibleDescription("Please enter a valid email address.");
+  });
+
+  it("shows a form-level error from the server", () => {
+    renderForm({ formError: "Please provide your name and a valid email address." });
+    expect(screen.getByRole("alert")).toHaveTextContent("Please provide your name and a valid email address.");
+  });
+
+  it("locks the fields and relabels the button while sending", () => {
+    renderForm({ isSubmitting: true, guest: { name: "Guest", email: "guest@example.com" } });
+
+    expect(screen.getByLabelText("Your name")).toBeDisabled();
+    expect(screen.getByLabelText("Email address")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Sending…" })).toBeDisabled();
+  });
+});

--- a/frontend/web/src/features/hostdashboard/website/tests/QuoteAvailabilitySection.test.jsx
+++ b/frontend/web/src/features/hostdashboard/website/tests/QuoteAvailabilitySection.test.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import QuoteAvailabilitySection from "../rendering/booking/QuoteAvailabilitySection";
 import { WebsitePublicQuoteError, requestPublicWebsiteQuote } from "../services/websitePublicQuoteService";
+import { WebsitePublicBookingError, requestPublicSiteBooking } from "../services/websitePublicBookingService";
 import "../rendering/AvailabilityCalendarPreview";
 
 jest.mock("../services/websitePublicQuoteService", () => {
@@ -12,6 +13,11 @@ jest.mock("../services/websitePublicQuoteService", () => {
 jest.mock("../services/websiteVisitorId", () => ({
   getOrCreateVisitorId: () => "visitor-test",
 }));
+
+jest.mock("../services/websitePublicBookingService", () => {
+  const actual = jest.requireActual("../services/websitePublicBookingService");
+  return { ...actual, requestPublicSiteBooking: jest.fn() };
+});
 
 const padDatePart = (value) => String(value).padStart(2, "0");
 const toKey = (date) => `${date.getFullYear()}-${padDatePart(date.getMonth() + 1)}-${padDatePart(date.getDate())}`;
@@ -41,7 +47,15 @@ const QUOTE = {
   quoteId: "quote_1",
   nights: 3,
   guestCount: 2,
-  priceBreakdown: { currency: "EUR", nightlyBaseTotal: 57000, cleaningFee: 5000, discounts: [], taxes: [], fees: [], total: 62000 },
+  priceBreakdown: {
+    currency: "EUR",
+    nightlyBaseTotal: 57000,
+    cleaningFee: 5000,
+    discounts: [],
+    taxes: [],
+    fees: [],
+    total: 62000,
+  },
   expiresAt: "2099-01-01T10:30:00.000Z",
   quoteToken: "qtok",
 };
@@ -115,5 +129,91 @@ describe("QuoteAvailabilitySection", () => {
 
     expect(await screen.findByText(/no longer available/i)).toBeInTheDocument();
     expect(screen.getByText("Pick a check-in date")).toBeInTheDocument();
+  });
+
+  describe("booking request", () => {
+    const RESULT = {
+      publicBookingRef: "DBW-ABCDEFGHJK",
+      status: "REQUESTED",
+      siteId: "site-1",
+      checkIn: toKey(checkInDate),
+      checkOut: toKey(checkOutDate),
+      guests: 2,
+      total: 62000,
+      currency: "EUR",
+    };
+    const bookingError = (code, status) =>
+      new WebsitePublicBookingError({ code, message: "", status, requestId: "req-1" });
+
+    const getQuote = async () => {
+      await selectStay();
+      fireEvent.click(screen.getByRole("button", { name: /^check availability$/i }));
+      await screen.findByText("€620.00");
+    };
+
+    const fillContact = () => {
+      fireEvent.change(screen.getByLabelText("Your name"), { target: { value: "Guest Name" } });
+      fireEvent.change(screen.getByLabelText("Email address"), { target: { value: "guest@example.com" } });
+    };
+
+    const submitRequest = () => fireEvent.click(screen.getByRole("button", { name: "Request to book" }));
+
+    beforeEach(() => {
+      requestPublicSiteBooking.mockReset();
+      globalThis.localStorage.clear();
+    });
+
+    it("sends the quoted stay with the guest's details and shows the booking reference", async () => {
+      requestPublicWebsiteQuote.mockResolvedValue(QUOTE);
+      requestPublicSiteBooking.mockResolvedValue(RESULT);
+      renderSection();
+
+      await getQuote();
+      fillContact();
+      submitRequest();
+
+      expect(await screen.findByText("Request sent")).toBeInTheDocument();
+      expect(screen.getByText("DBW-ABCDEFGHJK")).toBeInTheDocument();
+      expect(screen.getByText(/still has to confirm/i)).toBeInTheDocument();
+      expect(requestPublicSiteBooking).toHaveBeenCalledWith(
+        expect.objectContaining({
+          siteId: "site-1",
+          quoteToken: "qtok",
+          guest: { name: "Guest Name", email: "guest@example.com" },
+          sessionId: "visitor-test",
+          idempotencyKey: expect.any(String),
+        })
+      );
+    });
+
+    it("validates the contact details before calling the endpoint", async () => {
+      requestPublicWebsiteQuote.mockResolvedValue(QUOTE);
+      renderSection();
+
+      await getQuote();
+      fireEvent.change(screen.getByLabelText("Email address"), { target: { value: "not-an-email" } });
+      submitRequest();
+
+      expect(screen.getByText("Please enter your name.")).toBeInTheDocument();
+      expect(screen.getByText("Please enter a valid email address.")).toBeInTheDocument();
+      expect(requestPublicSiteBooking).not.toHaveBeenCalled();
+    });
+
+    it("retries with the same key after a transient failure", async () => {
+      requestPublicWebsiteQuote.mockResolvedValue(QUOTE);
+      requestPublicSiteBooking.mockRejectedValueOnce(bookingError("network_error", 0)).mockResolvedValueOnce(RESULT);
+      renderSection();
+
+      await getQuote();
+      fillContact();
+      submitRequest();
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(/couldn't send your request/i);
+      fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+      expect(await screen.findByText("Request sent")).toBeInTheDocument();
+      const [firstCall, secondCall] = requestPublicSiteBooking.mock.calls;
+      expect(secondCall[0].idempotencyKey).toBe(firstCall[0].idempotencyKey);
+    });
   });
 });

--- a/frontend/web/src/features/hostdashboard/website/tests/QuotePanel.test.jsx
+++ b/frontend/web/src/features/hostdashboard/website/tests/QuotePanel.test.jsx
@@ -2,12 +2,21 @@ import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import QuotePanel from "../rendering/booking/QuotePanel";
 import { QUOTE_STATUS } from "../rendering/booking/useWebsiteQuote";
+import { BOOKING_REQUEST_STATUS } from "../rendering/booking/useWebsiteBookingRequest";
 
 const QUOTE = {
   quoteId: "quote_1",
   nights: 4,
   guestCount: 2,
-  priceBreakdown: { currency: "EUR", nightlyBaseTotal: 76000, cleaningFee: 5000, discounts: [], taxes: [], fees: [], total: 81000 },
+  priceBreakdown: {
+    currency: "EUR",
+    nightlyBaseTotal: 76000,
+    cleaningFee: 5000,
+    discounts: [],
+    taxes: [],
+    fees: [],
+    total: 81000,
+  },
   expiresAt: "2099-01-01T10:30:00.000Z",
   quoteToken: "qtok",
 };
@@ -202,5 +211,133 @@ describe("QuotePanel", () => {
       />
     );
     expect(screen.getByRole("button", { name: /add a guest/i })).toBeDisabled();
+  });
+
+  describe("booking request", () => {
+    const QUOTED = { ...IDLE, status: QUOTE_STATUS.SUCCESS, quote: QUOTE };
+    const NO_BOOKING = { status: BOOKING_REQUEST_STATUS.IDLE, result: null, error: null };
+    const GUEST = { name: "Guest Name", email: "guest@example.com" };
+    const RESULT = {
+      publicBookingRef: "DBW-ABCDEFGHJK",
+      status: "REQUESTED",
+      siteId: "site-1",
+      checkIn: "2026-10-10",
+      checkOut: "2026-10-14",
+      guests: 2,
+      total: 81000,
+      currency: "EUR",
+    };
+    const bookingError = (code, message = "", status = 400) => ({
+      status: BOOKING_REQUEST_STATUS.ERROR,
+      result: null,
+      error: { code, message, status, requestId: "req-7" },
+    });
+    const requestButton = () => screen.queryByRole("button", { name: "Request to book" });
+
+    const renderQuotedPanel = (props = {}) => {
+      const onGuestChange = jest.fn();
+      const onSubmitBookingRequest = jest.fn();
+      const utils = renderPanel({
+        range: COMPLETE_RANGE,
+        quoteState: QUOTED,
+        bookingState: NO_BOOKING,
+        guest: GUEST,
+        guestErrors: {},
+        onGuestChange,
+        onSubmitBookingRequest,
+        ...props,
+      });
+      return { ...utils, onGuestChange, onSubmitBookingRequest };
+    };
+
+    it("only offers the request form once a fresh quote is on screen", () => {
+      const { rerender } = renderQuotedPanel({ quoteState: IDLE });
+      expect(requestButton()).not.toBeInTheDocument();
+
+      rerender(
+        <QuotePanel
+          range={COMPLETE_RANGE}
+          guests={2}
+          onGuestsChange={jest.fn()}
+          quoteState={{ ...IDLE, status: QUOTE_STATUS.STALE, quote: QUOTE, staleReason: "changed" }}
+          onRequestQuote={jest.fn()}
+          bookingState={NO_BOOKING}
+          guest={GUEST}
+          onGuestChange={jest.fn()}
+          onSubmitBookingRequest={jest.fn()}
+        />
+      );
+      expect(requestButton()).not.toBeInTheDocument();
+
+      rerender(
+        <QuotePanel
+          range={COMPLETE_RANGE}
+          guests={2}
+          onGuestsChange={jest.fn()}
+          quoteState={QUOTED}
+          onRequestQuote={jest.fn()}
+          bookingState={NO_BOOKING}
+          guest={GUEST}
+          onGuestChange={jest.fn()}
+          onSubmitBookingRequest={jest.fn()}
+        />
+      );
+      expect(requestButton()).toBeInTheDocument();
+      expect(screen.getByText("€810.00")).toBeInTheDocument();
+    });
+
+    it("hands the guest details and the submit up to the section", () => {
+      const { onGuestChange, onSubmitBookingRequest } = renderQuotedPanel();
+
+      fireEvent.change(screen.getByLabelText("Your name"), { target: { value: "Someone Else" } });
+      expect(onGuestChange).toHaveBeenCalledWith("name", "Someone Else");
+
+      fireEvent.click(requestButton());
+      expect(onSubmitBookingRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it("replaces the panel body with the confirmation after a successful request", () => {
+      renderQuotedPanel({ bookingState: { status: BOOKING_REQUEST_STATUS.SUCCESS, result: RESULT, error: null } });
+
+      expect(screen.getByRole("status")).toHaveTextContent("Request sent");
+      expect(screen.getByText("DBW-ABCDEFGHJK")).toBeInTheDocument();
+      expect(screen.getByText(/still has to confirm/i)).toBeInTheDocument();
+      expect(screen.getByText(/guest@example\.com/)).toBeInTheDocument();
+      expect(screen.getByText("€810.00")).toBeInTheDocument();
+      expect(actionButton()).not.toBeInTheDocument();
+      expect(requestButton()).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /add a guest/i })).not.toBeInTheDocument();
+    });
+
+    it("shows a rejected contact on the form", () => {
+      renderQuotedPanel({ bookingState: bookingError("invalid_guest_contact", "Please provide a valid email.") });
+      expect(screen.getByRole("alert")).toHaveTextContent("Please provide a valid email.");
+      expect(requestButton()).toBeInTheDocument();
+    });
+
+    it("offers a retry that resubmits the same request", () => {
+      const { onSubmitBookingRequest } = renderQuotedPanel({ bookingState: bookingError("network_error", "", 0) });
+      expect(screen.getByRole("alert")).toHaveTextContent(/couldn't send your request/i);
+      fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+      expect(onSubmitBookingRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows the reference for an unexpected failure", () => {
+      renderQuotedPanel({ bookingState: bookingError("internal_error", "", 500) });
+      expect(screen.getByText(/reference: req-7/i)).toBeInTheDocument();
+    });
+
+    it("hides the form when the site can no longer take requests", () => {
+      renderQuotedPanel({ bookingState: bookingError("site_suspended", "", 410) });
+      expect(requestButton()).not.toBeInTheDocument();
+      expect(actionButton()).not.toBeInTheDocument();
+      expect(screen.getByRole("alert")).toHaveTextContent(/isn't available/i);
+    });
+
+    it("locks the form while the request is being sent", () => {
+      renderQuotedPanel({ bookingState: { status: BOOKING_REQUEST_STATUS.SUBMITTING, result: null, error: null } });
+      expect(screen.getByRole("button", { name: "Sending…" })).toBeDisabled();
+      expect(screen.getByLabelText("Your name")).toBeDisabled();
+    });
   });
 });

--- a/frontend/web/src/features/hostdashboard/website/tests/bookingRequestErrorCopy.test.js
+++ b/frontend/web/src/features/hostdashboard/website/tests/bookingRequestErrorCopy.test.js
@@ -3,7 +3,7 @@ import {
   BOOKING_REQUEST_RECOVERY,
   resolveBookingRequestErrorPresentation,
 } from "../rendering/booking/bookingRequestErrorCopy";
-import { validateBookingGuestContact } from "../rendering/booking/bookingRequestContact";
+import { BOOKING_GUEST_EMAIL_PATTERN, validateBookingGuestContact } from "../rendering/booking/bookingRequestContact";
 
 const buildError = (code, overrides = {}) => ({
   code,
@@ -76,5 +76,17 @@ describe("validateBookingGuestContact", () => {
 
   it("reports both fields when both are missing", () => {
     expect(Object.keys(validateBookingGuestContact({ name: "", email: "" }).errors).sort()).toEqual(["email", "name"]);
+  });
+
+  it("rejects a pathological address in linear time", () => {
+    const email = `a@${"b.".repeat(50000)} `;
+    expect(BOOKING_GUEST_EMAIL_PATTERN.test(email)).toBe(false);
+  });
+
+  it("accepts subdomains and rejects consecutive or trailing dots", () => {
+    expect(BOOKING_GUEST_EMAIL_PATTERN.test("guest@mail.example.co.uk")).toBe(true);
+    expect(BOOKING_GUEST_EMAIL_PATTERN.test("guest@example..com")).toBe(false);
+    expect(BOOKING_GUEST_EMAIL_PATTERN.test("guest@example.com.")).toBe(false);
+    expect(BOOKING_GUEST_EMAIL_PATTERN.test("guest@example")).toBe(false);
   });
 });

--- a/frontend/web/src/features/hostdashboard/website/tests/bookingRequestErrorCopy.test.js
+++ b/frontend/web/src/features/hostdashboard/website/tests/bookingRequestErrorCopy.test.js
@@ -1,0 +1,80 @@
+import {
+  BOOKING_REQUEST_ERROR_SCOPES,
+  BOOKING_REQUEST_RECOVERY,
+  resolveBookingRequestErrorPresentation,
+} from "../rendering/booking/bookingRequestErrorCopy";
+import { validateBookingGuestContact } from "../rendering/booking/bookingRequestContact";
+
+const buildError = (code, overrides = {}) => ({
+  code,
+  message: "Server says so.",
+  status: 400,
+  requestId: "req-1",
+  ...overrides,
+});
+
+describe("resolveBookingRequestErrorPresentation", () => {
+  it("puts a rejected guest contact on the form with the server message", () => {
+    const presentation = resolveBookingRequestErrorPresentation(buildError("invalid_guest_contact"));
+    expect(presentation.scope).toBe(BOOKING_REQUEST_ERROR_SCOPES.CONTACT);
+    expect(presentation.message).toBe("Server says so.");
+    expect(presentation.recovery).toBe(BOOKING_REQUEST_RECOVERY.NONE);
+  });
+
+  it.each(["site_not_found", "site_not_published", "site_suspended"])(
+    "hides the whole action for a site lifecycle problem (%s)",
+    (code) => {
+      const presentation = resolveBookingRequestErrorPresentation(buildError(code));
+      expect(presentation.scope).toBe(BOOKING_REQUEST_ERROR_SCOPES.PANEL);
+      expect(presentation.hideAction).toBe(true);
+      expect(presentation.message).toMatch(/isn't available/i);
+    }
+  );
+
+  it.each(["quote_expired", "unavailable_dates", "network_error", "rate_limited", "internal_error", "something_new"])(
+    "offers a retry with the same key and the reference for everything else (%s)",
+    (code) => {
+      const presentation = resolveBookingRequestErrorPresentation(buildError(code));
+      expect(presentation.scope).toBe(BOOKING_REQUEST_ERROR_SCOPES.PANEL);
+      expect(presentation.recovery).toBe(BOOKING_REQUEST_RECOVERY.RETRY);
+      expect(presentation.showReference).toBe(true);
+      expect(presentation.message).toMatch(/couldn't send your request/i);
+    }
+  );
+
+  it("does not show a reference when the error carries none", () => {
+    expect(resolveBookingRequestErrorPresentation(buildError("internal_error", { requestId: "" })).showReference).toBe(
+      false
+    );
+  });
+
+  it("survives a missing error object", () => {
+    const presentation = resolveBookingRequestErrorPresentation(null);
+    expect(presentation.scope).toBe(BOOKING_REQUEST_ERROR_SCOPES.PANEL);
+    expect(presentation.recovery).toBe(BOOKING_REQUEST_RECOVERY.RETRY);
+  });
+});
+
+describe("validateBookingGuestContact", () => {
+  it("accepts a name and a plausible email, trimmed", () => {
+    expect(validateBookingGuestContact({ name: "  Guest Name ", email: " Guest@Example.com " })).toEqual({
+      guest: { name: "Guest Name", email: "guest@example.com" },
+      errors: {},
+    });
+  });
+
+  it.each([
+    ["missing name", { name: "", email: "guest@example.com" }, "name"],
+    ["missing email", { name: "Guest", email: "" }, "email"],
+    ["malformed email", { name: "Guest", email: "not-an-email" }, "email"],
+    ["email with spaces", { name: "Guest", email: "guest @example.com" }, "email"],
+  ])("rejects %s", (_label, guest, field) => {
+    const { errors } = validateBookingGuestContact(guest);
+    expect(Object.keys(errors)).toEqual([field]);
+    expect(errors[field]).toEqual(expect.any(String));
+  });
+
+  it("reports both fields when both are missing", () => {
+    expect(Object.keys(validateBookingGuestContact({ name: "", email: "" }).errors).sort()).toEqual(["email", "name"]);
+  });
+});

--- a/frontend/web/src/features/hostdashboard/website/tests/bookingRequestIdempotency.test.js
+++ b/frontend/web/src/features/hostdashboard/website/tests/bookingRequestIdempotency.test.js
@@ -1,0 +1,77 @@
+import {
+  clearBookingIdempotencyKey,
+  getOrCreateBookingIdempotencyKey,
+  resolveBookingIdempotencyStorageKey,
+} from "../rendering/booking/bookingRequestIdempotency";
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+describe("booking request idempotency key", () => {
+  afterEach(() => {
+    globalThis.localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  it("creates a UUID key and persists it per site", () => {
+    const key = getOrCreateBookingIdempotencyKey({ siteId: "site-1", quoteId: "quote_1" });
+
+    expect(key).toMatch(UUID_PATTERN);
+    const stored = JSON.parse(globalThis.localStorage.getItem(resolveBookingIdempotencyStorageKey("site-1")));
+    expect(stored).toMatchObject({ quoteId: "quote_1", idempotencyKey: key });
+    expect(typeof stored.createdAt).toBe("number");
+  });
+
+  it("returns the same key for the same quote so a retry replays instead of double-booking", () => {
+    const first = getOrCreateBookingIdempotencyKey({ siteId: "site-1", quoteId: "quote_1" });
+    const second = getOrCreateBookingIdempotencyKey({ siteId: "site-1", quoteId: "quote_1" });
+
+    expect(second).toBe(first);
+  });
+
+  it("rotates the key when the quote changes", () => {
+    const first = getOrCreateBookingIdempotencyKey({ siteId: "site-1", quoteId: "quote_1" });
+    const second = getOrCreateBookingIdempotencyKey({ siteId: "site-1", quoteId: "quote_2" });
+
+    expect(second).not.toBe(first);
+    expect(JSON.parse(globalThis.localStorage.getItem(resolveBookingIdempotencyStorageKey("site-1")))).toMatchObject({
+      quoteId: "quote_2",
+      idempotencyKey: second,
+    });
+  });
+
+  it("keeps sites apart", () => {
+    const siteOne = getOrCreateBookingIdempotencyKey({ siteId: "site-1", quoteId: "quote_1" });
+    const siteTwo = getOrCreateBookingIdempotencyKey({ siteId: "site-2", quoteId: "quote_1" });
+
+    expect(siteTwo).not.toBe(siteOne);
+  });
+
+  it("clears the stored key after a successful request", () => {
+    getOrCreateBookingIdempotencyKey({ siteId: "site-1", quoteId: "quote_1" });
+
+    clearBookingIdempotencyKey("site-1");
+
+    expect(globalThis.localStorage.getItem(resolveBookingIdempotencyStorageKey("site-1"))).toBeNull();
+  });
+
+  it("regenerates when the stored value is corrupt", () => {
+    globalThis.localStorage.setItem(resolveBookingIdempotencyStorageKey("site-1"), "{not json");
+
+    expect(getOrCreateBookingIdempotencyKey({ siteId: "site-1", quoteId: "quote_1" })).toMatch(UUID_PATTERN);
+  });
+
+  it("still returns a stable key within the session when storage is unavailable", () => {
+    jest.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+
+    const first = getOrCreateBookingIdempotencyKey({ siteId: "site-9", quoteId: "quote_1" });
+    const second = getOrCreateBookingIdempotencyKey({ siteId: "site-9", quoteId: "quote_1" });
+
+    expect(first).toMatch(UUID_PATTERN);
+    expect(second).toBe(first);
+  });
+});

--- a/frontend/web/src/features/hostdashboard/website/tests/bookingRequestIdempotency.test.js
+++ b/frontend/web/src/features/hostdashboard/website/tests/bookingRequestIdempotency.test.js
@@ -54,6 +54,24 @@ describe("booking request idempotency key", () => {
     expect(globalThis.localStorage.getItem(resolveBookingIdempotencyStorageKey("site-1"))).toBeNull();
   });
 
+  it("falls back to crypto.getRandomValues when randomUUID is unavailable", () => {
+    const originalRandomUuid = globalThis.crypto.randomUUID;
+    Object.defineProperty(globalThis.crypto, "randomUUID", { value: undefined, configurable: true, writable: true });
+    const getRandomValues = jest.spyOn(globalThis.crypto, "getRandomValues");
+
+    try {
+      const key = getOrCreateBookingIdempotencyKey({ siteId: "site-7", quoteId: "quote_1" });
+      expect(key).toMatch(UUID_PATTERN);
+      expect(getRandomValues).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(globalThis.crypto, "randomUUID", {
+        value: originalRandomUuid,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
   it("regenerates when the stored value is corrupt", () => {
     globalThis.localStorage.setItem(resolveBookingIdempotencyStorageKey("site-1"), "{not json");
 

--- a/frontend/web/src/features/hostdashboard/website/tests/useWebsiteBookingRequest.test.js
+++ b/frontend/web/src/features/hostdashboard/website/tests/useWebsiteBookingRequest.test.js
@@ -1,0 +1,180 @@
+import { act, renderHook } from "@testing-library/react";
+import { BOOKING_REQUEST_STATUS, useWebsiteBookingRequest } from "../rendering/booking/useWebsiteBookingRequest";
+import { WebsitePublicBookingError, requestPublicSiteBooking } from "../services/websitePublicBookingService";
+import { resolveBookingIdempotencyStorageKey } from "../rendering/booking/bookingRequestIdempotency";
+
+jest.mock("../services/websitePublicBookingService", () => {
+  const actual = jest.requireActual("../services/websitePublicBookingService");
+  return { ...actual, requestPublicSiteBooking: jest.fn() };
+});
+
+const QUOTE = {
+  quoteId: "quote_1",
+  quoteToken: "qtok_abc",
+  checkIn: "2026-10-01",
+  checkOut: "2026-10-05",
+  guestCount: 2,
+};
+const GUEST = { name: "Guest Name", email: "guest@example.com" };
+const RESULT = {
+  publicBookingRef: "DBW-ABCDEFGHJK",
+  status: "REQUESTED",
+  siteId: "site-1",
+  checkIn: "2026-10-01",
+  checkOut: "2026-10-05",
+  guests: 2,
+  total: 81000,
+  currency: "EUR",
+};
+
+const bookingError = (code, status = 400) =>
+  new WebsitePublicBookingError({ code, message: "", status, requestId: "req-1" });
+
+const sentIdempotencyKeys = () => requestPublicSiteBooking.mock.calls.map(([request]) => request.idempotencyKey);
+
+const renderBookingHook = () =>
+  renderHook(() => useWebsiteBookingRequest({ siteId: "site-1", sessionId: "visitor-1" }));
+
+describe("useWebsiteBookingRequest", () => {
+  beforeEach(() => {
+    requestPublicSiteBooking.mockReset();
+    globalThis.localStorage.clear();
+  });
+
+  it("submits the quote token with the guest, session and a generated Idempotency-Key", async () => {
+    requestPublicSiteBooking.mockResolvedValue(RESULT);
+    const { result } = renderBookingHook();
+
+    await act(async () => {
+      await result.current.submitBookingRequest({ quote: QUOTE, guest: GUEST });
+    });
+
+    expect(requestPublicSiteBooking).toHaveBeenCalledWith(
+      expect.objectContaining({
+        siteId: "site-1",
+        quoteToken: "qtok_abc",
+        guest: GUEST,
+        sessionId: "visitor-1",
+        idempotencyKey: expect.any(String),
+      })
+    );
+    expect(result.current.status).toBe(BOOKING_REQUEST_STATUS.SUCCESS);
+    expect(result.current.result).toEqual(RESULT);
+  });
+
+  it("clears the stored key once the request succeeded", async () => {
+    requestPublicSiteBooking.mockResolvedValue(RESULT);
+    const { result } = renderBookingHook();
+
+    await act(async () => {
+      await result.current.submitBookingRequest({ quote: QUOTE, guest: GUEST });
+    });
+
+    expect(globalThis.localStorage.getItem(resolveBookingIdempotencyStorageKey("site-1"))).toBeNull();
+  });
+
+  it("reuses the same key when the guest retries after a transient failure", async () => {
+    requestPublicSiteBooking.mockRejectedValueOnce(bookingError("network_error", 0)).mockResolvedValueOnce(RESULT);
+    const { result } = renderBookingHook();
+
+    await act(async () => {
+      await result.current.submitBookingRequest({ quote: QUOTE, guest: GUEST });
+    });
+    expect(result.current.status).toBe(BOOKING_REQUEST_STATUS.ERROR);
+    expect(result.current.error).toMatchObject({ code: "network_error" });
+
+    await act(async () => {
+      await result.current.submitBookingRequest({ quote: QUOTE, guest: GUEST });
+    });
+
+    const [firstKey, secondKey] = sentIdempotencyKeys();
+    expect(secondKey).toBe(firstKey);
+    expect(result.current.status).toBe(BOOKING_REQUEST_STATUS.SUCCESS);
+  });
+
+  it("uses a new key for a new quote", async () => {
+    requestPublicSiteBooking.mockRejectedValueOnce(bookingError("quote_expired", 409)).mockResolvedValueOnce(RESULT);
+    const { result } = renderBookingHook();
+
+    await act(async () => {
+      await result.current.submitBookingRequest({ quote: QUOTE, guest: GUEST });
+    });
+    await act(async () => {
+      await result.current.submitBookingRequest({
+        quote: { ...QUOTE, quoteId: "quote_2", quoteToken: "qtok_def" },
+        guest: GUEST,
+      });
+    });
+
+    const [firstKey, secondKey] = sentIdempotencyKeys();
+    expect(secondKey).not.toBe(firstKey);
+  });
+
+  it("rotates the key and retries once when the server says the key was reused", async () => {
+    requestPublicSiteBooking
+      .mockRejectedValueOnce(bookingError("idempotency_key_reused", 422))
+      .mockResolvedValueOnce(RESULT);
+    const { result } = renderBookingHook();
+
+    await act(async () => {
+      await result.current.submitBookingRequest({ quote: QUOTE, guest: GUEST });
+    });
+
+    expect(requestPublicSiteBooking).toHaveBeenCalledTimes(2);
+    const [firstKey, secondKey] = sentIdempotencyKeys();
+    expect(secondKey).not.toBe(firstKey);
+    expect(result.current.status).toBe(BOOKING_REQUEST_STATUS.SUCCESS);
+  });
+
+  it("gives up after one key rotation", async () => {
+    requestPublicSiteBooking.mockRejectedValue(bookingError("idempotency_key_reused", 422));
+    const { result } = renderBookingHook();
+
+    await act(async () => {
+      await result.current.submitBookingRequest({ quote: QUOTE, guest: GUEST });
+    });
+
+    expect(requestPublicSiteBooking).toHaveBeenCalledTimes(2);
+    expect(result.current.status).toBe(BOOKING_REQUEST_STATUS.ERROR);
+    expect(result.current.error).toMatchObject({ code: "idempotency_key_reused" });
+  });
+
+  it("returns the error to the caller and exposes it as state", async () => {
+    requestPublicSiteBooking.mockRejectedValue(bookingError("unavailable_dates", 409));
+    const { result } = renderBookingHook();
+
+    let outcome;
+    await act(async () => {
+      outcome = await result.current.submitBookingRequest({ quote: QUOTE, guest: GUEST });
+    });
+
+    expect(outcome).toMatchObject({ ok: false, error: { code: "unavailable_dates" } });
+    expect(result.current.error).toMatchObject({ code: "unavailable_dates" });
+  });
+
+  it("wraps a non-service failure as unexpected_response", async () => {
+    requestPublicSiteBooking.mockRejectedValue(new Error("boom"));
+    const { result } = renderBookingHook();
+
+    await act(async () => {
+      await result.current.submitBookingRequest({ quote: QUOTE, guest: GUEST });
+    });
+
+    expect(result.current.error).toMatchObject({ code: "unexpected_response" });
+  });
+
+  it("resets back to idle", async () => {
+    requestPublicSiteBooking.mockRejectedValue(bookingError("network_error", 0));
+    const { result } = renderBookingHook();
+
+    await act(async () => {
+      await result.current.submitBookingRequest({ quote: QUOTE, guest: GUEST });
+    });
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.status).toBe(BOOKING_REQUEST_STATUS.IDLE);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/frontend/web/src/features/hostdashboard/website/tests/websitePublicBookingService.test.js
+++ b/frontend/web/src/features/hostdashboard/website/tests/websitePublicBookingService.test.js
@@ -1,0 +1,140 @@
+import {
+  DIRECT_BOOKING_WEBSITE_BOOKINGS_API_BASE,
+  WEBSITE_PUBLIC_BOOKING_CLIENT_ERROR_CODES,
+  WebsitePublicBookingError,
+  requestPublicSiteBooking,
+} from "../services/websitePublicBookingService";
+
+const BOOKING_REQUEST = {
+  siteId: "site-1",
+  quoteToken: "qtok_abc",
+  guest: { name: "Guest Name", email: "guest@example.com" },
+  sessionId: "visitor-1",
+  idempotencyKey: "idem-1",
+};
+
+const BOOKING_RESPONSE = {
+  publicBookingRef: "DBW-ABCDEFGHJK",
+  status: "REQUESTED",
+  siteId: "site-1",
+  checkIn: "2026-10-01",
+  checkOut: "2026-10-05",
+  guests: 2,
+  total: 81000,
+  currency: "EUR",
+};
+
+const mockFetchResponse = ({ ok = true, status = 201, body = "" } = {}) => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok,
+    status,
+    text: () => Promise.resolve(typeof body === "string" ? body : JSON.stringify(body)),
+  });
+};
+
+const expectBookingError = async (promise, code) => {
+  await expect(promise).rejects.toBeInstanceOf(WebsitePublicBookingError);
+  await expect(promise).rejects.toMatchObject({ code });
+};
+
+describe("requestPublicSiteBooking", () => {
+  afterEach(() => {
+    delete global.fetch;
+    globalThis.localStorage.clear();
+  });
+
+  it("posts the request with the Idempotency-Key header and no auth header", async () => {
+    globalThis.localStorage.setItem("CognitoIdentityServiceProvider.abc.user.accessToken", "host-token");
+    mockFetchResponse({ body: BOOKING_RESPONSE });
+
+    await requestPublicSiteBooking(BOOKING_REQUEST);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [url, options] = global.fetch.mock.calls[0];
+    expect(url).toBe(`${DIRECT_BOOKING_WEBSITE_BOOKINGS_API_BASE}/public/sites/site-1/bookings`);
+    expect(options.method).toBe("POST");
+    expect(options.cache).toBe("no-store");
+    expect(options.headers).toEqual({ "Content-Type": "application/json", "Idempotency-Key": "idem-1" });
+    expect(JSON.parse(options.body)).toEqual({
+      quoteToken: "qtok_abc",
+      guest: { name: "Guest Name", email: "guest@example.com" },
+      session: { sessionId: "visitor-1", source: "standalone_site" },
+    });
+  });
+
+  it("encodes the site id in the path", async () => {
+    mockFetchResponse({ body: BOOKING_RESPONSE });
+
+    await requestPublicSiteBooking({ ...BOOKING_REQUEST, siteId: "site/one" });
+
+    expect(global.fetch.mock.calls[0][0]).toBe(
+      `${DIRECT_BOOKING_WEBSITE_BOOKINGS_API_BASE}/public/sites/site%2Fone/bookings`
+    );
+  });
+
+  it("returns the normalized booking request on success", async () => {
+    mockFetchResponse({ body: BOOKING_RESPONSE });
+
+    await expect(requestPublicSiteBooking(BOOKING_REQUEST)).resolves.toEqual(BOOKING_RESPONSE);
+  });
+
+  it("surfaces the endpoint's error code, message, status and requestId", async () => {
+    mockFetchResponse({
+      ok: false,
+      status: 409,
+      body: { error: { code: "quote_expired", message: "Your quote is no longer valid.", requestId: "req-9" } },
+    });
+
+    const promise = requestPublicSiteBooking(BOOKING_REQUEST);
+    await expectBookingError(promise, "quote_expired");
+    await expect(promise).rejects.toMatchObject({
+      status: 409,
+      message: "Your quote is no longer valid.",
+      requestId: "req-9",
+    });
+  });
+
+  it("maps an API Gateway throttle response to rate_limited", async () => {
+    mockFetchResponse({ ok: false, status: 429, body: { message: "Too Many Requests" } });
+
+    await expectBookingError(
+      requestPublicSiteBooking(BOOKING_REQUEST),
+      WEBSITE_PUBLIC_BOOKING_CLIENT_ERROR_CODES.RATE_LIMITED
+    );
+  });
+
+  it("maps a non-JSON failure body to unexpected_response", async () => {
+    mockFetchResponse({ ok: false, status: 502, body: "<html>Bad Gateway</html>" });
+
+    await expectBookingError(
+      requestPublicSiteBooking(BOOKING_REQUEST),
+      WEBSITE_PUBLIC_BOOKING_CLIENT_ERROR_CODES.UNEXPECTED_RESPONSE
+    );
+  });
+
+  it("maps a success body without a booking reference to unexpected_response", async () => {
+    mockFetchResponse({ body: { status: "REQUESTED" } });
+
+    await expectBookingError(
+      requestPublicSiteBooking(BOOKING_REQUEST),
+      WEBSITE_PUBLIC_BOOKING_CLIENT_ERROR_CODES.UNEXPECTED_RESPONSE
+    );
+  });
+
+  it("maps a network failure to network_error", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+
+    await expectBookingError(
+      requestPublicSiteBooking(BOOKING_REQUEST),
+      WEBSITE_PUBLIC_BOOKING_CLIENT_ERROR_CODES.NETWORK_ERROR
+    );
+  });
+
+  it("lets an abort propagate untouched so callers can ignore it", async () => {
+    const abortError = new Error("aborted");
+    abortError.name = "AbortError";
+    global.fetch = jest.fn().mockRejectedValue(abortError);
+
+    await expect(requestPublicSiteBooking(BOOKING_REQUEST)).rejects.toBe(abortError);
+  });
+});

--- a/frontend/web/src/setupTests.js
+++ b/frontend/web/src/setupTests.js
@@ -5,12 +5,16 @@ import "@testing-library/jest-dom";
 // (@smithy/@aws-sdk) modules require at import time when `aws-amplify`
 // is loaded. Polyfill them globally before any test runs.
 import { TextEncoder, TextDecoder } from "node:util";
+import { webcrypto } from "node:crypto";
 
 if (!("TextEncoder" in globalThis)) {
   globalThis.TextEncoder = TextEncoder;
 }
 if (!("TextDecoder" in globalThis)) {
   globalThis.TextDecoder = TextDecoder;
+}
+if (!("crypto" in globalThis)) {
+  Object.defineProperty(globalThis, "crypto", { configurable: true, value: webcrypto });
 }
 
 Object.defineProperty(Element.prototype, "scrollIntoView", {


### PR DESCRIPTION
## Close or Relate the Issue
[//]: # (Only if this should close the issue)
- Closes #

[//]: # (in the issue a reference will be added to this pr)
- Related Issue: #3038

## Proposed Changes
[//]: # (Add a detailed description of the changes here)
Description:

Adds the form where a guest actually sends in a booking request. After they get a live price, the panel asks for their name and email and posts to POST /public/sites/{siteId}/bookings with the quote token they already have.

**How it works**

The guest picks dates, hits check availability, gets a price. Below that price a short form appears with two fields and a submit button. The form only shows when the quote is fresh, so if they change the dates or the 30 minutes run out, it disappears and they have to check again first. That way the token being sent is always the one whose price they're looking at.

Every submit carries an Idempotency-Key header. That key is stored per site and per quote, so if someone clicks twice or the connection drops and they retry, the server sends back the original booking instead of making a second one. On success the key gets cleared.

The success screen shows the booking reference and says the host still has to confirm. Nothing is booked yet at that point, and the wording is explicit about that so nobody books a flight on it.

**About the errors**

This PR keeps error handling simple on purpose. A rejected name or email shows on the field, a site that can't take bookings hides the whole thing, and everything else gets one message with a retry: "We couldn't send your request. Please try again." The retry is safe because it reuses the same key.

The per-code handling (price changed, dates taken, and so on) is the next PR, together with turning the panel on by default. That way this one reviews the flow and that one reviews what each failure looks like.

**Visibility stays off**

The booking panel default is still false, so nothing changes for existing sites. Only hosts who already turned the panel on themselves get the form.

**Dependencies**

The endpoint from #3184 is live and reachable, with Idempotency-Key in the CORS allowed headers and throttling in place. Verified with curl from outside before opening this.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Optimization
- [ ] Documentation update

## Change Size
[//]: # (Indicate the size of this change.)
[//]: # (Clarify under Refactoring which parts are moved/unchanged code, so the reviewer doesn’t review old logic.)
- [x] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
- [ ] Big change (+-max 1000)
- [ ] Small change (less than 300)

## Refactoring
Refactors following files, but didn't change the code. This is to avoid reviewing old logic.
Nothing refactored or moved. It's 1546 lines of new code, roughly half of it tests (7 of the 17 files). The service, the hook and the error copy follow the same shape as the existing quote versions, but they're written fresh, not copied.

## Evidence
## Evidence
The form and success view are new UI in the booking panel. I can add screenshots if useful, but you need a published site with the panel turned on to see the flow.

- [ ] Screenshots or screen recording added for UI changes
- [ ] Before/after images added when relevant
- [ ] Images clearly show the implemented change
- [ ] Image quality is readable (no cropped or blurry evidence)

## Responsiveness
## Responsiveness
The form sits in the existing panel and uses its layout, so it follows whatever the panel already does.

- [ ] UI checked on mobile
- [ ] UI checked on tablet
- [ ] UI checked on desktop
- [ ] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages
- [ ] NPM Packages installed
- [ ] NPM Packages removed
- [ ] NPM Packages updated
- [ ] Checked for vulnerabilities using "npm audit"

## Checklist
[//]: # (All boxes must be checked before merging.)
- [x] Pull request has at least 2 reviewers assigned
- [x] PR title is descriptive and includes issue number
- [x] Conventions
  - [x] No config files have been added (Amplify config, cache files)
  - [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  - [x] No global styling (see [#1691](https://github.com/domits1/Domits/issues/1691))
  - [x] No `console.log` left in code
  - [x] No commented-out code remains
- [x] Testing
  - [x] Code tested locally
  - [x] Jest tests are included
  - [x] Jest tests are passing

## Keep or delete my branch
- [ ] Delete my branch after merge
- [x] Keep my branch  
