### PR TITLE
#3106 Deploy direct booking sites bundle to S3

### DIFF
--- a/.github/workflows/deploy-direct-booking-sites.yml
+++ b/.github/workflows/deploy-direct-booking-sites.yml
@@ -25,7 +25,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup frontend
         uses: ./.github/actions/setup-frontend
@@ -71,7 +71,7 @@ jobs:
           test -f build/index.html
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-direct-booking-sites.yml
+++ b/.github/workflows/deploy-direct-booking-sites.yml
@@ -1,0 +1,110 @@
+name: Deploy direct booking sites
+
+on:
+  push:
+    branches:
+      - acceptance
+    paths:
+      - "frontend/web/**"
+      - ".github/workflows/deploy-direct-booking-sites.yml"
+      - ".github/actions/setup-frontend/**"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-direct-booking-sites-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  SITES_BUCKET: domits-direct-booking-sites-acceptance
+  SITES_BUCKET_REGION: eu-north-1
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup frontend
+        uses: ./.github/actions/setup-frontend
+
+      - name: Write aws-exports
+        env:
+          AWS_EXPORTS: ${{ secrets.AWS_EXPORTS }}
+        run: |
+          if [ -z "$AWS_EXPORTS" ]; then
+            echo "::error::The AWS_EXPORTS secret is empty; the bundle would ship without an Amplify configuration."
+            exit 1
+          fi
+          printf '%s\n' "$AWS_EXPORTS" > frontend/web/src/aws-exports.js
+
+      - name: Build the sites bundle
+        working-directory: frontend/web
+        env:
+          CI: "true"
+          REACT_APP_DIRECT_BOOKING_WEBSITE_SURFACE: "true"
+          REACT_APP_DIRECT_BOOKING_WEBSITE_FALLBACK_DOMAIN_SUFFIX: ${{ vars.REACT_APP_DIRECT_BOOKING_WEBSITE_FALLBACK_DOMAIN_SUFFIX }}
+          REACT_APP_DIRECT_BOOKING_WEBSITE_BOOKINGS_API_BASE: ${{ vars.REACT_APP_DIRECT_BOOKING_WEBSITE_BOOKINGS_API_BASE }}
+          REACT_APP_BOOKINGS_API_BASE: ${{ vars.REACT_APP_BOOKINGS_API_BASE }}
+          REACT_APP_HOST_BOOKINGS_ENDPOINT: ${{ vars.REACT_APP_HOST_BOOKINGS_ENDPOINT }}
+          REACT_APP_ICAL_RETRIEVE_URL: ${{ vars.REACT_APP_ICAL_RETRIEVE_URL }}
+          REACT_APP_CONTACT_EMAIL_ENDPOINT: ${{ vars.REACT_APP_CONTACT_EMAIL_ENDPOINT }}
+          REACT_APP_DOMITS_WS_URL: ${{ vars.REACT_APP_DOMITS_WS_URL }}
+          REACT_APP_AUTOMATED_MESSAGING_API_URL: ${{ vars.REACT_APP_AUTOMATED_MESSAGING_API_URL }}
+          REACT_APP_PROFILE_UPLOAD_URL_ENDPOINT: ${{ vars.REACT_APP_PROFILE_UPLOAD_URL_ENDPOINT }}
+          REACT_APP_UPDATE_EMAIL_ENDPOINT: ${{ vars.REACT_APP_UPDATE_EMAIL_ENDPOINT }}
+          REACT_APP_UPDATE_NAME_ENDPOINT: ${{ vars.REACT_APP_UPDATE_NAME_ENDPOINT }}
+          REACT_APP_UPDATE_PHONE_ENDPOINT: ${{ vars.REACT_APP_UPDATE_PHONE_ENDPOINT }}
+          REACT_APP_CHANNEX_CERTIFICATION_USER_IDS: ${{ vars.REACT_APP_CHANNEX_CERTIFICATION_USER_IDS }}
+          REACT_APP_DEMO_OWNER_ID: ${{ vars.REACT_APP_DEMO_OWNER_ID }}
+          REACT_APP_DEMO_TESTER_ID: ${{ vars.REACT_APP_DEMO_TESTER_ID }}
+          REACT_APP_STRIPE_PUBLIC_KEY: ${{ secrets.REACT_APP_STRIPE_PUBLIC_KEY }}
+        run: |
+          for name in REACT_APP_DIRECT_BOOKING_WEBSITE_FALLBACK_DOMAIN_SUFFIX REACT_APP_DIRECT_BOOKING_WEBSITE_BOOKINGS_API_BASE; do
+            if [ -z "${!name}" ]; then
+              echo "::warning::$name is not set; the bundle will use the fallback compiled into the code."
+            fi
+          done
+          npm run build
+          test -f build/index.html
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.SITES_BUCKET_REGION }}
+
+      - name: Upload hashed assets
+        run: |
+          aws s3 sync frontend/web/build/static "s3://$SITES_BUCKET/static" \
+            --cache-control "public, max-age=31536000, immutable" \
+            --no-progress
+
+      - name: Upload root files
+        run: |
+          aws s3 sync frontend/web/build "s3://$SITES_BUCKET" \
+            --exclude "static/*" \
+            --exclude "index.html" \
+            --cache-control "public, max-age=300" \
+            --no-progress
+
+      - name: Upload index.html
+        run: |
+          aws s3 cp frontend/web/build/index.html "s3://$SITES_BUCKET/index.html" \
+            --cache-control "no-cache, no-store, must-revalidate" \
+            --content-type "text/html; charset=utf-8" \
+            --no-progress
+
+      - name: Invalidate index.html on CloudFront
+        if: vars.DIRECT_BOOKING_SITES_DISTRIBUTION_ID != ''
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "${{ vars.DIRECT_BOOKING_SITES_DISTRIBUTION_ID }}" \
+            --paths "/index.html" "/"
+
+      - name: Skip invalidation
+        if: vars.DIRECT_BOOKING_SITES_DISTRIBUTION_ID == ''
+        run: echo "::notice::DIRECT_BOOKING_SITES_DISTRIBUTION_ID is not set; no CloudFront invalidation was issued."

