### PR TITLE
feat(payments); add Stripe mode switch for test enviroments (only loc…

### DIFF
--- a/backend/functions/General-Bookings-CRUD-Bookings-develop/business/bookingService.js
+++ b/backend/functions/General-Bookings-CRUD-Bookings-develop/business/bookingService.js
@@ -173,6 +173,10 @@ class BookingService {
     return parseBookingDateToMs(value, fieldName);
   }
 
+  getStripeClient() {
+    return this.stripeRepository.getClient();
+  }
+
   async confirmPayment(paymentid) {
     const booking = await this.reservationRepository.getBookingByPaymentId(paymentid);
     if (booking.status === BOOKING_STATUS_PAID) {

--- a/backend/functions/General-Bookings-CRUD-Bookings-develop/controller/reservationController.js
+++ b/backend/functions/General-Bookings-CRUD-Bookings-develop/controller/reservationController.js
@@ -1,7 +1,6 @@
 import BookingService from "../business/bookingService.js";
 import PaymentService from "../business/paymentService.js";
 import { BadRequestException } from "../util/exception/badRequestException.js";
-import Stripe from "stripe";
 import SystemManagerRepository from "../data/systemManagerRepository.js";
 import { calculateRefundAmountCents } from "../util/refundCalculator.js";
 import Forbidden from "../util/exception/Forbidden.js";
@@ -51,34 +50,15 @@ class ReservationController {
     this.bookingService = bookingService;
     this.paymentSerivce = paymentService;
     this.systemManagerRepository = new SystemManagerRepository();
-    this.stripe = process.env.STRIPE_SECRET_KEY ? new Stripe(process.env.STRIPE_SECRET_KEY) : undefined;
-    this._stripeInitPromise = null;
   }
 
   async getStripeInstance() {
-    if (this.stripe !== undefined) return this.stripe;
-    if (this._stripeInitPromise) return this._stripeInitPromise;
-
-    this._stripeInitPromise = (async () => {
-      try {
-        const secret =
-          process.env.STRIPE_SECRET_KEY ||
-          (await this.systemManagerRepository.getSystemManagerParameter("/stripe/keys/secret/test"));
-        if (secret) {
-          this.stripe = new Stripe(secret);
-        } else {
-          this.stripe = null;
-        }
-      } catch (error) {
-        console.error("Failed to initialize Stripe from SSM:", error);
-        this.stripe = null;
-      } finally {
-        this._stripeInitPromise = null;
-      }
-      return this.stripe;
-    })();
-
-    return this._stripeInitPromise;
+    try {
+      return await this.bookingService.getStripeClient();
+    } catch (error) {
+      console.error("Failed to initialize Stripe:", error);
+      return null;
+    }
   }
 
   // POST

--- a/backend/functions/General-Bookings-CRUD-Bookings-develop/data/stripeRepository.js
+++ b/backend/functions/General-Bookings-CRUD-Bookings-develop/data/stripeRepository.js
@@ -1,7 +1,6 @@
 import Stripe from "stripe";
 import { randomUUID } from "node:crypto";
-import { DynamoDBClient, QueryCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
-import { unmarshall } from "@aws-sdk/util-dynamodb";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import NotFoundException from "../util/exception/NotFoundException.js";
 import SystemManagerRepository from "./systemManagerRepository.js";
 import CalculateTotalRate from "../util/calcuateTotalRate.js";
@@ -11,29 +10,40 @@ import { Booking } from "database/models/Booking";
 import { Stripe_Connected_Accounts } from "database/models/Stripe_Connected_Accounts";
 
 const systemManagerRepository = new SystemManagerRepository();
-const stripePromise =
-  process.env.TEST === "true"
-    ? Promise.resolve({
-        paymentIntents: {
-          create: async () => ({
-            id: `test_${randomUUID()}`,
-            client_secret: `test_secret_${randomUUID()}`,
-          }),
-        },
-      })
-    : systemManagerRepository
-        .getSystemManagerParameter("/stripe/keys/secret/live")
-        .then((secret) => new Stripe(secret));
+const STRIPE_MODES = new Set(["live", "test"]);
+const STRIPE_MODE = String(process.env.STRIPE_MODE || "live")
+  .trim()
+  .toLowerCase();
+if (!STRIPE_MODES.has(STRIPE_MODE)) {
+  throw new Error(`Unsupported STRIPE_MODE: "${STRIPE_MODE}". Expected "live" or "test".`);
+}
+
+const STRIPE_SECRET_PARAMETER = `/stripe/keys/secret/${STRIPE_MODE}`;
+const useFakeStripe = process.env.TEST === "true" && !process.env.STRIPEMODE;
+const stripePromise = useFakeStripe
+  ? Promise.resolve({
+    paymentIntents: {
+      create: async () => ({
+        id: `test${randomUUID()},
+          client_secret: testsecret${randomUUID()}`,
+      }),
+    },
+  })
+  : systemManagerRepository.getSystemManagerParameter(STRIPE_SECRET_PARAMETER).then((secret) => new Stripe(secret));
 
 const client = new DynamoDBClient({ region: "eu-north-1" });
 
 class StripeRepository {
+  getClient() {
+    return stripePromise;
+  }
+
   async createPaymentIntent(account_id, propertyId, dates, bookingId) {
     try {
       if (!account_id || !propertyId || !dates) {
         console.error(`accountId ${account_id}, property_id ${propertyId}, or dates ${dates} are NaN.`);
         throw new NotFoundException(
-          "account_id, propertyId, or dates is missing. This information is needed to create a PaymentIntent."
+          "account_id, propertyId, or dates is missing. This information is needed to create a PaymentIntent.",
         );
       }
 
@@ -148,4 +158,5 @@ class StripeRepository {
     await client.createQueryBuilder().update(Booking).set(updateObject).where("id = :id", { id: bookingId }).execute();
   }
 }
+
 export default StripeRepository;

--- a/backend/functions/General-Bookings-CRUD-Bookings-develop/data/stripeRepository.js
+++ b/backend/functions/General-Bookings-CRUD-Bookings-develop/data/stripeRepository.js
@@ -19,17 +19,19 @@ if (!STRIPE_MODES.has(STRIPE_MODE)) {
 }
 
 const STRIPE_SECRET_PARAMETER = `/stripe/keys/secret/${STRIPE_MODE}`;
-const useFakeStripe = process.env.TEST === "true" && !process.env.STRIPEMODE;
+const useFakeStripe = process.env.TEST === "true" && !process.env.STRIPE_MODE;
 const stripePromise = useFakeStripe
   ? Promise.resolve({
     paymentIntents: {
       create: async () => ({
-        id: `test${randomUUID()},
-          client_secret: testsecret${randomUUID()}`,
+        id: `test_${randomUUID()}`,
+        client_secret: `test_secret_${randomUUID()}`,
       }),
     },
   })
-  : systemManagerRepository.getSystemManagerParameter(STRIPE_SECRET_PARAMETER).then((secret) => new Stripe(secret));
+  : systemManagerRepository
+    .getSystemManagerParameter(STRIPE_SECRET_PARAMETER)
+    .then((secret) => new Stripe(secret));
 
 const client = new DynamoDBClient({ region: "eu-north-1" });
 

--- a/backend/test/General-Bookings-CRUD-Bookings-develop/refund.test.js
+++ b/backend/test/General-Bookings-CRUD-Bookings-develop/refund.test.js
@@ -179,6 +179,7 @@ describe("Refund Logic - 10 Test Scenarios", () => {
         authManager: {
           authenticateUser: jest.fn().mockResolvedValue({ sub: "guest123" }),
         },
+        getStripeClient: jest.fn().mockResolvedValue(mockStripe),
         reservationRepository: {
           getBookingById: jest.fn(),
           cancelBookingByGuest: jest.fn().mockResolvedValue({
@@ -331,6 +332,7 @@ describe("Refund Logic - 10 Test Scenarios", () => {
     it("should handle missing Stripe configuration", async () => {
       const bookingId = "booking_no_stripe";
       mockBooking({ id: bookingId, paymentid: "pi_test_123" });
+      mockBookingService.getStripeClient.mockResolvedValue(null);
       controller.stripe = null;
 
       const result = await controller.cancelBooking(bookingId, authEvent);

--- a/frontend/web/src/App.js
+++ b/frontend/web/src/App.js
@@ -54,7 +54,7 @@ import PageNotFound from "./utils/error/404NotFound";
 import ScrollToTop from "./utils/ScrollToTop/ScrollToTop.tsx";
 import { initializeUserAttributes } from "./utils/userAttributes";
 import Navbar from "./components/base/navbar";
-import publicKeys from "./utils/const/publicKeys.json";
+import { STRIPE_PUBLIC_KEY } from "./utils/const/stripePublicKey";
 import { loadStripe } from "@stripe/stripe-js";
 import { Elements } from "@stripe/react-stripe-js";
 import ChannelManager from "./pages/channelmanager/Channelmanager.js";
@@ -63,7 +63,7 @@ import WebsitePublicPreviewPage from "./features/hostdashboard/website/WebsitePu
 import WebsitePublicSitePage from "./features/hostdashboard/website/WebsitePublicSitePage.jsx";
 import AcceptInvite from "./features/hostdashboard/AcceptInvite";
 
-const stripePromise = loadStripe(publicKeys.STRIPE_PUBLIC_KEYS.LIVE);
+const stripePromise = loadStripe(STRIPE_PUBLIC_KEY);
 const DEFAULT_DIRECT_BOOKING_WEBSITE_FALLBACK_DOMAIN_SUFFIX = "direct.domits.com";
 const apolloClient = new ApolloClient({
   link: new HttpLink({

--- a/frontend/web/src/features/bookingengine/BookingOverview.js
+++ b/frontend/web/src/features/bookingengine/BookingOverview.js
@@ -15,11 +15,11 @@ import People from "@mui/icons-material/PeopleAltOutlined";
 import Back from "@mui/icons-material/KeyboardBackspace";
 import IosShareIcon from "@mui/icons-material/IosShare";
 import ShareModal from "./components/ShareModal";
-import publicKeys from "../../utils/const/publicKeys.json";
+import { STRIPE_PUBLIC_KEY } from "../../utils/const/stripePublicKey";
 import { resolvePrimaryAccommodationImageUrl } from "../../utils/accommodationImage";
 import CancellationPolicySection from "./CancellationPolicySection";
 
-const stripePromise = loadStripe(publicKeys.STRIPE_PUBLIC_KEYS.LIVE);
+const stripePromise = loadStripe(STRIPE_PUBLIC_KEY);
 const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 export const BOOKINGS_ENDPOINT = "https://92a7z9y2m5.execute-api.eu-north-1.amazonaws.com/development/bookings";
 

--- a/frontend/web/src/features/guestdashboard/InquiryPaymentPage.js
+++ b/frontend/web/src/features/guestdashboard/InquiryPaymentPage.js
@@ -4,10 +4,10 @@ import { Elements } from "@stripe/react-stripe-js";
 import { loadStripe } from "@stripe/stripe-js";
 import { getAccessToken } from "../../services/getAccessToken";
 import SetupForm from "../bookingengine/views/SetupForm";
-import publicKeys from "../../utils/const/publicKeys.json";
+import { STRIPE_PUBLIC_KEY } from "../../utils/const/stripePublicKey";
 import spinner from "../../images/spinnner.gif";
 
-const stripePromise = loadStripe(publicKeys.STRIPE_PUBLIC_KEYS.LIVE);
+const stripePromise = loadStripe(STRIPE_PUBLIC_KEY);
 const BOOKINGS_API = "https://92a7z9y2m5.execute-api.eu-north-1.amazonaws.com/development/bookings";
 const PAY_ROUTE_PREFIX = "/guestdashboard/pay/";
 

--- a/frontend/web/src/utils/const/stripePublicKey.js
+++ b/frontend/web/src/utils/const/stripePublicKey.js
@@ -1,0 +1,12 @@
+import publicKeys from "./publicKeys.json";
+
+const STRIPE_MODE = String(process.env.REACT_APP_STRIPE_MODE || "LIVE")
+  .trim()
+  .toUpperCase();
+const STRIPE_PUBLIC_KEY = publicKeys.STRIPE_PUBLIC_KEYS[STRIPE_MODE];
+
+if (!STRIPE_PUBLIC_KEY) {
+  throw new Error(`Unknown REACT_APP_STRIPE_MODE "${STRIPE_MODE}"; expected LIVE, TEST or SANDBOX.`);
+}
+
+export { STRIPE_MODE, STRIPE_PUBLIC_KEY };


### PR DESCRIPTION
## Close or Relate the Issue
- Closes #
- Related Issue: #2258

## Proposed Changes
Description:

Right now the backend reads the live Stripe key from SSM and the frontend has the live public key hardcoded. There's no way to run the payment flow against Stripe's sandbox without changing production.

This adds a switch. The backend reads /stripe/keys/secret/${STRIPE_MODE} instead of always /stripe/keys/secret/live. The frontend picks the public key based on REACT_APP_STRIPE_MODE. Without those env vars nothing changes, both default to live.

Also fixed while doing this: the refund path in reservationController built its own Stripe instance from STRIPE_SECRET_KEY, falling back to the test key from SSM. So refunds could try to refund a live PaymentIntent with the test key. Now refunds use the same client that created the payment.

**Nothing changes in production.** No env vars are set, so both sides stay on live.

**What this enables:** a second Lambda with STRIPE_MODE=test and TEST=true, pointing at the test schema, and a local frontend started with REACT_APP_STRIPE_MODE=SANDBOX. That's console work after this merges.

**Careful:** REACT_APP_STRIPE_MODE must never be set on the Amplify build. That would put production on sandbox.

## Change Type
- [x] Bug fix
- [x] New feature
- [ ] Optimization
- [ ] Documentation update

## Change Size
- [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
- [ ] Big change (+-max 1000)
- [x] Small change (less than 300)

## Refactoring
The Stripe instance in reservationController is gone. It now asks bookingService for the shared client instead of building its own.

## Evidence
No UI change. Verified locally that without env vars the app still uses the live key.

- [ ] Screenshots or screen recording added for UI changes
- [ ] Before/after images added when relevant
- [ ] Images clearly show the implemented change
- [ ] Image quality is readable (no cropped or blurry evidence)

## Responsiveness
Not applicable.

- [ ] UI checked on mobile
- [ ] UI checked on tablet
- [ ] UI checked on desktop
- [ ] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages
Nothing added, removed or updated.

- [ ] NPM Packages installed
- [ ] NPM Packages removed
- [ ] NPM Packages updated
- [ ] Checked for vulnerabilities using "npm audit"

## Checklist
- [ ] Pull request has at least 2 reviewers assigned
- [x] PR title is descriptive and includes issue number
- [x] Conventions
  - [x] No config files have been added (Amplify config, cache files)
  - [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  - [x] No global styling (see [#1691](https://github.com/domits1/Domits/issues/1691))
  - [x] No `console.log` left in code
  - [x] No commented-out code remains
- [x] Testing
  - [x] Code tested locally
  - [ ] Jest tests are included
  - [x] Jest tests are passing

## Keep or delete my branch
- [ ] Delete my branch after merge
- [x] Keep my branch