### PR TITLE
feature: add communication preferences persistence

### DIFF
--- a/backend/ORM/migrations/20260907_communication_preferences.js
+++ b/backend/ORM/migrations/20260907_communication_preferences.js
@@ -1,0 +1,30 @@
+export class CommunicationPreferences20260907 {
+  async up(queryRunner) {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS main.communication_preferences (
+        user_id VARCHAR NOT NULL,
+        persona VARCHAR NOT NULL,
+        reservation_email BOOLEAN NOT NULL DEFAULT TRUE,
+        reservation_sms BOOLEAN NOT NULL DEFAULT FALSE,
+        reservation_push BOOLEAN NOT NULL DEFAULT TRUE,
+        cancellation_email BOOLEAN NOT NULL DEFAULT TRUE,
+        cancellation_sms BOOLEAN NOT NULL DEFAULT TRUE,
+        cancellation_push BOOLEAN NOT NULL DEFAULT TRUE,
+        messages_email BOOLEAN NOT NULL DEFAULT TRUE,
+        messages_sms BOOLEAN NOT NULL DEFAULT FALSE,
+        messages_push BOOLEAN NOT NULL DEFAULT TRUE,
+        created_at BIGINT NOT NULL,
+        updated_at BIGINT NOT NULL,
+        PRIMARY KEY (user_id, persona),
+        CONSTRAINT communication_preferences_persona_chk
+          CHECK (persona IN ('HOST', 'GUEST')),
+        CONSTRAINT communication_preferences_required_email_chk
+          CHECK (reservation_email = TRUE AND cancellation_email = TRUE)
+      );
+    `);
+  }
+
+  async down(queryRunner) {
+    await queryRunner.query(`DROP TABLE IF EXISTS main.communication_preferences;`);
+  }
+}

--- a/backend/ORM/models/Communication_Preferences.js
+++ b/backend/ORM/models/Communication_Preferences.js
@@ -1,0 +1,26 @@
+import { EntitySchema } from "typeorm";
+
+const bigintTransformer = {
+  from: (value) => value !== null && value !== undefined ? Number(value) : null,
+  to: (value) => value,
+};
+
+export const Communication_Preferences = new EntitySchema({
+  name: "Communication_Preferences",
+  tableName: "communication_preferences",
+  columns: {
+    user_id: { primary: true, type: "varchar", nullable: false },
+    persona: { primary: true, type: "varchar", nullable: false },
+    reservation_email: { type: "boolean", default: true, nullable: false },
+    reservation_sms: { type: "boolean", default: false, nullable: false },
+    reservation_push: { type: "boolean", default: true, nullable: false },
+    cancellation_email: { type: "boolean", default: true, nullable: false },
+    cancellation_sms: { type: "boolean", default: true, nullable: false },
+    cancellation_push: { type: "boolean", default: true, nullable: false },
+    messages_email: { type: "boolean", default: true, nullable: false },
+    messages_sms: { type: "boolean", default: false, nullable: false },
+    messages_push: { type: "boolean", default: true, nullable: false },
+    created_at: { type: "bigint", nullable: false, transformer: bigintTransformer },
+    updated_at: { type: "bigint", nullable: false, transformer: bigintTransformer },
+  },
+});

--- a/backend/ORM/util/database/Tables.js
+++ b/backend/ORM/util/database/Tables.js
@@ -51,6 +51,7 @@ import { BookingAutomationOutbox } from "../../models/automation/BookingAutomati
 import { PropertyTask } from "../../models/Property_Task.js";
 import { Property_Task_Activity } from "../../models/Property_Task_Activity.js";
 import { Host_Settings } from "../../models/Host_Settings.js";
+import { Communication_Preferences } from "../../models/Communication_Preferences.js";
 import { Kpi_Snapshot } from "../../models/Kpi_Snapshot.js";
 import { PriceLabs_Connection } from "../../models/PriceLabs_Connection.js";
 import { Team_Member } from "../../models/Team_Member.js";
@@ -110,6 +111,7 @@ export const Tables = [
   PropertyTask,
   Property_Task_Activity,
   Host_Settings,
+  Communication_Preferences,
   Kpi_Snapshot,
   PriceLabs_Connection,
   Team_Member,

--- a/backend/functions/communication-preferences/README.md
+++ b/backend/functions/communication-preferences/README.md
@@ -1,0 +1,31 @@
+# Communication Preferences
+
+## Runtime
+
+- Lambda handler: `index.handler`
+- `GET /user/communication-preferences?persona=host` returns the authenticated user's saved Host communication preferences, or product defaults when no Host row exists.
+- `GET /user/communication-preferences?persona=guest` returns the authenticated user's saved Guest communication preferences, or product defaults when no Guest row exists.
+- `PUT /user/communication-preferences?persona=host` saves the complete Host preference matrix for the authenticated user.
+- `PUT /user/communication-preferences?persona=guest` saves the complete Guest preference matrix for the authenticated user.
+
+## Authentication
+
+- Every `GET` and `PUT` route MUST use `DomitsCognitoAuthorizer`.
+- The authenticated user identity is `claims.sub` from API Gateway/Cognito authorizer claims.
+- The preference identity is `(claims.sub, persona)`.
+- The API must not accept `userId` from the request body, query string, or path parameters.
+- The `persona` query parameter is required and must be `host` or `guest`; the backend normalizes it to `HOST` or `GUEST`.
+- `OPTIONS` remains unauthenticated for CORS preflight requests.
+- Do not use `backend/CD/npm/createLambda.js` as-is for this endpoint because it creates API Gateway methods with `authorizationType` set to `NONE`.
+
+## Lambda Prerequisites
+
+- The Lambda must exist before CI/deployment attempts to update its code.
+- The execution role should follow the existing `General-Lambda-Function` pattern.
+- The execution role requires SSM `GetParameter` access for the Aurora DSQL configuration parameters.
+- The execution role requires Aurora DSQL connection permission.
+
+## Database Prerequisite
+
+- The `main.communication_preferences` migration must be applied through the approved Domits database process before enabling the endpoint.
+- This function does not run migrations at runtime.

--- a/backend/functions/communication-preferences/auth/authContext.js
+++ b/backend/functions/communication-preferences/auth/authContext.js
@@ -1,0 +1,20 @@
+import { unauthorized } from "../util/httpErrors.js";
+
+const extractClaims = (event) =>
+  event?.requestContext?.authorizer?.claims ||
+  event?.requestContext?.authorizer?.jwt?.claims ||
+  null;
+
+export const getAuthenticatedUser = (event) => {
+  const claims = extractClaims(event);
+  const userId = claims?.sub || null;
+
+  if (!userId) {
+    throw unauthorized("Unable to establish an authenticated user.");
+  }
+
+  return {
+    userId: String(userId),
+    claims,
+  };
+};

--- a/backend/functions/communication-preferences/business/service/service.js
+++ b/backend/functions/communication-preferences/business/service/service.js
@@ -1,0 +1,151 @@
+import { CommunicationPreferencesRepository } from "../../data/repository.js";
+import { badRequest } from "../../util/httpErrors.js";
+
+export const DEFAULT_COMMUNICATION_PREFERENCES = Object.freeze({
+  reservation: Object.freeze({
+    email: true,
+    sms: false,
+    push: true,
+  }),
+  cancellation: Object.freeze({
+    email: true,
+    sms: true,
+    push: true,
+  }),
+  messages: Object.freeze({
+    email: true,
+    sms: false,
+    push: true,
+  }),
+});
+
+export const ALLOWED_COMMUNICATION_PREFERENCE_PERSONAS = Object.freeze(["HOST", "GUEST"]);
+
+const EVENT_KEYS = ["reservation", "cancellation", "messages"];
+const CHANNEL_KEYS = ["email", "sms", "push"];
+const SPOOFED_USER_ID_KEYS = ["userId", "user_id", "cognitoUserId", "sub"];
+
+const hasOwn = (object, key) => Object.prototype.hasOwnProperty.call(object, key);
+
+const cloneDefaults = () => ({
+  reservation: { ...DEFAULT_COMMUNICATION_PREFERENCES.reservation },
+  cancellation: { ...DEFAULT_COMMUNICATION_PREFERENCES.cancellation },
+  messages: { ...DEFAULT_COMMUNICATION_PREFERENCES.messages },
+});
+
+export const normalizePersona = (persona) => {
+  const normalized = String(persona || "").trim().toUpperCase();
+  if (!ALLOWED_COMMUNICATION_PREFERENCE_PERSONAS.includes(normalized)) {
+    throw badRequest("persona must be one of HOST or GUEST.");
+  }
+  return normalized;
+};
+
+export class CommunicationPreferencesService {
+  constructor({ repository = new CommunicationPreferencesRepository(), now = () => Date.now() } = {}) {
+    this.repository = repository;
+    this.now = now;
+  }
+
+  async getPreferences(userId, persona) {
+    const normalizedPersona = normalizePersona(persona);
+    const record = await this.repository.findByUserIdAndPersona(userId, normalizedPersona);
+    if (!record) return cloneDefaults();
+    return this.toApi(record);
+  }
+
+  async savePreferences(userId, persona, payload) {
+    const normalizedPersona = normalizePersona(persona);
+    const preferences = this.validateCompleteMatrix(payload);
+    const existing = await this.repository.findByUserIdAndPersona(userId, normalizedPersona);
+    const now = this.now();
+    const record = {
+      user_id: userId,
+      persona: normalizedPersona,
+      ...this.toRecordColumns(preferences),
+      created_at: existing?.created_at ?? now,
+      updated_at: now,
+    };
+
+    await this.repository.save(record);
+    return this.toApi(record);
+  }
+
+  validateCompleteMatrix(payload) {
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      throw badRequest("Request body must be a communication preferences object.");
+    }
+
+    for (const key of Object.keys(payload)) {
+      if (SPOOFED_USER_ID_KEYS.includes(key)) {
+        throw badRequest("userId must not be provided for communication preferences.");
+      }
+      if (!EVENT_KEYS.includes(key)) {
+        throw badRequest(`Unknown communication preferences field: ${key}.`);
+      }
+    }
+
+    const preferences = {};
+    for (const eventKey of EVENT_KEYS) {
+      const eventValue = payload[eventKey];
+      if (!eventValue || typeof eventValue !== "object" || Array.isArray(eventValue)) {
+        throw badRequest(`${eventKey} preferences are required.`);
+      }
+
+      for (const key of Object.keys(eventValue)) {
+        if (!CHANNEL_KEYS.includes(key)) {
+          throw badRequest(`Unknown ${eventKey} preference field: ${key}.`);
+        }
+      }
+
+      preferences[eventKey] = {};
+      for (const channelKey of CHANNEL_KEYS) {
+        if (!hasOwn(eventValue, channelKey)) {
+          throw badRequest(`${eventKey}.${channelKey} is required.`);
+        }
+        if (typeof eventValue[channelKey] !== "boolean") {
+          throw badRequest(`${eventKey}.${channelKey} must be a boolean.`);
+        }
+        preferences[eventKey][channelKey] = eventValue[channelKey];
+      }
+    }
+
+    preferences.reservation.email = true;
+    preferences.cancellation.email = true;
+    return preferences;
+  }
+
+  toApi(record) {
+    return {
+      reservation: {
+        email: true,
+        sms: record.reservation_sms ?? DEFAULT_COMMUNICATION_PREFERENCES.reservation.sms,
+        push: record.reservation_push ?? DEFAULT_COMMUNICATION_PREFERENCES.reservation.push,
+      },
+      cancellation: {
+        email: true,
+        sms: record.cancellation_sms ?? DEFAULT_COMMUNICATION_PREFERENCES.cancellation.sms,
+        push: record.cancellation_push ?? DEFAULT_COMMUNICATION_PREFERENCES.cancellation.push,
+      },
+      messages: {
+        email: record.messages_email ?? DEFAULT_COMMUNICATION_PREFERENCES.messages.email,
+        sms: record.messages_sms ?? DEFAULT_COMMUNICATION_PREFERENCES.messages.sms,
+        push: record.messages_push ?? DEFAULT_COMMUNICATION_PREFERENCES.messages.push,
+      },
+    };
+  }
+
+  toRecordColumns(preferences) {
+    return {
+      reservation_email: true,
+      reservation_sms: preferences.reservation.sms,
+      reservation_push: preferences.reservation.push,
+      cancellation_email: true,
+      cancellation_sms: preferences.cancellation.sms,
+      cancellation_push: preferences.cancellation.push,
+      messages_email: preferences.messages.email,
+      messages_sms: preferences.messages.sms,
+      messages_push: preferences.messages.push,
+    };
+  }
+}

--- a/backend/functions/communication-preferences/controller/controller.js
+++ b/backend/functions/communication-preferences/controller/controller.js
@@ -1,0 +1,63 @@
+import { getAuthenticatedUser } from "../auth/authContext.js";
+import { CommunicationPreferencesService, normalizePersona } from "../business/service/service.js";
+import { badRequest } from "../util/httpErrors.js";
+
+const USER_ID_KEYS = ["userId", "user_id", "cognitoUserId", "sub"];
+
+const hasUserIdParameter = (parameters = {}) =>
+  Object.keys(parameters || {}).some((key) => USER_ID_KEYS.includes(key));
+
+const parseBody = (event) => {
+  if (!event?.body) {
+    throw badRequest("Request body is required.");
+  }
+
+  try {
+    return typeof event.body === "string" ? JSON.parse(event.body) : event.body;
+  } catch {
+    throw badRequest("Request body must be valid JSON.");
+  }
+};
+
+const getPersonaFromQuery = (event) => {
+  const query = event?.queryStringParameters || {};
+  if (!Object.prototype.hasOwnProperty.call(query, "persona")) {
+    throw badRequest("persona query parameter is required.");
+  }
+  return normalizePersona(query.persona);
+};
+
+export class CommunicationPreferencesController {
+  constructor({ service = new CommunicationPreferencesService() } = {}) {
+    this.service = service;
+  }
+
+  async getPreferences(event) {
+    if (
+      hasUserIdParameter(event?.queryStringParameters) ||
+      hasUserIdParameter(event?.pathParameters)
+    ) {
+      throw badRequest("userId must not be provided for communication preferences.");
+    }
+
+    const persona = getPersonaFromQuery(event);
+    const authenticatedUser = getAuthenticatedUser(event);
+    const preferences = await this.service.getPreferences(authenticatedUser.userId, persona);
+    return { statusCode: 200, response: preferences };
+  }
+
+  async updatePreferences(event) {
+    if (
+      hasUserIdParameter(event?.queryStringParameters) ||
+      hasUserIdParameter(event?.pathParameters)
+    ) {
+      throw badRequest("userId must not be provided for communication preferences.");
+    }
+
+    const persona = getPersonaFromQuery(event);
+    const authenticatedUser = getAuthenticatedUser(event);
+    const body = parseBody(event);
+    const preferences = await this.service.savePreferences(authenticatedUser.userId, persona, body);
+    return { statusCode: 200, response: preferences };
+  }
+}

--- a/backend/functions/communication-preferences/data/repository.js
+++ b/backend/functions/communication-preferences/data/repository.js
@@ -1,0 +1,18 @@
+import Database from "database";
+import { Communication_Preferences } from "database/models/Communication_Preferences";
+
+export class CommunicationPreferencesRepository {
+  async findByUserIdAndPersona(userId, persona) {
+    const dataSource = await Database.getInstance();
+    return await dataSource
+      .getRepository(Communication_Preferences)
+      .findOne({ where: { user_id: userId, persona } });
+  }
+
+  async save(record) {
+    const dataSource = await Database.getInstance();
+    return await dataSource
+      .getRepository(Communication_Preferences)
+      .save(record);
+  }
+}

--- a/backend/functions/communication-preferences/index.js
+++ b/backend/functions/communication-preferences/index.js
@@ -1,0 +1,58 @@
+import { CommunicationPreferencesController } from "./controller/controller.js";
+
+const controller = new CommunicationPreferencesController();
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "Content-Type,Authorization",
+  "Access-Control-Allow-Methods": "GET,PUT,OPTIONS",
+};
+
+const createLambdaResponse = (returnedResponse) => ({
+  statusCode: returnedResponse?.statusCode || 200,
+  headers: {
+    ...corsHeaders,
+    ...(returnedResponse?.headers || {}),
+  },
+  body: JSON.stringify(returnedResponse?.response),
+});
+
+export const handler = async (event) => {
+  try {
+    if (event.httpMethod === "OPTIONS") {
+      return { statusCode: 200, headers: corsHeaders, body: "" };
+    }
+
+    if (event.httpMethod === "GET") {
+      return createLambdaResponse(await controller.getPreferences(event));
+    }
+
+    if (event.httpMethod === "PUT") {
+      return createLambdaResponse(await controller.updatePreferences(event));
+    }
+
+    return createLambdaResponse({
+      statusCode: 404,
+      response: { message: `Method ${event.httpMethod} not supported.` },
+    });
+  } catch (error) {
+    if (error?.statusCode) {
+      return createLambdaResponse({
+        statusCode: error.statusCode,
+        response: {
+          error: error.code || "REQUEST_FAILED",
+          message: error.message,
+        },
+      });
+    }
+
+    console.error("Communication preferences handler failed", error);
+    return createLambdaResponse({
+      statusCode: 500,
+      response: {
+        error: "INTERNAL_ERROR",
+        message: "Internal Server Error",
+      },
+    });
+  }
+};

--- a/backend/functions/communication-preferences/metadata.json
+++ b/backend/functions/communication-preferences/metadata.json
@@ -1,0 +1,1 @@
+{ "functionName": "communication-preferences" }

--- a/backend/functions/communication-preferences/package.json
+++ b/backend/functions/communication-preferences/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "communication-preferences",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {},
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/backend/functions/communication-preferences/util/httpErrors.js
+++ b/backend/functions/communication-preferences/util/httpErrors.js
@@ -1,0 +1,12 @@
+export class HttpError extends Error {
+  constructor(statusCode, message, code = null) {
+    super(message);
+    this.name = "HttpError";
+    this.statusCode = statusCode;
+    this.code = code || `HTTP_${statusCode}`;
+  }
+}
+
+export const badRequest = (message) => new HttpError(400, message, "BAD_REQUEST");
+export const unauthorized = (message = "Authentication is required.") =>
+  new HttpError(401, message, "UNAUTHORIZED");

--- a/backend/test/communication-preferences/controller.test.js
+++ b/backend/test/communication-preferences/controller.test.js
@@ -1,0 +1,162 @@
+const { CommunicationPreferencesController } = require("../../functions/communication-preferences/controller/controller.js");
+
+const validPreferences = {
+  reservation: { email: true, sms: false, push: true },
+  cancellation: { email: true, sms: true, push: true },
+  messages: { email: true, sms: false, push: true },
+};
+
+const authenticatedEvent = (patch = {}) => ({
+  requestContext: {
+    authorizer: {
+      claims: {
+        sub: "user-1",
+        "custom:group": "Guest",
+      },
+    },
+  },
+  queryStringParameters: { persona: "host" },
+  pathParameters: null,
+  ...patch,
+});
+
+const createController = () => {
+  const service = {
+    getPreferences: jest.fn(async () => validPreferences),
+    savePreferences: jest.fn(async () => validPreferences),
+  };
+  return {
+    service,
+    controller: new CommunicationPreferencesController({ service }),
+  };
+};
+
+describe("CommunicationPreferencesController", () => {
+  test("GET uses claims.sub and normalized persona", async () => {
+    const { controller, service } = createController();
+
+    await expect(controller.getPreferences(authenticatedEvent())).resolves.toEqual({
+      statusCode: 200,
+      response: validPreferences,
+    });
+    expect(service.getPreferences).toHaveBeenCalledWith("user-1", "HOST");
+  });
+
+  test("GET supports guest persona for the same current-user endpoint", async () => {
+    const { controller, service } = createController();
+
+    await controller.getPreferences(authenticatedEvent({ queryStringParameters: { persona: "guest" } }));
+
+    expect(service.getPreferences).toHaveBeenCalledWith("user-1", "GUEST");
+  });
+
+  test("PUT parses the complete matrix and uses claims.sub plus normalized persona", async () => {
+    const { controller, service } = createController();
+    const event = authenticatedEvent({ body: JSON.stringify(validPreferences) });
+
+    await expect(controller.updatePreferences(event)).resolves.toEqual({
+      statusCode: 200,
+      response: validPreferences,
+    });
+    expect(service.savePreferences).toHaveBeenCalledWith("user-1", "HOST", validPreferences);
+  });
+
+  test("supports HTTP API jwt authorizer claims", async () => {
+    const { controller, service } = createController();
+    const event = {
+      body: JSON.stringify(validPreferences),
+      queryStringParameters: { persona: "guest" },
+      requestContext: {
+        authorizer: {
+          jwt: {
+            claims: {
+              sub: "jwt-user-1",
+            },
+          },
+        },
+      },
+    };
+
+    await controller.updatePreferences(event);
+
+    expect(service.savePreferences).toHaveBeenCalledWith("jwt-user-1", "GUEST", validPreferences);
+  });
+
+  test("missing persona is rejected", async () => {
+    const { controller, service } = createController();
+
+    await expect(controller.getPreferences(authenticatedEvent({ queryStringParameters: null }))).rejects.toMatchObject({
+      statusCode: 400,
+      code: "BAD_REQUEST",
+    });
+    expect(service.getPreferences).not.toHaveBeenCalled();
+  });
+
+  test("invalid persona is rejected", async () => {
+    const { controller, service } = createController();
+
+    await expect(controller.updatePreferences(authenticatedEvent({
+      queryStringParameters: { persona: "admin" },
+      body: JSON.stringify(validPreferences),
+    }))).rejects.toMatchObject({ statusCode: 400, code: "BAD_REQUEST" });
+    expect(service.savePreferences).not.toHaveBeenCalled();
+  });
+
+  test("missing auth is rejected", async () => {
+    const { controller, service } = createController();
+
+    await expect(controller.getPreferences({ queryStringParameters: { persona: "host" } })).rejects.toMatchObject({
+      statusCode: 401,
+      code: "UNAUTHORIZED",
+    });
+    expect(service.getPreferences).not.toHaveBeenCalled();
+  });
+
+  test("auth without sub is rejected", async () => {
+    const { controller, service } = createController();
+
+    await expect(controller.getPreferences(authenticatedEvent({
+      requestContext: { authorizer: { claims: { username: "user-1" } } },
+    }))).rejects.toMatchObject({ statusCode: 401, code: "UNAUTHORIZED" });
+    expect(service.getPreferences).not.toHaveBeenCalled();
+  });
+
+  test("invalid JSON body is rejected", async () => {
+    const { controller, service } = createController();
+
+    await expect(controller.updatePreferences(authenticatedEvent({ body: "not-json" }))).rejects.toMatchObject({
+      statusCode: 400,
+      code: "BAD_REQUEST",
+    });
+    expect(service.savePreferences).not.toHaveBeenCalled();
+  });
+
+  test("missing body is rejected", async () => {
+    const { controller, service } = createController();
+
+    await expect(controller.updatePreferences(authenticatedEvent())).rejects.toMatchObject({
+      statusCode: 400,
+      code: "BAD_REQUEST",
+    });
+    expect(service.savePreferences).not.toHaveBeenCalled();
+  });
+
+  test("query userId spoofing is rejected", async () => {
+    const { controller, service } = createController();
+
+    await expect(controller.getPreferences(authenticatedEvent({
+      queryStringParameters: { persona: "host", userId: "other-user" },
+    }))).rejects.toMatchObject({ statusCode: 400, code: "BAD_REQUEST" });
+    expect(service.getPreferences).not.toHaveBeenCalled();
+  });
+
+  test("path userId spoofing is rejected", async () => {
+    const { controller, service } = createController();
+
+    await expect(controller.updatePreferences(authenticatedEvent({
+      pathParameters: { user_id: "other-user" },
+      body: JSON.stringify(validPreferences),
+    }))).rejects.toMatchObject({ statusCode: 400, code: "BAD_REQUEST" });
+    expect(service.savePreferences).not.toHaveBeenCalled();
+  });
+});

--- a/backend/test/communication-preferences/repository.test.js
+++ b/backend/test/communication-preferences/repository.test.js
@@ -1,0 +1,153 @@
+const mockTypeOrmRepository = {
+  findOne: jest.fn(),
+  save: jest.fn(),
+};
+
+const mockDataSource = {
+  getRepository: jest.fn(() => mockTypeOrmRepository),
+};
+
+jest.mock("database", () => ({
+  __esModule: true,
+  default: {
+    getInstance: jest.fn(async () => mockDataSource),
+  },
+}));
+
+const Database = require("database").default;
+const { Communication_Preferences } = require("../../ORM/models/Communication_Preferences.js");
+const { CommunicationPreferencesRepository } = require("../../functions/communication-preferences/data/repository.js");
+
+const fullRecord = {
+  user_id: "user-1",
+  persona: "HOST",
+  reservation_email: true,
+  reservation_sms: true,
+  reservation_push: false,
+  cancellation_email: true,
+  cancellation_sms: false,
+  cancellation_push: true,
+  messages_email: false,
+  messages_sms: true,
+  messages_push: false,
+  created_at: 100,
+  updated_at: 200,
+};
+
+describe("CommunicationPreferencesRepository", () => {
+  let repository;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    repository = new CommunicationPreferencesRepository();
+  });
+
+  test("findByUserIdAndPersona queries the exact composite identity", async () => {
+    mockTypeOrmRepository.findOne.mockResolvedValue(fullRecord);
+
+    await expect(repository.findByUserIdAndPersona("user-1", "HOST")).resolves.toBe(fullRecord);
+
+    expect(Database.getInstance).toHaveBeenCalledTimes(1);
+    expect(mockDataSource.getRepository).toHaveBeenCalledWith(Communication_Preferences);
+    expect(mockTypeOrmRepository.findOne).toHaveBeenCalledWith({ where: { user_id: "user-1", persona: "HOST" } });
+  });
+
+  test("findByUserIdAndPersona returns null for a missing composite row", async () => {
+    mockTypeOrmRepository.findOne.mockResolvedValue(null);
+
+    await expect(repository.findByUserIdAndPersona("missing-user", "GUEST")).resolves.toBeNull();
+
+    expect(mockTypeOrmRepository.findOne).toHaveBeenCalledWith({ where: { user_id: "missing-user", persona: "GUEST" } });
+  });
+
+  test("save inserts a complete communication preferences record", async () => {
+    mockTypeOrmRepository.save.mockResolvedValue(fullRecord);
+
+    await expect(repository.save(fullRecord)).resolves.toBe(fullRecord);
+
+    expect(Database.getInstance).toHaveBeenCalledTimes(1);
+    expect(mockDataSource.getRepository).toHaveBeenCalledWith(Communication_Preferences);
+    expect(mockTypeOrmRepository.save).toHaveBeenCalledWith(fullRecord);
+  });
+
+  test("save passes the exact user_id, persona, and all preference columns to TypeORM", async () => {
+    mockTypeOrmRepository.save.mockResolvedValue(fullRecord);
+
+    await repository.save(fullRecord);
+
+    expect(mockTypeOrmRepository.save).toHaveBeenCalledWith({
+      user_id: "user-1",
+      persona: "HOST",
+      reservation_email: true,
+      reservation_sms: true,
+      reservation_push: false,
+      cancellation_email: true,
+      cancellation_sms: false,
+      cancellation_push: true,
+      messages_email: false,
+      messages_sms: true,
+      messages_push: false,
+      created_at: 100,
+      updated_at: 200,
+    });
+  });
+
+  test("subsequent save updates/upserts the same user/persona without creating a duplicate row", async () => {
+    const rows = new Map();
+    mockTypeOrmRepository.save.mockImplementation(async (record) => {
+      const key = `${record.user_id}:${record.persona}`;
+      rows.set(key, { ...(rows.get(key) || {}), ...record });
+      return rows.get(key);
+    });
+
+    await repository.save({ ...fullRecord, created_at: 100, updated_at: 200 });
+    await repository.save({ ...fullRecord, created_at: 100, updated_at: 300, messages_sms: false });
+
+    expect(rows.size).toBe(1);
+    expect(rows.get("user-1:HOST")).toEqual(expect.objectContaining({
+      user_id: "user-1",
+      persona: "HOST",
+      created_at: 100,
+      updated_at: 300,
+      messages_sms: false,
+    }));
+    expect(mockTypeOrmRepository.save).toHaveBeenCalledTimes(2);
+  });
+
+  test("HOST and GUEST rows for the same user remain independent", async () => {
+    const rows = new Map();
+    mockTypeOrmRepository.save.mockImplementation(async (record) => {
+      rows.set(`${record.user_id}:${record.persona}`, { ...record });
+      return record;
+    });
+
+    await repository.save({ ...fullRecord, persona: "HOST", messages_sms: false, created_at: 100, updated_at: 200 });
+    await repository.save({ ...fullRecord, persona: "GUEST", messages_sms: true, created_at: 300, updated_at: 400 });
+
+    expect(rows.size).toBe(2);
+    expect(rows.get("user-1:HOST")).toEqual(expect.objectContaining({ persona: "HOST", messages_sms: false }));
+    expect(rows.get("user-1:GUEST")).toEqual(expect.objectContaining({ persona: "GUEST", messages_sms: true }));
+  });
+
+  test("update records preserve created_at and change updated_at when provided by the service", async () => {
+    const updateRecord = {
+      ...fullRecord,
+      created_at: 100,
+      updated_at: 999,
+      reservation_sms: false,
+      messages_email: true,
+    };
+    mockTypeOrmRepository.save.mockResolvedValue(updateRecord);
+
+    await repository.save(updateRecord);
+
+    expect(mockTypeOrmRepository.save).toHaveBeenCalledWith(expect.objectContaining({
+      user_id: "user-1",
+      persona: "HOST",
+      created_at: 100,
+      updated_at: 999,
+      reservation_sms: false,
+      messages_email: true,
+    }));
+  });
+});

--- a/backend/test/communication-preferences/service.test.js
+++ b/backend/test/communication-preferences/service.test.js
@@ -1,0 +1,247 @@
+const {
+  CommunicationPreferencesService,
+  DEFAULT_COMMUNICATION_PREFERENCES,
+  normalizePersona,
+} = require("../../functions/communication-preferences/business/service/service.js");
+
+const completePreferences = (overrides = {}) => ({
+  reservation: {
+    email: true,
+    sms: false,
+    push: true,
+    ...(overrides.reservation || {}),
+  },
+  cancellation: {
+    email: true,
+    sms: true,
+    push: true,
+    ...(overrides.cancellation || {}),
+  },
+  messages: {
+    email: true,
+    sms: false,
+    push: true,
+    ...(overrides.messages || {}),
+  },
+});
+
+const existingRecord = {
+  user_id: "user-1",
+  persona: "HOST",
+  reservation_email: true,
+  reservation_sms: true,
+  reservation_push: false,
+  cancellation_email: true,
+  cancellation_sms: false,
+  cancellation_push: true,
+  messages_email: false,
+  messages_sms: true,
+  messages_push: false,
+  created_at: 100,
+  updated_at: 200,
+};
+
+const createRepository = ({ rows = [] } = {}) => {
+  const records = new Map(rows.map((row) => [`${row.user_id}:${row.persona}`, { ...row }]));
+  return {
+    records,
+    findByUserIdAndPersona: jest.fn(async (userId, persona) => records.get(`${userId}:${persona}`) || null),
+    save: jest.fn(async (record) => {
+      records.set(`${record.user_id}:${record.persona}`, { ...record });
+      return records.get(`${record.user_id}:${record.persona}`);
+    }),
+  };
+};
+
+const createService = ({ rows = [], now = 12345 } = {}) => {
+  const repository = createRepository({ rows });
+  return {
+    repository,
+    service: new CommunicationPreferencesService({ repository, now: () => now }),
+  };
+};
+
+describe("CommunicationPreferencesService", () => {
+  test("normalizes supported personas", () => {
+    expect(normalizePersona("host")).toBe("HOST");
+    expect(normalizePersona("GUEST")).toBe("GUEST");
+  });
+
+  test("rejects missing persona", () => {
+    expect(() => normalizePersona()).toThrow("persona must be one of HOST or GUEST.");
+  });
+
+  test("rejects invalid persona", () => {
+    expect(() => normalizePersona("admin")).toThrow("persona must be one of HOST or GUEST.");
+  });
+
+  test("GET returns defaults when no row exists for the user/persona", async () => {
+    const { service, repository } = createService();
+
+    await expect(service.getPreferences("user-1", "HOST")).resolves.toEqual(DEFAULT_COMMUNICATION_PREFERENCES);
+    expect(repository.findByUserIdAndPersona).toHaveBeenCalledWith("user-1", "HOST");
+    expect(repository.save).not.toHaveBeenCalled();
+  });
+
+  test("GET returns existing preferences scoped to persona", async () => {
+    const { service, repository } = createService({ rows: [existingRecord] });
+
+    await expect(service.getPreferences("user-1", "host")).resolves.toEqual({
+      reservation: { email: true, sms: true, push: false },
+      cancellation: { email: true, sms: false, push: true },
+      messages: { email: false, sms: true, push: false },
+    });
+    expect(repository.findByUserIdAndPersona).toHaveBeenCalledWith("user-1", "HOST");
+  });
+
+  test("GET HOST does not return a GUEST row for the same user", async () => {
+    const guestRecord = { ...existingRecord, persona: "GUEST", messages_sms: false };
+    const { service } = createService({ rows: [guestRecord] });
+
+    await expect(service.getPreferences("user-1", "HOST")).resolves.toEqual(DEFAULT_COMMUNICATION_PREFERENCES);
+  });
+
+  test("GET GUEST does not return a HOST row for the same user", async () => {
+    const { service } = createService({ rows: [existingRecord] });
+
+    await expect(service.getPreferences("user-1", "GUEST")).resolves.toEqual(DEFAULT_COMMUNICATION_PREFERENCES);
+  });
+
+  test("PUT persists valid complete HOST preferences for the authenticated user/persona", async () => {
+    const { service, repository } = createService({ now: 777 });
+    const payload = completePreferences({
+      reservation: { sms: true, push: false },
+      cancellation: { sms: false },
+      messages: { email: false, sms: true, push: false },
+    });
+
+    await expect(service.savePreferences("user-1", "host", payload)).resolves.toEqual({
+      reservation: { email: true, sms: true, push: false },
+      cancellation: { email: true, sms: false, push: true },
+      messages: { email: false, sms: true, push: false },
+    });
+
+    expect(repository.save).toHaveBeenCalledWith({
+      user_id: "user-1",
+      persona: "HOST",
+      reservation_email: true,
+      reservation_sms: true,
+      reservation_push: false,
+      cancellation_email: true,
+      cancellation_sms: false,
+      cancellation_push: true,
+      messages_email: false,
+      messages_sms: true,
+      messages_push: false,
+      created_at: 777,
+      updated_at: 777,
+    });
+  });
+
+  test("PUT HOST does not modify GUEST for the same user", async () => {
+    const guestRecord = { ...existingRecord, persona: "GUEST", messages_sms: true, created_at: 10, updated_at: 20 };
+    const { service, repository } = createService({ rows: [guestRecord], now: 999 });
+
+    await service.savePreferences("user-1", "HOST", completePreferences({ messages: { sms: false } }));
+
+    expect(repository.records.get("user-1:GUEST")).toEqual(guestRecord);
+    expect(repository.records.get("user-1:HOST")).toEqual(expect.objectContaining({
+      persona: "HOST",
+      messages_sms: false,
+      created_at: 999,
+      updated_at: 999,
+    }));
+  });
+
+  test("PUT GUEST does not modify HOST for the same user", async () => {
+    const hostRecord = { ...existingRecord, persona: "HOST", messages_sms: true, created_at: 10, updated_at: 20 };
+    const { service, repository } = createService({ rows: [hostRecord], now: 999 });
+
+    await service.savePreferences("user-1", "GUEST", completePreferences({ messages: { sms: false } }));
+
+    expect(repository.records.get("user-1:HOST")).toEqual(hostRecord);
+    expect(repository.records.get("user-1:GUEST")).toEqual(expect.objectContaining({
+      persona: "GUEST",
+      messages_sms: false,
+      created_at: 999,
+      updated_at: 999,
+    }));
+  });
+
+  test("PUT preserves created_at independently when updating an existing persona row", async () => {
+    const { service, repository } = createService({ rows: [existingRecord], now: 999 });
+
+    await service.savePreferences("user-1", "HOST", completePreferences());
+
+    expect(repository.save).toHaveBeenCalledWith(expect.objectContaining({
+      user_id: "user-1",
+      persona: "HOST",
+      created_at: 100,
+      updated_at: 999,
+    }));
+  });
+
+  test("rejects unknown top-level fields", async () => {
+    const { service, repository } = createService();
+
+    await expect(service.savePreferences("user-1", "HOST", {
+      ...completePreferences(),
+      marketing: { email: true, sms: false, push: true },
+    })).rejects.toMatchObject({ statusCode: 400, code: "BAD_REQUEST" });
+    expect(repository.save).not.toHaveBeenCalled();
+  });
+
+  test("rejects unknown nested fields", async () => {
+    const { service, repository } = createService();
+
+    await expect(service.savePreferences("user-1", "HOST", completePreferences({
+      messages: { whatsapp: true },
+    }))).rejects.toMatchObject({ statusCode: 400, code: "BAD_REQUEST" });
+    expect(repository.save).not.toHaveBeenCalled();
+  });
+
+  test("rejects non-boolean values", async () => {
+    const { service, repository } = createService();
+
+    await expect(service.savePreferences("user-1", "HOST", completePreferences({
+      reservation: { sms: "false" },
+    }))).rejects.toMatchObject({ statusCode: 400, code: "BAD_REQUEST" });
+    expect(repository.save).not.toHaveBeenCalled();
+  });
+
+  test("rejects spoofed userId in the body", async () => {
+    const { service, repository } = createService();
+
+    await expect(service.savePreferences("user-1", "HOST", {
+      userId: "other-user",
+      ...completePreferences(),
+    })).rejects.toMatchObject({ statusCode: 400, code: "BAD_REQUEST" });
+    expect(repository.save).not.toHaveBeenCalled();
+  });
+
+  test("forces mandatory reservation email to true", async () => {
+    const { service, repository } = createService();
+
+    const response = await service.savePreferences("user-1", "HOST", completePreferences({
+      reservation: { email: false },
+    }));
+
+    expect(response.reservation.email).toBe(true);
+    expect(repository.save).toHaveBeenCalledWith(expect.objectContaining({
+      reservation_email: true,
+    }));
+  });
+
+  test("forces mandatory cancellation email to true", async () => {
+    const { service, repository } = createService();
+
+    const response = await service.savePreferences("user-1", "HOST", completePreferences({
+      cancellation: { email: false },
+    }));
+
+    expect(response.cancellation.email).toBe(true);
+    expect(repository.save).toHaveBeenCalledWith(expect.objectContaining({
+      cancellation_email: true,
+    }));
+  });
+});

--- a/frontend/web/src/components/settings/NotificationPreferencesForm.jsx
+++ b/frontend/web/src/components/settings/NotificationPreferencesForm.jsx
@@ -1,54 +1,64 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
-
-export const DEFAULT_NOTIFICATION_PREFERENCES = {
-    reservation: {
-        email: true,
-        sms: false,
-        push: true,
-    },
-    cancellation: {
-        email: true,
-        sms: true,
-        push: true,
-    },
-    messages: {
-        email: true,
-        sms: false,
-        push: true,
-    },
-};
+import {
+    DEFAULT_NOTIFICATION_PREFERENCES,
+    REQUIRED_COMMUNICATION_PREFERENCES,
+    enforceRequiredCommunicationPreferences,
+} from "./communicationPreferencesConfig";
 
 const EVENT_KEYS = ["reservation", "cancellation", "messages"];
 const CHANNEL_KEYS = ["email", "sms", "push"];
-const REQUIRED_PREFERENCES = {
-    reservation: { email: true },
-    cancellation: { email: true },
-};
+const isRequiredPreference = (eventKey, channelKey) => Boolean(REQUIRED_COMMUNICATION_PREFERENCES[eventKey]?.[channelKey]);
 
-const isRequiredPreference = (eventKey, channelKey) => Boolean(REQUIRED_PREFERENCES[eventKey]?.[channelKey]);
+const NotificationPreferencesForm = ({
+    labels,
+    preferences: controlledPreferences,
+    onPreferencesChange,
+    onSave,
+    isLoading = false,
+    isSaving = false,
+    isDirty = false,
+    saveSuccess = false,
+    error = "",
+}) => {
+    const [localPreferences, setLocalPreferences] = useState(DEFAULT_NOTIFICATION_PREFERENCES);
+    const isControlled = controlledPreferences && onPreferencesChange;
+    const preferences = enforceRequiredCommunicationPreferences(isControlled ? controlledPreferences : localPreferences);
+    const saveDisabled = isLoading || isSaving || !isDirty;
 
-const NotificationPreferencesForm = ({ labels }) => {
-    const [preferences, setPreferences] = useState(DEFAULT_NOTIFICATION_PREFERENCES);
+    const updatePreferences = (nextPreferences) => {
+        const normalized = enforceRequiredCommunicationPreferences(nextPreferences);
+        if (isControlled) {
+            onPreferencesChange(normalized);
+            return;
+        }
+        setLocalPreferences(normalized);
+    };
 
     const togglePreference = (eventKey, channelKey) => {
-        if (isRequiredPreference(eventKey, channelKey)) {
+        if (isLoading || isSaving || isRequiredPreference(eventKey, channelKey)) {
             return;
         }
 
-        setPreferences((current) => ({
-            ...current,
+        updatePreferences({
+            ...preferences,
             [eventKey]: {
-                ...current[eventKey],
-                [channelKey]: !current[eventKey][channelKey],
+                ...preferences[eventKey],
+                [channelKey]: !preferences[eventKey][channelKey],
             },
-        }));
+        });
     };
 
     return (
         <div className="personal-data-section">
             <h2 className="personal-data-section-title">{labels.sectionTitle}</h2>
-            <div className="personal-data-card notification-preferences-card">
+            <div className="personal-data-card notification-preferences-card" aria-busy={isLoading || isSaving}>
+                {isLoading && (
+                    <div className="notification-preferences-status" role="status">
+                        Loading communication preferences...
+                    </div>
+                )}
+
                 <div className="notification-preferences-grid" role="table" aria-label={labels.sectionTitle}>
                     <div className="notification-preferences-row notification-preferences-row--head" role="row">
                         <div className="notification-preferences-cell notification-preferences-cell--event" role="columnheader" />
@@ -79,7 +89,7 @@ const NotificationPreferencesForm = ({ labels }) => {
                                             aria-checked={checked}
                                             aria-label={ariaLabel}
                                             aria-describedby={required ? requiredId : undefined}
-                                            disabled={required}
+                                            disabled={required || isLoading || isSaving}
                                             onClick={() => togglePreference(eventKey, channelKey)}
                                         >
                                             <span className="notification-toggle-text">{checked ? labels.states.on : labels.states.off}</span>
@@ -97,9 +107,13 @@ const NotificationPreferencesForm = ({ labels }) => {
                     ))}
                 </div>
 
-                <div className="personal-data-card-footer">
-                    <button type="button" className="pd-save-btn" disabled>
-                        {labels.actions.saveChanges}
+                <div className="personal-data-card-footer notification-preferences-footer">
+                    <div className="notification-preferences-feedback" aria-live="polite">
+                        {error && <span className="notification-preferences-error">{error}</span>}
+                        {saveSuccess && !error && <span className="notification-preferences-success">Communication preferences saved.</span>}
+                    </div>
+                    <button type="button" className="pd-save-btn" disabled={saveDisabled} onClick={onSave}>
+                        {isSaving ? "Saving..." : labels.actions.saveChanges}
                     </button>
                 </div>
             </div>
@@ -130,6 +144,30 @@ NotificationPreferencesForm.propTypes = {
             saveChanges: PropTypes.string.isRequired,
         }).isRequired,
     }).isRequired,
+    preferences: PropTypes.shape({
+        reservation: PropTypes.shape({
+            email: PropTypes.bool.isRequired,
+            sms: PropTypes.bool.isRequired,
+            push: PropTypes.bool.isRequired,
+        }),
+        cancellation: PropTypes.shape({
+            email: PropTypes.bool.isRequired,
+            sms: PropTypes.bool.isRequired,
+            push: PropTypes.bool.isRequired,
+        }),
+        messages: PropTypes.shape({
+            email: PropTypes.bool.isRequired,
+            sms: PropTypes.bool.isRequired,
+            push: PropTypes.bool.isRequired,
+        }),
+    }),
+    onPreferencesChange: PropTypes.func,
+    onSave: PropTypes.func,
+    isLoading: PropTypes.bool,
+    isSaving: PropTypes.bool,
+    isDirty: PropTypes.bool,
+    saveSuccess: PropTypes.bool,
+    error: PropTypes.string,
 };
 
 export default NotificationPreferencesForm;

--- a/frontend/web/src/components/settings/api/communicationPreferences.js
+++ b/frontend/web/src/components/settings/api/communicationPreferences.js
@@ -1,0 +1,63 @@
+import { Auth } from "aws-amplify";
+import { enforceRequiredCommunicationPreferences } from "../communicationPreferencesConfig";
+
+export const COMMUNICATION_PREFERENCES_ENDPOINT =
+    process.env.REACT_APP_COMMUNICATION_PREFERENCES_API_URL || "/user/communication-preferences";
+
+export const normalizeCommunicationPreferencesPersona = (persona) => {
+    const normalized = String(persona || "").trim().toLowerCase();
+    if (!["host", "guest"].includes(normalized)) {
+        throw new Error("Communication preferences persona must be host or guest.");
+    }
+    return normalized;
+};
+
+export const buildCommunicationPreferencesUrl = (persona) =>
+    `${COMMUNICATION_PREFERENCES_ENDPOINT}?persona=${encodeURIComponent(normalizeCommunicationPreferencesPersona(persona))}`;
+
+const getIdToken = async () => {
+    const session = await Auth.currentSession();
+    const token = session.getIdToken().getJwtToken();
+
+    if (!token) {
+        throw new Error("Authentication is required.");
+    }
+
+    return token;
+};
+
+const requestCommunicationPreferences = async ({ method, body, persona, errorMessage } = {}) => {
+    const token = await getIdToken();
+    const response = await fetch(buildCommunicationPreferencesUrl(persona), {
+        method,
+        cache: "no-store",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+        },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+
+    const payload = await response.json().catch(() => null);
+
+    if (!response.ok) {
+        throw new Error(errorMessage);
+    }
+
+    return enforceRequiredCommunicationPreferences(payload);
+};
+
+export const fetchCommunicationPreferences = (persona) =>
+    requestCommunicationPreferences({
+        method: "GET",
+        persona,
+        errorMessage: "We could not load your communication preferences. Please try again.",
+    });
+
+export const saveCommunicationPreferences = (persona, preferences) =>
+    requestCommunicationPreferences({
+        method: "PUT",
+        persona,
+        body: enforceRequiredCommunicationPreferences(preferences),
+        errorMessage: "We could not save your communication preferences. Please try again.",
+    });

--- a/frontend/web/src/components/settings/communicationPreferencesConfig.js
+++ b/frontend/web/src/components/settings/communicationPreferencesConfig.js
@@ -1,0 +1,40 @@
+export const DEFAULT_NOTIFICATION_PREFERENCES = {
+    reservation: {
+        email: true,
+        sms: false,
+        push: true,
+    },
+    cancellation: {
+        email: true,
+        sms: true,
+        push: true,
+    },
+    messages: {
+        email: true,
+        sms: false,
+        push: true,
+    },
+};
+
+export const REQUIRED_COMMUNICATION_PREFERENCES = {
+    reservation: { email: true },
+    cancellation: { email: true },
+};
+
+export const enforceRequiredCommunicationPreferences = (preferences = DEFAULT_NOTIFICATION_PREFERENCES) => ({
+    reservation: {
+        email: true,
+        sms: Boolean(preferences?.reservation?.sms),
+        push: Boolean(preferences?.reservation?.push),
+    },
+    cancellation: {
+        email: true,
+        sms: Boolean(preferences?.cancellation?.sms),
+        push: Boolean(preferences?.cancellation?.push),
+    },
+    messages: {
+        email: Boolean(preferences?.messages?.email),
+        sms: Boolean(preferences?.messages?.sms),
+        push: Boolean(preferences?.messages?.push),
+    },
+});

--- a/frontend/web/src/features/guestdashboard/GuestCommunicationPreferences.jsx
+++ b/frontend/web/src/features/guestdashboard/GuestCommunicationPreferences.jsx
@@ -2,6 +2,7 @@ import React, { useContext } from "react";
 import { Link } from "react-router-dom";
 import { LanguageContext } from "../../context/LanguageContext";
 import NotificationPreferencesForm from "../../components/settings/NotificationPreferencesForm";
+import useCommunicationPreferences from "../../hooks/useCommunicationPreferences";
 import en from "../../content/en.json";
 import nl from "../../content/nl.json";
 import de from "../../content/de.json";
@@ -15,6 +16,7 @@ const GuestCommunicationPreferences = () => {
     const { language } = useContext(LanguageContext);
     const settingsContent = contentByLanguage[language]?.settings ?? contentByLanguage.en.settings;
     const t = settingsContent.communicationPreferences;
+    const communicationPreferences = useCommunicationPreferences("guest");
 
     return (
         <div className="personal-data-page">
@@ -29,7 +31,7 @@ const GuestCommunicationPreferences = () => {
                 <p className="personal-data-subtitle">{t.subtitle}</p>
             </div>
 
-            <NotificationPreferencesForm labels={t} />
+            <NotificationPreferencesForm labels={t} {...communicationPreferences} />
         </div>
     );
 };

--- a/frontend/web/src/features/hostdashboard/hostsettings/pages/HostCommunicationPreferences.jsx
+++ b/frontend/web/src/features/hostdashboard/hostsettings/pages/HostCommunicationPreferences.jsx
@@ -2,6 +2,7 @@ import React, { useContext } from "react";
 import { Link } from "react-router-dom";
 import { LanguageContext } from "../../../../context/LanguageContext";
 import NotificationPreferencesForm from "../../../../components/settings/NotificationPreferencesForm";
+import useCommunicationPreferences from "../../../../hooks/useCommunicationPreferences";
 import en from "../../../../content/en.json";
 import nl from "../../../../content/nl.json";
 import de from "../../../../content/de.json";
@@ -15,6 +16,7 @@ const HostCommunicationPreferences = () => {
     const { language } = useContext(LanguageContext);
     const settingsContent = contentByLanguage[language]?.settings ?? contentByLanguage.en.settings;
     const t = settingsContent.communicationPreferences;
+    const communicationPreferences = useCommunicationPreferences("host");
 
     return (
         <div className="personal-data-page">
@@ -29,7 +31,7 @@ const HostCommunicationPreferences = () => {
                 <p className="personal-data-subtitle">{t.subtitle}</p>
             </div>
 
-            <NotificationPreferencesForm labels={t} />
+            <NotificationPreferencesForm labels={t} {...communicationPreferences} />
         </div>
     );
 };

--- a/frontend/web/src/features/hostdashboard/hostsettings/styles/hostSettings.css
+++ b/frontend/web/src/features/hostdashboard/hostsettings/styles/hostSettings.css
@@ -719,6 +719,35 @@
     overflow: hidden;
 }
 
+.notification-preferences-status {
+    padding: 14px 20px;
+    background: #f9fafb;
+    border-bottom: 1px solid #f3f4f6;
+    color: #6b7280;
+    font-size: 0.875rem;
+}
+
+.notification-preferences-footer {
+    align-items: center;
+    gap: 16px;
+}
+
+.notification-preferences-feedback {
+    flex: 1;
+    min-height: 20px;
+    font-size: 0.85rem;
+}
+
+.notification-preferences-success {
+    color: #166534;
+    font-weight: 600;
+}
+
+.notification-preferences-error {
+    color: #b91c1c;
+    font-weight: 600;
+}
+
 .notification-preferences-grid {
     width: 100%;
 }

--- a/frontend/web/src/hooks/useCommunicationPreferences.js
+++ b/frontend/web/src/hooks/useCommunicationPreferences.js
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+    fetchCommunicationPreferences,
+    saveCommunicationPreferences,
+} from "../components/settings/api/communicationPreferences";
+import {
+    DEFAULT_NOTIFICATION_PREFERENCES,
+    enforceRequiredCommunicationPreferences,
+} from "../components/settings/communicationPreferencesConfig";
+
+const toComparable = (preferences) => JSON.stringify(enforceRequiredCommunicationPreferences(preferences));
+
+const cloneDefaults = () => enforceRequiredCommunicationPreferences(DEFAULT_NOTIFICATION_PREFERENCES);
+
+export default function useCommunicationPreferences(persona) {
+    const [preferences, setPreferences] = useState(cloneDefaults);
+    const [baseline, setBaseline] = useState(cloneDefaults);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isSaving, setIsSaving] = useState(false);
+    const [error, setError] = useState("");
+    const [saveSuccess, setSaveSuccess] = useState(false);
+
+    useEffect(() => {
+        let isMounted = true;
+
+        const loadPreferences = async () => {
+            setIsLoading(true);
+            setError("");
+            setSaveSuccess(false);
+
+            try {
+                const loaded = await fetchCommunicationPreferences(persona);
+                if (!isMounted) return;
+                setPreferences(loaded);
+                setBaseline(loaded);
+            } catch {
+                if (!isMounted) return;
+                const defaults = cloneDefaults();
+                setPreferences(defaults);
+                setBaseline(defaults);
+                setError("We could not load your communication preferences. Please try again.");
+            } finally {
+                if (isMounted) {
+                    setIsLoading(false);
+                }
+            }
+        };
+
+        loadPreferences();
+
+        return () => {
+            isMounted = false;
+        };
+    }, [persona]);
+
+    const normalizedPreferences = useMemo(
+        () => enforceRequiredCommunicationPreferences(preferences),
+        [preferences]
+    );
+
+    const isDirty = useMemo(
+        () => toComparable(normalizedPreferences) !== toComparable(baseline),
+        [baseline, normalizedPreferences]
+    );
+
+    const updatePreferences = useCallback((nextPreferences) => {
+        setPreferences(enforceRequiredCommunicationPreferences(nextPreferences));
+        setSaveSuccess(false);
+        setError("");
+    }, []);
+
+    const save = useCallback(async () => {
+        if (isLoading || isSaving || !isDirty) return;
+
+        setIsSaving(true);
+        setError("");
+        setSaveSuccess(false);
+
+        try {
+            const saved = await saveCommunicationPreferences(persona, normalizedPreferences);
+            setPreferences(saved);
+            setBaseline(saved);
+            setSaveSuccess(true);
+        } catch {
+            setError("We could not save your communication preferences. Your changes are still here.");
+        } finally {
+            setIsSaving(false);
+        }
+    }, [isDirty, isLoading, isSaving, normalizedPreferences, persona]);
+
+    return {
+        preferences: normalizedPreferences,
+        setPreferences: updatePreferences,
+        onPreferencesChange: updatePreferences,
+        isLoading,
+        isSaving,
+        isDirty,
+        saveSuccess,
+        error,
+        save,
+        onSave: save,
+    };
+}

--- a/frontend/web/src/tests/settings/CommunicationPreferencesPages.test.jsx
+++ b/frontend/web/src/tests/settings/CommunicationPreferencesPages.test.jsx
@@ -1,0 +1,185 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MemoryRouter } from "react-router-dom";
+import { LanguageContext } from "../../context/LanguageContext";
+import HostCommunicationPreferences from "../../features/hostdashboard/hostsettings/pages/HostCommunicationPreferences";
+import GuestCommunicationPreferences from "../../features/guestdashboard/GuestCommunicationPreferences";
+import {
+    fetchCommunicationPreferences,
+    saveCommunicationPreferences,
+} from "../../components/settings/api/communicationPreferences";
+
+jest.mock("../../components/settings/api/communicationPreferences", () => ({
+    fetchCommunicationPreferences: jest.fn(),
+    saveCommunicationPreferences: jest.fn(),
+}));
+
+const hostPreferences = {
+    reservation: { email: true, sms: true, push: false },
+    cancellation: { email: true, sms: false, push: true },
+    messages: { email: false, sms: true, push: false },
+};
+
+const guestPreferences = {
+    reservation: { email: true, sms: false, push: true },
+    cancellation: { email: true, sms: true, push: false },
+    messages: { email: true, sms: false, push: true },
+};
+
+const defaults = {
+    reservation: { email: true, sms: false, push: true },
+    cancellation: { email: true, sms: true, push: true },
+    messages: { email: true, sms: false, push: true },
+};
+
+const renderWithLanguage = (ui) => render(
+    <LanguageContext.Provider value={{ language: "en" }}>
+        <MemoryRouter>{ui}</MemoryRouter>
+    </LanguageContext.Provider>
+);
+
+const getToggle = (eventName, channelName) =>
+    screen.getByRole("switch", { name: `${eventName} ${channelName} notifications` });
+
+const waitForLoadedPreferences = async () => {
+    await waitFor(() => expect(fetchCommunicationPreferences).toHaveBeenCalled());
+    await waitFor(() => expect(screen.queryByRole("status")).not.toBeInTheDocument());
+};
+
+describe("Communication Preferences pages", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        fetchCommunicationPreferences.mockResolvedValue(defaults);
+        saveCommunicationPreferences.mockResolvedValue(defaults);
+    });
+
+    test("Host page GET uses persona=host and populates saved preferences", async () => {
+        fetchCommunicationPreferences.mockResolvedValueOnce(hostPreferences);
+
+        renderWithLanguage(<HostCommunicationPreferences />);
+
+        expect(screen.getByRole("status")).toHaveTextContent("Loading communication preferences");
+        await waitForLoadedPreferences();
+
+        expect(fetchCommunicationPreferences).toHaveBeenCalledWith("host");
+        expect(getToggle("Reservation", "SMS")).toHaveAttribute("aria-checked", "true");
+        expect(getToggle("Reservation", "Push")).toHaveAttribute("aria-checked", "false");
+        expect(getToggle("Cancellation", "SMS")).toHaveAttribute("aria-checked", "false");
+        expect(getToggle("Messages", "Email")).toHaveAttribute("aria-checked", "false");
+        expect(screen.getByRole("button", { name: /save changes/i })).toBeDisabled();
+    });
+
+    test("Guest page GET uses persona=guest and default rendering", async () => {
+        renderWithLanguage(<GuestCommunicationPreferences />);
+
+        await waitForLoadedPreferences();
+
+        expect(fetchCommunicationPreferences).toHaveBeenCalledWith("guest");
+        expect(getToggle("Reservation", "Email")).toBeDisabled();
+        expect(getToggle("Reservation", "Email")).toHaveAttribute("aria-checked", "true");
+        expect(getToggle("Cancellation", "Email")).toBeDisabled();
+        expect(getToggle("Cancellation", "Email")).toHaveAttribute("aria-checked", "true");
+        expect(getToggle("Messages", "Email")).not.toBeDisabled();
+    });
+
+    test("editing enables Save and successful Host PUT sends persona plus exact complete matrix", async () => {
+        renderWithLanguage(<HostCommunicationPreferences />);
+        await waitForLoadedPreferences();
+
+        const reservationSms = getToggle("Reservation", "SMS");
+        const saveButton = screen.getByRole("button", { name: /save changes/i });
+        expect(saveButton).toBeDisabled();
+
+        fireEvent.click(reservationSms);
+        expect(saveButton).toBeEnabled();
+
+        saveCommunicationPreferences.mockResolvedValueOnce({
+            ...defaults,
+            reservation: { ...defaults.reservation, sms: true },
+        });
+
+        fireEvent.click(saveButton);
+
+        await waitFor(() => expect(saveCommunicationPreferences).toHaveBeenCalledWith("host", {
+            reservation: { email: true, sms: true, push: true },
+            cancellation: { email: true, sms: true, push: true },
+            messages: { email: true, sms: false, push: true },
+        }));
+        await waitFor(() => expect(screen.getByRole("button", { name: /save changes/i })).toBeDisabled());
+        expect(screen.getByText("Communication preferences saved.")).toBeInTheDocument();
+    });
+
+    test("required email fields remain true and disabled after backend data loads", async () => {
+        fetchCommunicationPreferences.mockResolvedValueOnce({
+            reservation: { email: false, sms: false, push: true },
+            cancellation: { email: false, sms: true, push: true },
+            messages: { email: true, sms: false, push: true },
+        });
+
+        renderWithLanguage(<HostCommunicationPreferences />);
+        await waitForLoadedPreferences();
+
+        expect(getToggle("Reservation", "Email")).toBeDisabled();
+        expect(getToggle("Reservation", "Email")).toHaveAttribute("aria-checked", "true");
+        expect(getToggle("Cancellation", "Email")).toBeDisabled();
+        expect(getToggle("Cancellation", "Email")).toHaveAttribute("aria-checked", "true");
+        expect(screen.getAllByText("Required")).toHaveLength(2);
+    });
+
+    test("failed Guest PUT preserves unsaved state", async () => {
+        saveCommunicationPreferences.mockRejectedValueOnce(new Error("network failed"));
+        renderWithLanguage(<GuestCommunicationPreferences />);
+        await waitForLoadedPreferences();
+
+        const messagesEmail = getToggle("Messages", "Email");
+        fireEvent.click(messagesEmail);
+        expect(messagesEmail).toHaveAttribute("aria-checked", "false");
+
+        fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+        await waitFor(() => expect(saveCommunicationPreferences).toHaveBeenCalledWith("guest", expect.any(Object)));
+        await waitFor(() => expect(screen.getByText("We could not save your communication preferences. Your changes are still here.")).toBeInTheDocument());
+        expect(getToggle("Messages", "Email")).toHaveAttribute("aria-checked", "false");
+        expect(screen.getByRole("button", { name: /save changes/i })).toBeEnabled();
+    });
+
+    test("Host and Guest page states are independent", async () => {
+        fetchCommunicationPreferences.mockResolvedValueOnce(hostPreferences);
+        const { unmount } = renderWithLanguage(<HostCommunicationPreferences />);
+        await waitForLoadedPreferences();
+        expect(getToggle("Reservation", "SMS")).toHaveAttribute("aria-checked", "true");
+        expect(getToggle("Messages", "Email")).toHaveAttribute("aria-checked", "false");
+        unmount();
+
+        fetchCommunicationPreferences.mockResolvedValueOnce(guestPreferences);
+        renderWithLanguage(<GuestCommunicationPreferences />);
+        await waitForLoadedPreferences();
+        expect(getToggle("Reservation", "SMS")).toHaveAttribute("aria-checked", "false");
+        expect(getToggle("Messages", "Email")).toHaveAttribute("aria-checked", "true");
+
+        expect(fetchCommunicationPreferences).toHaveBeenNthCalledWith(1, "host");
+        expect(fetchCommunicationPreferences).toHaveBeenNthCalledWith(2, "guest");
+    });
+
+    test("Host and Guest save through the same API contract with different personas", async () => {
+        const { unmount } = renderWithLanguage(<HostCommunicationPreferences />);
+        await waitForLoadedPreferences();
+        fireEvent.click(getToggle("Messages", "SMS"));
+        fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+        await waitFor(() => expect(saveCommunicationPreferences).toHaveBeenCalledTimes(1));
+        unmount();
+
+        fetchCommunicationPreferences.mockResolvedValue(defaults);
+        saveCommunicationPreferences.mockResolvedValue(defaults);
+        renderWithLanguage(<GuestCommunicationPreferences />);
+        await waitForLoadedPreferences();
+        fireEvent.click(getToggle("Messages", "SMS"));
+        fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+        await waitFor(() => expect(saveCommunicationPreferences).toHaveBeenCalledTimes(2));
+
+        expect(saveCommunicationPreferences.mock.calls[0][0]).toBe("host");
+        expect(saveCommunicationPreferences.mock.calls[1][0]).toBe("guest");
+        expect(saveCommunicationPreferences.mock.calls[0][1]).toEqual(saveCommunicationPreferences.mock.calls[1][1]);
+    });
+});

--- a/frontend/web/src/tests/settings/communicationPreferencesApi.test.js
+++ b/frontend/web/src/tests/settings/communicationPreferencesApi.test.js
@@ -1,0 +1,112 @@
+import {
+    COMMUNICATION_PREFERENCES_ENDPOINT,
+    buildCommunicationPreferencesUrl,
+    fetchCommunicationPreferences,
+    normalizeCommunicationPreferencesPersona,
+    saveCommunicationPreferences,
+} from "../../components/settings/api/communicationPreferences";
+import { Auth } from "aws-amplify";
+
+jest.mock("aws-amplify", () => ({
+    Auth: {
+        currentSession: jest.fn(),
+    },
+}));
+
+const mockSession = () => {
+    Auth.currentSession.mockResolvedValue({
+        getIdToken: () => ({
+            getJwtToken: () => "id-token-1",
+        }),
+    });
+};
+
+const savedPreferences = {
+    reservation: { email: true, sms: true, push: false },
+    cancellation: { email: true, sms: false, push: true },
+    messages: { email: false, sms: true, push: false },
+};
+
+describe("communicationPreferences API", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockSession();
+        global.fetch = jest.fn(async () => ({
+            ok: true,
+            json: async () => savedPreferences,
+        }));
+    });
+
+    test("normalizes allowed personas", () => {
+        expect(normalizeCommunicationPreferencesPersona("host")).toBe("host");
+        expect(normalizeCommunicationPreferencesPersona("GUEST")).toBe("guest");
+    });
+
+    test("rejects invalid persona before calling the API", async () => {
+        await expect(fetchCommunicationPreferences("admin")).rejects.toThrow("Communication preferences persona must be host or guest.");
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test("builds the same current-user endpoint with persona query", () => {
+        expect(buildCommunicationPreferencesUrl("host")).toBe(`${COMMUNICATION_PREFERENCES_ENDPOINT}?persona=host`);
+        expect(buildCommunicationPreferencesUrl("guest")).toBe(`${COMMUNICATION_PREFERENCES_ENDPOINT}?persona=guest`);
+    });
+
+    test("GET Host uses persona=host with Cognito authorizer token", async () => {
+        await expect(fetchCommunicationPreferences("host")).resolves.toEqual(savedPreferences);
+
+        expect(global.fetch).toHaveBeenCalledWith(`${COMMUNICATION_PREFERENCES_ENDPOINT}?persona=host`, expect.objectContaining({
+            method: "GET",
+            cache: "no-store",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: "Bearer id-token-1",
+            },
+        }));
+    });
+
+    test("GET Guest uses persona=guest with the same endpoint", async () => {
+        await fetchCommunicationPreferences("guest");
+
+        expect(global.fetch).toHaveBeenCalledWith(`${COMMUNICATION_PREFERENCES_ENDPOINT}?persona=guest`, expect.objectContaining({
+            method: "GET",
+        }));
+    });
+
+    test("PUT sends persona and complete matrix without user identity fields", async () => {
+        const attemptedPreferences = {
+            reservation: { email: false, sms: true, push: false },
+            cancellation: { email: false, sms: false, push: true },
+            messages: { email: false, sms: true, push: false },
+        };
+
+        await saveCommunicationPreferences("guest", attemptedPreferences);
+
+        const [url, request] = global.fetch.mock.calls[0];
+        const body = JSON.parse(request.body);
+
+        expect(url).toBe(`${COMMUNICATION_PREFERENCES_ENDPOINT}?persona=guest`);
+        expect(request.method).toBe("PUT");
+        expect(body).toEqual({
+            reservation: { email: true, sms: true, push: false },
+            cancellation: { email: true, sms: false, push: true },
+            messages: { email: false, sms: true, push: false },
+        });
+        expect(body.userId).toBeUndefined();
+        expect(body.user_id).toBeUndefined();
+        expect(body.hostId).toBeUndefined();
+        expect(body.guestId).toBeUndefined();
+    });
+
+    test("failed requests show a safe user-facing error", async () => {
+        global.fetch.mockResolvedValueOnce({
+            ok: false,
+            status: 500,
+            json: async () => ({ message: "AWS stack trace" }),
+        });
+
+        await expect(fetchCommunicationPreferences("host")).rejects.toThrow(
+            "We could not load your communication preferences. Please try again."
+        );
+    });
+});


### PR DESCRIPTION
## Close or Relate the Issue
[//]: # (Only if this should close the issue)
- Closes #2800

[//]: # (In the issue, a reference will be added to this pr)
- Related Issue: #3083

## Proposed Changes
[//]: # (Add a detailed description of the changes here)
Description:

- Added persistent Communication Preferences for Host and Guest.
- Added authenticated `GET` and `PUT /user/communication-preferences` endpoints.
- Uses Cognito `claims.sub` as the authenticated user identity.
- Added persona-based preference isolation so the same user can have separate `HOST` and `GUEST` preferences.
- Added Aurora DSQL `communication_preferences` model and migration using composite primary key `(user_id, persona)`.
- Added validation for `HOST` and `GUEST` personas.
- Enforced Reservation Email and Cancellation Email as required preferences.
- Connected the Host and Guest Communication Preferences pages to the backend API.
- Added loading, save, success, and error handling.
- Added backend controller, service, and repository tests.
- Added frontend API and page integration tests.
- Verified the complete Cognito → API Gateway → Lambda → Aurora DSQL flow.
- Verified Host and Guest preferences are stored independently and persist after refresh.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Optimization
- [ ] Documentation update

## Change Size
[//]: # (Indicate the size of this change.)
[//]: # (Clarify under Refactoring which parts are moved/unchanged code, so the reviewer doesn’t review old logic.)
- [x] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
- [ ] Big change (+-max 1000)
- [ ] Small change (less than 300)

## Refactoring
No existing feature was substantially refactored or moved.

Most of the approximately 1,600 changed lines are new Communication Preferences backend implementation, frontend integration, ORM/migration code, and automated tests.

Existing shared components were only modified where necessary to connect persistence and preference state.

## Evidence
- [ ] Screenshots or screen recording added for UI changes
- [ ] Before/after images added when relevant
- [ ] Images clearly show the implemented change
- [ ] Image quality is readable (no cropped or blurry evidence)

## Responsiveness
- [ ] UI checked on mobile
- [ ] UI checked on tablet
- [x] UI checked on desktop
- [x] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages
- [ ] NPM Packages installed
- [ ] NPM Packages removed
- [ ] NPM Packages updated
- [ ] Checked for vulnerabilities using "npm audit"

No new NPM packages were added, removed, or updated as part of this feature.

## Checklist
[//]: # (All boxes must be checked before merging.)
- [ ] Pull request has at least 2 reviewers assigned
- [x] PR title is descriptive and includes issue number
- [x] Conventions
  - [x] No config files have been added (Amplify config, cache files)
  - [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  - [x] No global styling (see [#1691](https://github.com/domits1/Domits/issues/1691))
  - [x] No `console.log` left in code
  - [x] No commented-out code remains
- [x] Testing
  - [x] Code tested locally
  - [x] Jest tests are included
  - [x] Jest tests are passing

### Test results

Backend Communication Preferences tests:

- 3 test suites passed
- 36 tests passed

Frontend Communication Preferences tests:

- 3 test suites passed
- 19 tests passed

Additional verification:

- `git diff --check` passed
- Real authenticated API flow tested successfully
- Preferences persist after refresh
- Same Cognito user stores independent `HOST` and `GUEST` rows in Aurora DSQL

## Keep or delete my branch
- [] Delete my branch after merge
- [ ] Keep my branch