--- a/docs/internal/tools/direct_booking_sites_hosting.md
+++ b/docs/internal/tools/direct_booking_sites_hosting.md
@@ -1,0 +1,84 @@
+# Direct booking sites hosting
+
+How the public direct booking websites (`*.direct.domits.com` today, hosts' own domains later) are served, and how the bundle that serves them gets there.
+
+## Today
+
+The marketplace web app is hosted by AWS Amplify Hosting, app `d34jwd0sihmsus` (eu-north-1), branch auto-build:
+
+| Hostname | Amplify branch | CloudFront distribution |
+| --- | --- | --- |
+| `www.domits.com` | `main` | `d3fqel8fucbpox.cloudfront.net` |
+| `acceptance.domits.com` | `acceptance` | `d3fqel8fucbpox.cloudfront.net` |
+| `direct.domits.com` and `*.direct.domits.com` | `acceptance` | `d1q86xmwckzc37.cloudfront.net` |
+
+The third row is an Amplify custom-domain association with a wildcard subdomain, created in the console. It serves the **acceptance** build of the marketplace app; the app recognises the hostname suffix and renders `WebsitePublicSitePage` at `/`. The artifacts live in Amplify's own S3 bucket in an AWS-managed account. Nothing in this repository configures any of it, and it is not a valid origin for anything else.
+
+Deep links on both distributions redirect `/path` to `/path/` and then return `index.html`; only `/` matters for a site.
+
+## After
+
+A second bundle of the same web app is built by CI with `REACT_APP_DIRECT_BOOKING_WEBSITE_SURFACE=true`, so it renders the site page on any hostname, and is uploaded to an S3 bucket we own:
+
+| Environment | Bucket | Region |
+| --- | --- | --- |
+| acceptance | `domits-direct-booking-sites-acceptance` | eu-north-1 |
+
+That bucket is the single origin of the CloudFront multi-tenant distribution (CloudFront SaaS Manager) that will carry hosts' custom domains and, once cut over, the `*.direct.domits.com` wildcard. The marketplace app stays on Amplify.
+
+```
+theirvilla.com ──CNAME──▶ <connection group routing endpoint>.cloudfront.net
+                                 │  multi-tenant distribution (template + tenants)
+                                 ▼
+                     s3://domits-direct-booking-sites-acceptance   ◀── deploy-direct-booking-sites.yml
+                                 │
+                                 ▼
+                     browser: GET /property/website/public/render?domain=theirvilla.com
+```
+
+## Pipeline
+
+`.github/workflows/deploy-direct-booking-sites.yml` runs on every push to `acceptance` that touches `frontend/web/**`, and on demand.
+
+1. Installs through `.github/actions/setup-frontend` (Node 22, the pinned npm, `npm ci`).
+2. Writes `frontend/web/src/aws-exports.js` from the `AWS_EXPORTS` secret and fails if the secret is empty.
+3. Builds with `REACT_APP_DIRECT_BOOKING_WEBSITE_SURFACE=true` and every other `REACT_APP_*` the code reads, taken from repository variables of the same name.
+4. Uploads `build/static/**` with `public, max-age=31536000, immutable` (file names are content-hashed), the remaining root files with `public, max-age=300`, and finally `index.html` with `no-cache, no-store, must-revalidate`. `index.html` goes last so it never references an asset that is not uploaded yet.
+5. Invalidates `/index.html` and `/` on the distribution named by the `DIRECT_BOOKING_SITES_DISTRIBUTION_ID` repository variable, or says so if that variable is not set yet.
+
+Old hashed assets are not deleted, so a tab that loaded the previous `index.html` keeps working. The bucket is versioned; add a lifecycle rule for non-current versions once the pattern has settled.
+
+## Repository configuration
+
+Secrets: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` (shared with `deploy.yml`), `AWS_EXPORTS` (the acceptance `aws-exports.js` content), `REACT_APP_STRIPE_PUBLIC_KEY`.
+
+Variables: `DIRECT_BOOKING_SITES_DISTRIBUTION_ID` once the multi-tenant distribution exists, and one `REACT_APP_*` variable per value the Amplify acceptance build sets. To read those values from Amplify:
+
+```
+aws amplify get-app --app-id d34jwd0sihmsus --query 'app.environmentVariables'
+aws amplify get-branch --app-id d34jwd0sihmsus --branch-name acceptance --query 'branch.environmentVariables'
+```
+
+For a site bundle the values that matter are `REACT_APP_DIRECT_BOOKING_WEBSITE_BOOKINGS_API_BASE` (where booking requests go; the code falls back to the `development` stage of API `92a7z9y2m5`) and `REACT_APP_DIRECT_BOOKING_WEBSITE_FALLBACK_DOMAIN_SUFFIX` (defaults to `direct.domits.com`). The quote endpoint base is not configurable; it is `PROPERTY_API_BASE` in `hostproperty/constants.js`.
+
+## Console steps, in order
+
+1. Bucket `domits-direct-booking-sites-acceptance`: private, versioning on. Done.
+2. Add the repository secrets and variables above; run the workflow once by hand and confirm the bucket holds `index.html` and `static/`.
+3. CloudFront: an Origin Access Control for the bucket; a multi-tenant distribution with the bucket as origin, default root object `index.html`, custom error responses `403` and `404` to `/index.html` with code `200`, caching that ignores query strings for `static/*`; a connection group, whose routing endpoint is the CNAME target hosts will use; managed certificates enabled. Bucket policy allows only that OAC.
+4. Set `DIRECT_BOOKING_SITES_DISTRIBUTION_ID`; re-run the workflow and confirm the invalidation.
+5. Create one tenant by hand for a domain we control and verify quote and booking request end to end before any host is offered the feature.
+6. Only after custom domains are live for hosts: add a wildcard tenant for `*.direct.domits.com`, repoint DNS from the Amplify association to the routing endpoint, remove the Amplify domain association.
+
+## Verifying a deploy
+
+```
+curl -sI https://<any tenant domain>/ | grep -i "cache-control\|etag"
+curl -s https://<any tenant domain>/ | grep -o 'static/js/main\.[a-z0-9]*\.js'
+```
+
+The bundle name must match the latest workflow run's build; `index.html` must carry `no-cache`; a `static/js/*.js` must carry `immutable`.
+
+## Rolling back
+
+Every object is versioned. Restore the previous `index.html` version in the bucket (its hashed assets are still present) and issue the same invalidation.


### PR DESCRIPTION
## Close or Relate the Issue
- Closes #
- Related Issue: #3106

## Proposed Changes
Description:

Second step for custom domains. Right now the direct booking sites run through Amplify. We can't put CloudFront in front of that, because Amplify keeps the built files in an AWS account we don't have access to. So the sites need their own place to live.

This adds a workflow that runs on every push to acceptance. It builds the web app with the site flag on and copies the result to an S3 bucket that's ours: domits-direct-booking-sites-acceptance. The JS and CSS files get cached for a year, index.html doesn't get cached at all, and index.html is uploaded last so it never links to a file that hasn't arrived yet.

Also added a doc under docs/internal/tools/ that explains how the sites are hosted now and how it'll work after. Right now the *.direct.domits.com wildcard is set up in the Amplify console on the acceptance branch, and nobody ever wrote that down.

**Nothing changes for live sites.** Nothing points at the bucket yet. That's the CloudFront part, which comes next.

**Merge order:** the flag this workflow turns on doesn't exist in acceptance yet, it's in #XXXX. Until that one's merged, this just builds a normal marketplace bundle. So merge that one first, or merge this and run it again by hand after.

**Something I ran into:** the existing webapp-build-test.yml writes aws-exports.js from a secret, but it never actually passes that secret to the shell. So it's been writing an empty file and the build still passes. This new workflow fails on purpose if that secret is empty. The old one probably needs the same fix, but that's a separate PR.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Optimization
- [x] Documentation update

## Change Size
- [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
- [ ] Big change (+-max 1000)
- [x] Small change (less than 300)

## Refactoring
Nothing refactored.

## Evidence
Can't run until it's on acceptance, so the first real run is after the merge. The YAML parses and the step order checks out.

- [ ] Screenshots or screen recording added for UI changes
- [ ] Before/after images added when relevant
- [ ] Images clearly show the implemented change
- [ ] Image quality is readable (no cropped or blurry evidence)

## Responsiveness
No UI.

- [ ] UI checked on mobile
- [ ] UI checked on tablet
- [ ] UI checked on desktop
- [ ] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages
Nothing added, removed or updated.

- [ ] NPM Packages installed
- [ ] NPM Packages removed
- [ ] NPM Packages updated
- [ ] Checked for vulnerabilities using "npm audit"

## Checklist
- [ ] Pull request has at least 2 reviewers assigned
- [x] PR title is descriptive and includes issue number
- [x] Conventions
  - [x] No config files have been added (Amplify config, cache files)
  - [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  - [x] No global styling (see [#1691](https://github.com/domits1/Domits/issues/1691))
  - [x] No `console.log` left in code
  - [x] No commented-out code remains
- [ ] Testing
  - [ ] Code tested locally
  - [ ] Jest tests are included
  - [ ] Jest tests are passing

## Keep or delete my branch
- [x] Delete my branch after merge
- [ ] Keep my branch