### PR TITLE
feat(inbox): add read/unread conversation status (#2291)

### DIFF
--- a/backend/functions/UnifiedMessaging/business/messageService.authorization.test.js
+++ b/backend/functions/UnifiedMessaging/business/messageService.authorization.test.js
@@ -1,6 +1,8 @@
 const mockMessageRepository = {
   createMessage: jest.fn(),
   getMessagesByThreadId: jest.fn(),
+  markThreadMessagesRead: jest.fn(),
+  getUnreadCountsForThreads: jest.fn(),
 };
 const mockThreadRepository = {
   createThread: jest.fn(),
@@ -69,6 +71,7 @@ describe("MessageService authorization and booking scoping", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockThreadRepository.updateThreadActivity.mockResolvedValue(undefined);
+    mockMessageRepository.getUnreadCountsForThreads.mockResolvedValue({});
     service = new MessageService();
   });
 
@@ -263,6 +266,46 @@ describe("MessageService authorization and booking scoping", () => {
     expect(result.response).toEqual([expect.objectContaining({ id: "thread-1", bookingId: null })]);
     expect(mockBookingRepository.getBookingById).not.toHaveBeenCalled();
     expect(mockBookingRepository.findBookingsForGuestHostProperty).not.toHaveBeenCalled();
+  });
+
+  test("attaches unreadCount to each visible thread in /threads", async () => {
+    mockThreadRepository.getThreadsForUser.mockResolvedValue([
+      thread({ id: "thread-unread", bookingId: null, propertyId: null }),
+      thread({ id: "thread-read", bookingId: null, propertyId: null }),
+    ]);
+    mockMessageRepository.getUnreadCountsForThreads.mockResolvedValue({ "thread-unread": 3 });
+
+    const result = await service.getThreads(hostAuth);
+
+    expect(mockMessageRepository.getUnreadCountsForThreads).toHaveBeenCalledWith(
+      ["thread-unread", "thread-read"],
+      "host-1"
+    );
+    expect(result.response).toEqual([
+      expect.objectContaining({ id: "thread-unread", unreadCount: 3 }),
+      expect.objectContaining({ id: "thread-read", unreadCount: 0 }),
+    ]);
+  });
+
+  test("markThreadRead marks only the authenticated recipient's messages as read", async () => {
+    mockThreadRepository.getThreadById.mockResolvedValue(thread({ bookingId: null, propertyId: null }));
+    mockMessageRepository.markThreadMessagesRead.mockResolvedValue(2);
+
+    const result = await service.markThreadRead("thread-1", hostAuth);
+
+    expect(result).toEqual({ statusCode: 200, response: { threadId: "thread-1", updated: 2 } });
+    expect(mockMessageRepository.markThreadMessagesRead).toHaveBeenCalledWith("thread-1", "host-1");
+  });
+
+  test("rejects markThreadRead for a user who is not a participant in the thread", async () => {
+    mockThreadRepository.getThreadById.mockResolvedValue(
+      thread({ hostId: "host-1", guestId: "guest-1", bookingId: null, propertyId: null })
+    );
+
+    await expect(
+      service.markThreadRead("thread-1", { userId: "stranger-1", isGuest: true, isHost: false })
+    ).rejects.toMatchObject({ statusCode: 403, code: "FORBIDDEN" });
+    expect(mockMessageRepository.markThreadMessagesRead).not.toHaveBeenCalled();
   });
 
   test("rejects spoofed sender ids", async () => {

--- a/backend/functions/UnifiedMessaging/business/messageService.js
+++ b/backend/functions/UnifiedMessaging/business/messageService.js
@@ -548,6 +548,14 @@ class MessageService {
     return { statusCode: 201, response: { ...message, threadId, reused: false, diagnostic } };
   }
 
+  async markThreadRead(threadId, authenticatedUser) {
+    if (!threadId) throw badRequest("threadId is required.");
+    const thread = await this.threadRepository.getThreadById(threadId);
+    await this.assertThreadAccess(thread, authenticatedUser);
+    const updated = await this.messageRepository.markThreadMessagesRead(threadId, authenticatedUser.userId);
+    return { statusCode: 200, response: { threadId, updated } };
+  }
+
   async getThreads(authenticatedUser) {
     const threads = await this.threadRepository.getThreadsForUser(authenticatedUser.userId);
     const visible = [];
@@ -562,9 +570,14 @@ class MessageService {
       }
     }
 
+    const unreadCounts = await this.messageRepository.getUnreadCountsForThreads(
+      visible.map((t) => t.id),
+      authenticatedUser.userId
+    );
+
     return {
       statusCode: 200,
-      response: visible,
+      response: visible.map((t) => ({ ...t, unreadCount: unreadCounts[t.id] || 0 })),
     };
   }
 

--- a/backend/functions/UnifiedMessaging/controller/controllerUtils.js
+++ b/backend/functions/UnifiedMessaging/controller/controllerUtils.js
@@ -21,3 +21,10 @@ export const extractLastPathSegment = (path) => {
 
   return parts.at(-1) ?? null;
 };
+
+const threadIdForReadPattern = /\/threads\/([^/]+)\/read/;
+
+export const extractThreadIdForRead = (path) => {
+  const match = threadIdForReadPattern.exec(String(path || ""));
+  return match?.[1] || null;
+};

--- a/backend/functions/UnifiedMessaging/controller/messageController.auth.test.js
+++ b/backend/functions/UnifiedMessaging/controller/messageController.auth.test.js
@@ -2,6 +2,7 @@ const mockMessageService = {
   sendMessage: jest.fn(),
   getThreads: jest.fn(),
   getMessages: jest.fn(),
+  markThreadRead: jest.fn(),
 };
 
 jest.mock("../business/messageService.js", () => ({
@@ -18,8 +19,10 @@ const buildEvent = ({
   body = "{}",
   jwt = false,
   claimsPatch = {},
+  path = "/default",
 } = {}) => ({
   body,
+  path,
   queryStringParameters: query,
   requestContext: sub
     ? {
@@ -123,5 +126,19 @@ describe("MessageController authenticated user handling", () => {
       statusCode: 400,
       code: "BAD_REQUEST",
     });
+  });
+
+  test("markThreadRead extracts threadId from the path and forwards the authenticated user", async () => {
+    mockMessageService.markThreadRead.mockResolvedValue({
+      statusCode: 200,
+      response: { threadId: "thread-1", updated: 2 },
+    });
+
+    await controller.markThreadRead(buildEvent({ path: "/default/threads/thread-1/read" }));
+
+    expect(mockMessageService.markThreadRead).toHaveBeenCalledWith(
+      "thread-1",
+      expect.objectContaining({ userId: "guest-1", isGuest: true })
+    );
   });
 });

--- a/backend/functions/UnifiedMessaging/controller/messageController.js
+++ b/backend/functions/UnifiedMessaging/controller/messageController.js
@@ -1,6 +1,7 @@
 import MessageService from "../business/messageService.js";
 import { getAuthenticatedUser } from "../auth/authContext.js";
 import { badRequest, forbidden } from "../util/httpErrors.js";
+import { extractThreadIdForRead } from "./controllerUtils.js";
 
 const parseBody = (event) => {
   if (!event?.body) return {};
@@ -36,6 +37,12 @@ class MessageController {
     const authenticatedUser = getAuthenticatedUser(event);
     const threadId = event.queryStringParameters?.threadId;
     return await this.messageService.getMessages(threadId, authenticatedUser);
+  }
+
+  async markThreadRead(event) {
+    const authenticatedUser = getAuthenticatedUser(event);
+    const threadId = extractThreadIdForRead(event.path);
+    return await this.messageService.markThreadRead(threadId, authenticatedUser);
   }
 }
 

--- a/backend/functions/UnifiedMessaging/data/messageRepository.js
+++ b/backend/functions/UnifiedMessaging/data/messageRepository.js
@@ -193,6 +193,37 @@ class MessageRepository {
 
     return messages;
   }
+
+  async markThreadMessagesRead(threadId, recipientId) {
+    const client = await Database.getInstance();
+    const result = await client
+      .createQueryBuilder()
+      .update(UnifiedMessage)
+      .set({ isRead: true })
+      .where({ threadId, recipientId, isRead: false })
+      .execute();
+    return result?.affected ?? 0;
+  }
+
+  async getUnreadCountsForThreads(threadIds, recipientId) {
+    if (!Array.isArray(threadIds) || threadIds.length === 0) return {};
+    const client = await Database.getInstance();
+    const rows = await client
+      .getRepository(UnifiedMessage)
+      .createQueryBuilder("message")
+      .select("message.threadId", "threadId")
+      .addSelect("COUNT(*)", "count")
+      .where("message.threadId IN (:...threadIds)", { threadIds })
+      .andWhere("message.recipientId = :recipientId", { recipientId })
+      .andWhere("message.isRead = :isRead", { isRead: false })
+      .groupBy("message.threadId")
+      .getRawMany();
+
+    return rows.reduce((acc, row) => {
+      acc[row.threadId] = Number(row.count);
+      return acc;
+    }, {});
+  }
 }
 
 export default MessageRepository;

--- a/backend/functions/UnifiedMessaging/index.js
+++ b/backend/functions/UnifiedMessaging/index.js
@@ -132,6 +132,11 @@ const routeDefinitions = [
   },
   {
     matches: (method, path) =>
+      method === "POST" && /\/threads\/[^/]+\/read$/.test(String(path || "")),
+    handle: (event) => messageController.markThreadRead(event),
+  },
+  {
+    matches: (method, path) =>
       method === "POST" &&
       String(path || "").includes("/integrations/") &&
       String(path || "").endsWith("/ingest/messages"),

--- a/backend/functions/UnifiedMessaging/index.retainedRoutes.test.js
+++ b/backend/functions/UnifiedMessaging/index.retainedRoutes.test.js
@@ -2,6 +2,7 @@ const mockMessageControllerMethods = {
   sendMessage: jest.fn(),
   getThreads: jest.fn(),
   getMessages: jest.fn(),
+  markThreadRead: jest.fn(),
 };
 const mockIntegrationControllerMethods = {
   startWhatsAppConnect: jest.fn(),
@@ -78,6 +79,7 @@ describe("UnifiedMessaging retained route contracts", () => {
     ["POST", "/default/send", mockMessageControllerMethods.sendMessage, "send"],
     ["GET", "/default/threads", mockMessageControllerMethods.getThreads, "threads"],
     ["GET", "/default/messages", mockMessageControllerMethods.getMessages, "messages"],
+    ["POST", "/default/threads/thread-1/read", mockMessageControllerMethods.markThreadRead, "mark-read"],
     [
       "POST",
       "/default/integrations/whatsapp/ingest/messages",

--- a/frontend/web/src/components/messages/Messages.js
+++ b/frontend/web/src/components/messages/Messages.js
@@ -1,13 +1,15 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { UserProvider, useUser } from "../../features/hostdashboard/hostmessages/context/AuthContext";
 import { WebSocketProvider } from "../../features/hostdashboard/hostmessages/context/webSocketContext";
 import { useAuth } from "../../features/hostdashboard/hostmessages/hooks/useAuth";
+import { getIdToken } from "../../services/getAccessToken";
 
 import useFetchContacts from "../../features/hostdashboard/hostmessages/hooks/useFetchContacts";
 
 import ContactList from "./ContactList";
 import ChatScreen from "./ChatScreen";
+import { markThreadRead } from "../../features/hostdashboard/hostmessages/services/messagingService";
 import NewContactModal from "./NewContactModal";
 import ListingPanel from "./ListingPanel";
 import { getMessageCapabilities } from "./messageCapabilities";
@@ -59,6 +61,7 @@ const MessagesContent = ({ dashboardType }) => {
   const isTablet = screenWidth >= 768 && screenWidth < 1280;
 
   const { contacts, pendingContacts, loading: contactsLoading, setContacts } = useFetchContacts(userId, dashboardType);
+  const contactsRef = useRef(contacts);
 
   const syncGuestBookingUrl = (bookingId) => {
     if (dashboardType !== "guest") return;
@@ -249,6 +252,38 @@ const MessagesContent = ({ dashboardType }) => {
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
   }, []);
+
+  useEffect(() => {
+    contactsRef.current = contacts;
+  }, [contacts]);
+
+  useEffect(() => {
+    if (!selectedThreadId) return;
+
+    const matchedContact = (contactsRef.current || []).find((c) => c?.threadId === selectedThreadId);
+    if (matchedContact && !matchedContact.unreadCount) return;
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const idToken = await getIdToken();
+        await markThreadRead(selectedThreadId, idToken);
+        if (cancelled) return;
+        setContacts((prev) =>
+          (Array.isArray(prev) ? prev : []).map((c) =>
+            c?.threadId === selectedThreadId ? { ...c, unreadCount: 0 } : c
+          )
+        );
+      } catch {
+        // Mark-read failures should not interrupt viewing the conversation.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedThreadId, setContacts]);
 
   useEffect(() => {
     let cancelled = false;

--- a/frontend/web/src/components/messages/Messages.test.js
+++ b/frontend/web/src/components/messages/Messages.test.js
@@ -7,8 +7,21 @@ import "@testing-library/jest-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import Messages from "./Messages";
+import { getIdToken } from "../../services/getAccessToken";
+import { markThreadRead } from "../../features/hostdashboard/hostmessages/services/messagingService";
 
 let mockContacts = [];
+let mockSetContacts = jest.fn();
+
+jest.mock("../../services/getAccessToken", () => ({
+  __esModule: true,
+  getIdToken: jest.fn(),
+}));
+
+jest.mock("../../features/hostdashboard/hostmessages/services/messagingService", () => ({
+  __esModule: true,
+  markThreadRead: jest.fn(),
+}));
 
 jest.mock("../../features/hostdashboard/hostmessages/context/AuthContext", () => {
   const React = require("react");
@@ -53,7 +66,7 @@ jest.mock("../../features/hostdashboard/hostmessages/hooks/useFetchContacts", ()
     contacts: mockContacts,
     pendingContacts: [],
     loading: false,
-    setContacts: jest.fn(),
+    setContacts: mockSetContacts,
   }),
 }));
 
@@ -137,6 +150,11 @@ const renderMessages = (entry) =>
 
 describe("Messages booking URL context", () => {
   beforeEach(() => {
+    mockSetContacts = jest.fn();
+    getIdToken.mockReset();
+    getIdToken.mockResolvedValue("id-token-1");
+    markThreadRead.mockReset();
+    markThreadRead.mockResolvedValue({ threadId: "thread-1", updated: 3 });
     mockContacts = [
       {
         partnerId: "host-1",
@@ -145,6 +163,7 @@ describe("Messages booking URL context", () => {
         propertyId: "property-1",
         bookingId: "booking-1",
         propertyTitle: "Exact stay",
+        unreadCount: 3,
       },
     ];
   });
@@ -214,5 +233,25 @@ describe("Messages booking URL context", () => {
       expect(screen.getByTestId("chat-screen")).toHaveAttribute("data-booking-id", "missing-booking");
     });
     expect(screen.getByTestId("chat-screen")).toHaveAttribute("data-contact-id", "");
+  });
+
+  test("opening a conversation marks it read using the shared ID token and clears the unread badge locally", async () => {
+    renderMessages("/guestdashboard/messages?bookingId=booking-1");
+
+    await waitFor(() => {
+      expect(getIdToken).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(markThreadRead).toHaveBeenCalledWith("thread-1", "id-token-1");
+    });
+
+    await waitFor(() => {
+      expect(mockSetContacts).toHaveBeenCalled();
+    });
+
+    const updaterFn = mockSetContacts.mock.calls.at(-1)[0];
+    const updatedContacts = updaterFn(mockContacts);
+    expect(updatedContacts.find((c) => c.threadId === "thread-1").unreadCount).toBe(0);
   });
 });

--- a/frontend/web/src/features/hostdashboard/hostmessages/hooks/useFetchContacts.js
+++ b/frontend/web/src/features/hostdashboard/hostmessages/hooks/useFetchContacts.js
@@ -149,6 +149,7 @@ const buildUnifiedContactsFromThreads = ({ threads, userId, role }) => {
         platform: t.platform || "DOMITS",
         externalThreadId: t.externalThreadId || null,
         integrationAccountId: t.integrationaccountid || t.integrationAccountId || null,
+        unreadCount: t.unreadCount ?? 0,
       };
     })
     .filter((c) => c.partnerId && String(c.partnerId) !== String(userId));

--- a/frontend/web/src/features/hostdashboard/hostmessages/hooks/useFetchContacts.test.js
+++ b/frontend/web/src/features/hostdashboard/hostmessages/hooks/useFetchContacts.test.js
@@ -44,7 +44,12 @@ const Harness = ({ userId = "host-1", role = "host" }) => {
     <div>
       <div data-testid="loading">{String(loading)}</div>
       <div data-testid="contacts">
-        {contacts.map((contact) => `${contact.threadId || "legacy"}:${contact.partnerId}:${contact.platform}`).join("|")}
+        {contacts
+          .map(
+            (contact) =>
+              `${contact.threadId || "legacy"}:${contact.partnerId}:${contact.platform}:${contact.unreadCount ?? "none"}`
+          )
+          .join("|")}
       </div>
       <div data-testid="pending">{pendingContacts.length}</div>
     </div>
@@ -85,6 +90,7 @@ describe("useFetchContacts history merging", () => {
             platform: "WHATSAPP",
             externalThreadId: "wa-thread-1",
             integrationAccountId: "integration-1",
+            unreadCount: 4,
           },
         ]);
       }
@@ -132,7 +138,7 @@ describe("useFetchContacts history merging", () => {
       expect(screen.getByTestId("loading")).toHaveTextContent("false");
     });
 
-    expect(screen.getByTestId("contacts")).toHaveTextContent("external-thread-1:+31612345678:WHATSAPP");
+    expect(screen.getByTestId("contacts")).toHaveTextContent("external-thread-1:+31612345678:WHATSAPP:4");
     expect(screen.getByTestId("contacts")).toHaveTextContent("legacy:legacy-guest-1:DOMITS");
     expect(screen.getByTestId("pending")).toHaveTextContent("0");
 

--- a/frontend/web/src/features/hostdashboard/hostmessages/services/messagingService.js
+++ b/frontend/web/src/features/hostdashboard/hostmessages/services/messagingService.js
@@ -328,3 +328,17 @@ export async function sendUnifiedMessage({
 
   return res.json();
 }
+
+export async function markThreadRead(threadId, idToken = null) {
+  const res = await fetch(`${UNIFIED_MESSAGING_API}/threads/${encodeURIComponent(threadId)}/read`, {
+    method: "POST",
+    headers: buildAuthHeaders(idToken, { requireAuth: true }),
+  });
+
+  if (!res.ok) {
+    const txt = await res.text().catch(() => "");
+    throw new Error(`UnifiedMessaging /threads/{id}/read failed: ${res.status} ${txt}`);
+  }
+
+  return res.json();
+}

--- a/frontend/web/src/features/hostdashboard/hostmessages/services/messagingService.test.js
+++ b/frontend/web/src/features/hostdashboard/hostmessages/services/messagingService.test.js
@@ -1,4 +1,4 @@
-import { getGuestBookingDetailsByBookingId, getHostBookingDetails, sendUnifiedMessage } from "./messagingService";
+import { getGuestBookingDetailsByBookingId, getHostBookingDetails, sendUnifiedMessage, markThreadRead } from "./messagingService";
 
 describe("messagingService unified REST client", () => {
   beforeEach(() => {
@@ -57,6 +57,34 @@ describe("messagingService unified REST client", () => {
         token: null,
       })
     ).rejects.toMatchObject({
+      code: "AUTH_TOKEN_REQUIRED",
+    });
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  test("markThreadRead posts to /threads/{id}/read with the Cognito ID token", async () => {
+    globalThis.fetch.mockResolvedValueOnce({ ok: true, json: async () => ({ threadId: "thread-1", updated: 2 }) });
+
+    const result = await markThreadRead("thread-1", "id-token-1");
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://54s3llwby8.execute-api.eu-north-1.amazonaws.com/default/threads/thread-1/read",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer id-token-1",
+        },
+      })
+    );
+    expect(result).toEqual({ threadId: "thread-1", updated: 2 });
+  });
+
+  test("markThreadRead does not call the API without a token", async () => {
+    globalThis.fetch.mockClear();
+
+    await expect(markThreadRead("thread-1", null)).rejects.toMatchObject({
       code: "AUTH_TOKEN_REQUIRED",
     });
 


### PR DESCRIPTION
## Close or Relate the Issue
[//]: # (Only if this should close the issue)

[//]: # (in the issue a reference will be added to this pr)
- Related Issue: #2291
- Parent Issue: #767

## Proposed Changes
[//]: # (Add a detailed description of the changes here)

Description:

Adds read/unread status support to the Unified Inbox.

Backend:
- Adds unread message counts per thread to `GET /threads`.
- Adds `POST /threads/{id}/read` to mark messages addressed to the authenticated user as read.
- Reuses the existing `assertThreadAccess` authorization checks.
- Adds authorization and routing tests for the new behavior.

Frontend:
- Preserves `unreadCount` when mapping threads to contacts.
- Connects the unread count to the existing unread badge and filter.
- Marks a conversation as read when it is opened.
- Uses the shared Cognito ID-token flow for the authenticated request.
- Updates the unread count locally after marking the thread as read.

Manual "Mark unread" is not included in this PR and can be handled separately.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Optimization
- [ ] Documentation update

## Change Size
[//]: # (Indicate the size of this change.)
[//]: # (Clarify under Refactoring which parts are moved/unchanged code, so the reviewer doesn’t review old logic.)
- [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
- [ ] Big change (+-max 1000)
- [x] Small change (less than 300)

## Refactoring
N/A

## Evidence
- [ ] Screenshots or screen recording added for UI changes
- [ ] Before/after images added when relevant
- [ ] Images clearly show the implemented change
- [ ] Image quality is readable (no cropped or blurry evidence)

## Responsiveness
- [ ] UI checked on mobile
- [ ] UI checked on tablet
- [ ] UI checked on desktop
- [ ] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages
- [ ] NPM Packages installed
- [ ] NPM Packages removed
- [ ] NPM Packages updated
- [ ] Checked for vulnerabilities using "npm audit"

## Checklist
[//]: # (All boxes must be checked before merging.)
- [ ] Pull request has at least 2 reviewers assigned
- [x] PR title is descriptive and includes issue number
- [x] Conventions
  - [x] No config files have been added (Amplify config, cache files)
  - [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  - [x] No global styling (see [#1691](https://github.com/domits1/Domits/issues/1691))
  - [x] No `console.log` left in code
  - [x] No commented-out code remains
- [x] Testing
  - [x] Code tested locally
  - [x] Jest tests are included
  - [x] Jest tests are passing

### Test results
- Backend UnifiedMessaging: 28 suites / 265 tests passing
- Frontend messaging regression suite: 14 suites / 61 tests passing
- Focused frontend tests: 3 suites / 14 tests passing
- ESLint: 0 errors / 0 warnings

### Deployment note
`POST /threads/{id}/read` still requires an explicit Cognito-authorized API Gateway route before end-to-end testing in `acceptance`.

No AWS/API Gateway changes are included in this PR.

## Keep or delete my branch
- [x] Delete my branch after merge
- [ ] Keep my branch