### PR TITLE
fix(inbox): allow guests to read pre-booking threads (#767)

### DIFF
--- a/backend/functions/UnifiedMessaging/business/messageService.authorization.test.js
+++ b/backend/functions/UnifiedMessaging/business/messageService.authorization.test.js
@@ -96,7 +96,7 @@ describe("MessageService authorization and booking scoping", () => {
   });
 
   test("allows legacy guest threads only when a matching reservation exists", async () => {
-    mockThreadRepository.getThreadById.mockResolvedValue(thread({ bookingId: null }));
+    mockThreadRepository.getThreadById.mockResolvedValue(thread({ bookingId: null, platform: "WHATSAPP" }));
     mockBookingRepository.findBookingsForGuestHostProperty.mockResolvedValue([booking()]);
     mockMessageRepository.getMessagesByThreadId.mockResolvedValue([]);
 
@@ -126,7 +126,7 @@ describe("MessageService authorization and booking scoping", () => {
   });
 
   test("rejects legacy guest threads when no matching reservation exists", async () => {
-    mockThreadRepository.getThreadById.mockResolvedValue(thread({ bookingId: null }));
+    mockThreadRepository.getThreadById.mockResolvedValue(thread({ bookingId: null, platform: "WHATSAPP" }));
     mockBookingRepository.findBookingsForGuestHostProperty.mockResolvedValue([]);
 
     await expect(service.getMessages("thread-1", guestAuth)).rejects.toMatchObject({
@@ -137,7 +137,7 @@ describe("MessageService authorization and booking scoping", () => {
   });
 
   test("rejects ambiguous legacy guest threads with multiple matching reservations", async () => {
-    mockThreadRepository.getThreadById.mockResolvedValue(thread({ bookingId: null }));
+    mockThreadRepository.getThreadById.mockResolvedValue(thread({ bookingId: null, platform: "WHATSAPP" }));
     mockBookingRepository.findBookingsForGuestHostProperty.mockResolvedValue([
       booking({ id: "booking-1" }),
       booking({ id: "booking-2" }),
@@ -160,6 +160,48 @@ describe("MessageService authorization and booking scoping", () => {
     await expect(service.getMessages("thread-1", guestAuth)).rejects.toMatchObject({
       statusCode: 403,
       code: "FORBIDDEN",
+    });
+    expect(mockMessageRepository.getMessagesByThreadId).not.toHaveBeenCalled();
+  });
+
+  test("guest sees own DOMITS pre-booking thread in /threads", async () => {
+    mockThreadRepository.getThreadsForUser.mockResolvedValue([
+      thread({ id: "pre-booking-thread", bookingId: null, propertyId: "property-1", platform: "DOMITS" }),
+    ]);
+
+    const result = await service.getThreads(guestAuth);
+
+    expect(result.response).toEqual([expect.objectContaining({ id: "pre-booking-thread", bookingId: null })]);
+    expect(mockBookingRepository.findBookingsForGuestHostProperty).not.toHaveBeenCalled();
+    expect(mockBookingRepository.findBookingsForGuestHost).not.toHaveBeenCalled();
+  });
+
+  test("guest can getMessages on own DOMITS pre-booking thread", async () => {
+    mockThreadRepository.getThreadById.mockResolvedValue(
+      thread({ bookingId: null, propertyId: "property-1", platform: "DOMITS" })
+    );
+    mockMessageRepository.getMessagesByThreadId.mockResolvedValue([{ id: "message-1" }]);
+
+    const result = await service.getMessages("thread-1", guestAuth);
+
+    expect(result).toEqual({ statusCode: 200, response: [{ id: "message-1" }] });
+    expect(mockBookingRepository.findBookingsForGuestHostProperty).not.toHaveBeenCalled();
+  });
+
+  test("rejects a non-DOMITS thread with propertyId but no bookingId without a matching reservation", async () => {
+    mockThreadRepository.getThreadById.mockResolvedValue(
+      thread({ bookingId: null, propertyId: "property-1", platform: "WHATSAPP" })
+    );
+    mockBookingRepository.findBookingsForGuestHostProperty.mockResolvedValue([]);
+
+    await expect(service.getMessages("thread-1", guestAuth)).rejects.toMatchObject({
+      statusCode: 403,
+      code: "FORBIDDEN",
+    });
+    expect(mockBookingRepository.findBookingsForGuestHostProperty).toHaveBeenCalledWith({
+      guestId: "guest-1",
+      hostId: "host-1",
+      propertyId: "property-1",
     });
     expect(mockMessageRepository.getMessagesByThreadId).not.toHaveBeenCalled();
   });

--- a/backend/functions/UnifiedMessaging/business/messageService.js
+++ b/backend/functions/UnifiedMessaging/business/messageService.js
@@ -161,6 +161,10 @@ class MessageService {
       return booking;
     }
 
+    if (thread?.propertyId && thread?.platform === "DOMITS") {
+      return null;
+    }
+
     const matches = await this.getMatchingLegacyBookings(thread, authenticatedUserId);
     if (matches.length === 0) {
       throw forbidden("This conversation is not connected to one of your reservations.");


### PR DESCRIPTION
## Close or Relate the Issue
[//]: # (Only if this should close the issue)
- Closes #

[//]: # (in the issue a reference will be added to this pr)
- Related Issue: #767

## Proposed Changes
[//]: # (Add a detailed description of the changes here)
Description:
Fixes guest access to pre-booking messaging threads.

Guests could successfully send messages and hosts could see and reply to them, but the guest inbox returned an empty thread list.

This change:
- Allows guests to read their own DOMITS pre-booking threads.
- Keeps booking validation for legacy and external messaging threads.
- Keeps booking-linked and host messaging behavior unchanged.
- Adds authorization coverage for guest thread and message access.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Optimization
- [ ] Documentation update

## Change Size
- [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
- [ ] Big change (+-max 1000)
- [x] Small change (less than 300)

## Refactoring
N/A

## Evidence
- [ ] Screenshots or screen recording added for UI changes
- [ ] Before/after images added when relevant
- [ ] Images clearly show the implemented change
- [ ] Image quality is readable (no cropped or blurry evidence)

N/A - no UI design changes.

## Responsiveness
- [ ] UI checked on mobile
- [ ] UI checked on tablet
- [x] UI checked on desktop
- [x] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages
- [ ] NPM Packages installed
- [ ] NPM Packages removed
- [ ] NPM Packages updated
- [ ] Checked for vulnerabilities using "npm audit"

N/A - no npm package changes.

## Checklist
[//]: # (All boxes must be checked before merging.)
- [ ] Pull request has at least 2 reviewers assigned
- [x] PR title is descriptive and includes issue number
- [x] Conventions
  - [x] No config files have been added (Amplify config, cache files)
  - [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  - [x] No global styling (see [#1691](https://github.com/domits1/Domits/issues/169