### PR TITLE
test(channex): add ARI push wire tests for channexProviderClient (#440)

### DIFF
--- a/backend/functions/UnifiedMessaging/business/channexProviderClient.ariPush.test.js
+++ b/backend/functions/UnifiedMessaging/business/channexProviderClient.ariPush.test.js
@@ -1,0 +1,382 @@
+const ChannexProviderClient = require("../.shared/channelManagement/providers/channex/providerClient.js").default;
+
+const originalFetch = global.fetch;
+const CREDENTIALS = { apiKey: "test-api-key" };
+
+const jsonResponse = (status, body) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  text: async () => JSON.stringify(body),
+});
+
+const availabilityGroup = (overrides = {}) => ({
+  externalPropertyId: "ext-property-1",
+  externalRoomTypeId: "ext-room-1",
+  values: [{ date: "2026-06-01", availability: 1 }],
+  ...overrides,
+});
+
+const restrictionGroup = (overrides = {}) => ({
+  externalPropertyId: "ext-property-1",
+  externalRoomTypeId: "ext-room-1",
+  externalRatePlanId: "ext-rate-1",
+  values: [{ date: "2026-06-01", rate: "123.00" }],
+  ...overrides,
+});
+
+const PUSH_METHODS = [
+  {
+    method: "pushAvailability",
+    call: (client, groups, options) => client.pushAvailability(CREDENTIALS, groups, options),
+    callWithoutKey: (client, groups) => client.pushAvailability({}, groups),
+    group: availabilityGroup,
+    endpoint: "/api/v1/availability",
+    url: "https://staging.channex.io/api/v1/availability",
+    fallbackStatus: "AVAILABILITY_PUSH_FAILED",
+    errorCodePrefix: "CHANNEX_AVAILABILITY_PUSH",
+    missingValuesCode: "CHANNEX_AVAILABILITY_VALUES_MISSING",
+  },
+  {
+    method: "pushRestrictions",
+    call: (client, groups, options) => client.pushRestrictions(CREDENTIALS, groups, options),
+    callWithoutKey: (client, groups) => client.pushRestrictions({}, groups),
+    group: restrictionGroup,
+    endpoint: "/api/v1/restrictions",
+    url: "https://staging.channex.io/api/v1/restrictions",
+    fallbackStatus: "RESTRICTIONS_PUSH_FAILED",
+    errorCodePrefix: "CHANNEX_RESTRICTIONS_PUSH",
+    missingValuesCode: "CHANNEX_RESTRICTIONS_VALUES_MISSING",
+  },
+];
+
+describe("ChannexProviderClient ARI push", () => {
+  let client;
+
+  beforeEach(() => {
+    client = new ChannexProviderClient();
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe("missing apiKey short-circuits before any request", () => {
+    it.each(PUSH_METHODS)(
+      "$method returns one INVALID_CREDENTIALS result per group without calling fetch",
+      async ({ callWithoutKey, group, endpoint }) => {
+        const groups = [group(), group({ externalRoomTypeId: "ext-room-2" })];
+
+        const result = await callWithoutKey(client, groups);
+
+        expect(global.fetch).not.toHaveBeenCalled();
+        expect(result.success).toBe(false);
+        expect(result.results).toHaveLength(2);
+        result.results.forEach((entry) => {
+          expect(entry).toMatchObject({
+            success: false,
+            providerStatus: "INVALID_CREDENTIALS",
+            errorCode: "MISSING_API_KEY",
+            httpStatus: null,
+            endpoint,
+            method: "POST",
+          });
+        });
+      }
+    );
+  });
+
+  describe("groups with no values never reach the provider", () => {
+    it.each(PUSH_METHODS)(
+      "$method reports INVALID_REQUEST for an empty values array",
+      async ({ call, group, missingValuesCode }) => {
+        const result = await call(client, [group({ values: [] })]);
+
+        expect(global.fetch).not.toHaveBeenCalled();
+        expect(result.success).toBe(false);
+        expect(result.results[0]).toMatchObject({
+          success: false,
+          providerStatus: "INVALID_REQUEST",
+          errorCode: missingValuesCode,
+          httpStatus: null,
+        });
+      }
+    );
+
+    test("an empty group does not stop the remaining groups in the same batch", async () => {
+      global.fetch.mockResolvedValue(jsonResponse(200, { data: [{ id: "task-1" }] }));
+
+      const result = await client.pushAvailability(CREDENTIALS, [
+        availabilityGroup({ values: [] }),
+        availabilityGroup({ externalRoomTypeId: "ext-room-2" }),
+      ]);
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(result.results).toHaveLength(2);
+      expect(result.results[0].providerStatus).toBe("INVALID_REQUEST");
+      expect(result.results[1].providerStatus).toBe("SYNCED");
+    });
+  });
+
+  describe("successful pushes", () => {
+    it.each(PUSH_METHODS)(
+      "$method posts each group to $endpoint with the api key header",
+      async ({ call, group, url }) => {
+        global.fetch.mockResolvedValue(jsonResponse(200, { data: [{ id: "task-1" }] }));
+        const pushed = group();
+
+        await call(client, [pushed]);
+
+        const [requestUrl, init] = global.fetch.mock.calls[0];
+        expect(requestUrl.toString()).toBe(url);
+        expect(init.method).toBe("POST");
+        expect(init.headers).toMatchObject({
+          "user-api-key": "test-api-key",
+          "Content-Type": "application/json",
+        });
+        expect(JSON.parse(init.body)).toEqual({ values: pushed.values });
+      }
+    );
+
+    it.each(PUSH_METHODS)("$method reports SYNCED with the first returned task id", async ({ call, group }) => {
+      global.fetch.mockResolvedValue(jsonResponse(200, { data: [{ id: "task-1" }, { id: "task-2" }] }));
+
+      const result = await call(client, [group()]);
+
+      expect(result.success).toBe(true);
+      expect(result.results[0]).toMatchObject({
+        success: true,
+        providerStatus: "SYNCED",
+        taskId: "task-1",
+        httpStatus: 200,
+        warnings: [],
+        errorCode: null,
+      });
+    });
+
+    // A 2xx response carrying meta.warnings is still reported as success:false, because
+    // buildProviderPushSuccessResult derives success from warnings.length === 0 rather than
+    // from the HTTP status. Pinning it so the behaviour is not mistaken for a bug later.
+    it.each(PUSH_METHODS)(
+      "$method reports ACCEPTED_WITH_WARNINGS and success false when Channex returns warnings",
+      async ({ call, group }) => {
+        global.fetch.mockResolvedValue(
+          jsonResponse(200, { data: [{ id: "task-1" }], meta: { warnings: ["rate plan is closed"] } })
+        );
+
+        const result = await call(client, [group()]);
+
+        expect(result.success).toBe(false);
+        expect(result.results[0]).toMatchObject({
+          success: false,
+          providerStatus: "ACCEPTED_WITH_WARNINGS",
+          warnings: ["rate plan is closed"],
+          errorMessage: "Channex accepted the request with warnings.",
+        });
+      }
+    );
+  });
+
+  describe("non-2xx responses map to push-specific provider statuses", () => {
+    it.each(
+      PUSH_METHODS.flatMap(({ method, call, group, fallbackStatus, errorCodePrefix }) => [
+        { method, call, group, status: 500, expectedStatus: fallbackStatus, errorCodePrefix },
+        { method, call, group, status: 401, expectedStatus: "UNAUTHORIZED", errorCodePrefix },
+        { method, call, group, status: 429, expectedStatus: "RATE_LIMITED", errorCodePrefix },
+      ])
+    )(
+      "$method with status $status reports $expectedStatus",
+      async ({ call, group, status, expectedStatus, errorCodePrefix }) => {
+        global.fetch.mockResolvedValue(jsonResponse(status, {}));
+
+        const result = await call(client, [group()]);
+
+        expect(result.success).toBe(false);
+        expect(result.results[0]).toMatchObject({
+          success: false,
+          providerStatus: expectedStatus,
+          httpStatus: status,
+          errorCode: `${errorCodePrefix}_${status}`,
+        });
+      }
+    );
+
+    test("a Channex-provided error code takes priority over the fallback template", async () => {
+      global.fetch.mockResolvedValue(
+        jsonResponse(422, { errors: { code: "RATE_PLAN_CLOSED", title: "Rate plan is closed." } })
+      );
+
+      const result = await client.pushRestrictions(CREDENTIALS, [restrictionGroup()]);
+
+      expect(result.results[0]).toMatchObject({
+        errorCode: "RATE_PLAN_CLOSED",
+        errorMessage: "Rate plan is closed.",
+      });
+    });
+  });
+
+  describe("stopOnFailure controls how much of the batch is attempted", () => {
+    const threeGroups = () => [
+      availabilityGroup({ externalRoomTypeId: "ext-room-1" }),
+      availabilityGroup({ externalRoomTypeId: "ext-room-2" }),
+      availabilityGroup({ externalRoomTypeId: "ext-room-3" }),
+    ];
+
+    test("stops after the first failed group when enabled", async () => {
+      global.fetch
+        .mockResolvedValueOnce(jsonResponse(200, { data: [{ id: "task-1" }] }))
+        .mockResolvedValueOnce(jsonResponse(500, {}))
+        .mockResolvedValueOnce(jsonResponse(200, { data: [{ id: "task-3" }] }));
+
+      const result = await client.pushAvailability(CREDENTIALS, threeGroups(), { stopOnFailure: true });
+
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(result.results).toHaveLength(2);
+      expect(result.results[1].providerStatus).toBe("AVAILABILITY_PUSH_FAILED");
+    });
+
+    test("attempts every group when disabled", async () => {
+      global.fetch
+        .mockResolvedValueOnce(jsonResponse(200, { data: [{ id: "task-1" }] }))
+        .mockResolvedValueOnce(jsonResponse(500, {}))
+        .mockResolvedValueOnce(jsonResponse(200, { data: [{ id: "task-3" }] }));
+
+      const result = await client.pushAvailability(CREDENTIALS, threeGroups());
+
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+      expect(result.results).toHaveLength(3);
+      expect(result.success).toBe(false);
+    });
+
+    // The failed-response and thrown-request paths each carry their own stopOnFailure break,
+    // so a thrown request has to be exercised separately from the non-2xx case above.
+    test("stops after the first thrown request when enabled", async () => {
+      global.fetch
+        .mockResolvedValueOnce(jsonResponse(200, { data: [{ id: "task-1" }] }))
+        .mockRejectedValueOnce(new Error("socket hang up"))
+        .mockResolvedValueOnce(jsonResponse(200, { data: [{ id: "task-3" }] }));
+
+      const result = await client.pushAvailability(CREDENTIALS, threeGroups(), { stopOnFailure: true });
+
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(result.results).toHaveLength(2);
+      expect(result.results[1]).toMatchObject({
+        success: false,
+        providerStatus: "AVAILABILITY_PUSH_FAILED",
+        httpStatus: null,
+        errorMessage: "socket hang up",
+      });
+    });
+
+    // stopOnFailure is only checked after a request actually fails or throws; the empty-values
+    // branch continues unconditionally, so an unusable group never halts the batch.
+    test("an empty group does not halt the batch even when stopOnFailure is enabled", async () => {
+      global.fetch.mockResolvedValue(jsonResponse(200, { data: [{ id: "task-2" }] }));
+
+      const result = await client.pushAvailability(
+        CREDENTIALS,
+        [availabilityGroup({ values: [] }), availabilityGroup({ externalRoomTypeId: "ext-room-2" })],
+        { stopOnFailure: true }
+      );
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(result.results).toHaveLength(2);
+      expect(result.results[1].providerStatus).toBe("SYNCED");
+    });
+  });
+
+  describe("request failures and timeouts", () => {
+    it.each(PUSH_METHODS)(
+      "$method reports $fallbackStatus when the request throws",
+      async ({ call, group, fallbackStatus }) => {
+        global.fetch.mockRejectedValue(new Error("socket hang up"));
+
+        const result = await call(client, [group()]);
+
+        expect(result.results[0]).toMatchObject({
+          success: false,
+          providerStatus: fallbackStatus,
+          httpStatus: null,
+          errorMessage: "socket hang up",
+        });
+      }
+    );
+
+    test("a 401 thrown as an exception does not get the UNAUTHORIZED mapping", async () => {
+      global.fetch.mockRejectedValue(new Error("unauthorized"));
+
+      const result = await client.pushAvailability(CREDENTIALS, [availabilityGroup()]);
+
+      expect(result.results[0].providerStatus).toBe("AVAILABILITY_PUSH_FAILED");
+    });
+
+    test("does not attach an abort signal when no timeout is configured", async () => {
+      global.fetch.mockResolvedValue(jsonResponse(200, { data: [{ id: "task-1" }] }));
+
+      await client.pushAvailability(CREDENTIALS, [availabilityGroup()]);
+
+      expect(global.fetch.mock.calls[0][1].signal).toBeUndefined();
+    });
+
+    // A real 1 ms timer is used rather than fake timers: the abort has to propagate through the
+    // fetch rejection and back into the catch that inspects controller.signal.aborted.
+    test("maps an aborted request to the push timeout code", async () => {
+      global.fetch.mockImplementation(
+        (_url, init) =>
+          new Promise((_resolve, reject) => {
+            init.signal?.addEventListener("abort", () => reject(new Error("The operation was aborted")));
+          })
+      );
+
+      const result = await client.pushAvailability(CREDENTIALS, [availabilityGroup()], { requestTimeoutMs: 1 });
+
+      expect(global.fetch.mock.calls[0][1].signal).toBeDefined();
+      expect(result.results[0]).toMatchObject({
+        success: false,
+        providerStatus: "AVAILABILITY_PUSH_FAILED",
+        errorCode: "CHANNEX_PUSH_REQUEST_TIMEOUT",
+        errorMessage: "Channex push request timed out after 1 ms.",
+      });
+    });
+  });
+
+  // results.every(...) is vacuously true on an empty results array, so a batch that pushed
+  // nothing still reports overall success. Pinned because a caller reading only `success`
+  // cannot tell "everything synced" apart from "there was nothing to sync".
+  describe("an empty batch reports success without pushing anything", () => {
+    it.each([
+      { description: "an empty array", groups: [] },
+      { description: "undefined", groups: undefined },
+      { description: "a non-array value", groups: "not-a-batch" },
+    ])("$description yields success true with no results", async ({ groups }) => {
+      const result = await client.pushAvailability(CREDENTIALS, groups);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(result).toEqual({ success: true, results: [] });
+    });
+  });
+
+  describe("group identity differs between the two push endpoints", () => {
+    test("pushRestrictions carries the rate plan identity", async () => {
+      global.fetch.mockResolvedValue(jsonResponse(200, { data: [{ id: "task-1" }] }));
+
+      const result = await client.pushRestrictions(CREDENTIALS, [restrictionGroup()]);
+
+      expect(result.results[0]).toMatchObject({
+        externalPropertyId: "ext-property-1",
+        externalRoomTypeId: "ext-room-1",
+        externalRatePlanId: "ext-rate-1",
+      });
+    });
+
+    test("pushAvailability omits the rate plan identity", async () => {
+      global.fetch.mockResolvedValue(jsonResponse(200, { data: [{ id: "task-1" }] }));
+
+      const result = await client.pushAvailability(CREDENTIALS, [
+        availabilityGroup({ externalRatePlanId: "ext-rate-1" }),
+      ]);
+
+      expect(result.results[0]).not.toHaveProperty("externalRatePlanId");
+    });
+  });
+});


### PR DESCRIPTION
## Close or Relate the Issue
[//]: # (Only if this should close the issue)
- Closes #

[//]: # (in the issue a reference will be added to this pr)
- Related Issue: #440

## Proposed Changes
[//]: # (Add a detailed description of the changes here)
Description:
Slice 2 of 3 for ChannexProviderClient (functions/.shared/channelManagement/providers/channex/providerClient.js) — the HTTP boundary to the Channex API, which had zero unit coverage before this series because every consumer test mocks the class away.

This slice covers the ARI push path: pushAvailability, pushRestrictions, and the shared pushGroupedPayloads / postChannexPushRequest helpers they both delegate to. This is the most behaviourally complex code path in the file — it's the only one with batching, stopOnFailure, and AbortController timeout handling.

Covered:

Batch semantics — one request per group, one result per group; a group with empty values is rejected locally without a request while the rest of the batch still proceeds.
Both stopOnFailure break paths — the non-2xx response case and the thrown-request case, which are two separate branches in the loop (providerClient.js:310 and :326) and needed separate tests.
Status mapping unique to the push path — 401→UNAUTHORIZED and 429→RATE_LIMITED (the discovery-read methods only special-case 401), plus the method-specific fallback statuses.
Timeout handling — an aborted request maps to CHANNEX_PUSH_REQUEST_TIMEOUT, and no abort signal is attached at all when no requestTimeoutMs is configured.
Group identity — pushRestrictions carries externalRatePlanId, pushAvailability deliberately doesn't.

Three behaviours are pinned as characterization tests rather than "fixed", since changing them is a production decision and this is a tests-only PR:

A 2xx response carrying meta.warnings still reports success: false (success derives from warnings.length === 0, not the HTTP status).
An empty-values group never halts a batch even with stopOnFailure: true — that branch continues unconditionally; only real failures break.
An empty, undefined, or non-array batch returns { success: true, results: [] } — [].every(...) is vacuously true, so a caller reading only success can't distinguish "everything synced" from "nothing was sent". Worth knowing about given this path feeds certification demos.

Verified beyond a green run: I mutation-tested the three hardest assertions by temporarily breaking the production code — the abort→timeout mapping, and each stopOnFailure break independently — and confirmed the corresponding test (and only that test) fails each time, then restored. Went through the eng-review gate; both findings it raised are applied in this PR.

Slice 1 (discovery reads) is a separate open PR; Slice 3 (booking revisions) is next. No production code changed here.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Optimization
- [ ] Documentation update

## Change Size
[//]: # (Indicate the size of this change.)
[//]: # (Clarify under Refactoring which parts are moved/unchanged code, so the reviewer doesn’t review old logic.)
- [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
- [x ] Big change (+-max 1000)
- [ ] Small change (less than 300)

## Refactoring
Refactors following files, but didn't change the code. This is to avoid reviewing old logic.
- src/features/example.xx

## Evidence
- [ ] Screenshots or screen recording added for UI changes
- [ ] Before/after images added when relevant
- [ ] Images clearly show the implemented change
- [ ] Image quality is readable (no cropped or blurry evidence)

## Responsiveness
- [ ] UI checked on mobile
- [ ] UI checked on tablet
- [ ] UI checked on desktop
- [ ] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages
- [ ] NPM Packages installed
- [ ] NPM Packages removed
- [ ] NPM Packages updated
- [ ] Checked for vulnerabilities using "npm audit"

## Checklist
[//]: # (All boxes must be checked before merging.)
- [x ] Pull request has at least 2 reviewers assigned
- [x ] PR title is descriptive and includes issue number
- [x ] Conventions
  - [x ] No config files have been added (Amplify config, cache files)
  - [x ] No hardcoded sensitive data (e.g., API-keys/passwords)
  - [x ] No global styling (see [#1691](https://github.com/domits1/Domits/issues/1691))
  - [x ] No `console.log` left in code
  - [x ] No commented-out code remains
- [x ] Testing
  - [x] Code tested locally
  - [x ] Jest tests are included
  - [x ] Jest tests are passing

## Keep or delete my branch
- [x] Delete my branch after merge
- [ ] Keep my branch  
