### PR TITLE
#3106 Add CloudFront tenant repository for custom domains

### DIFF
--- a/backend/functions/PropertyHandler/data/repository/cloudFrontTenantRepository.js
+++ b/backend/functions/PropertyHandler/data/repository/cloudFrontTenantRepository.js
@@ -1,0 +1,124 @@
+import {
+  CloudFrontClient,
+  CreateDistributionTenantCommand,
+  GetDistributionTenantByDomainCommand,
+  GetDistributionTenantCommand,
+  GetManagedCertificateDetailsCommand,
+  UpdateDistributionTenantCommand,
+  VerifyDnsConfigurationCommand,
+} from "@aws-sdk/client-cloudfront";
+
+const CLOUDFRONT_REGION = "us-east-1";
+const MANAGED_CERTIFICATE_VALIDATION_TOKEN_HOST = "cloudfront";
+const DNS_STATUS_UNKNOWN = "unknown-configuration";
+
+const isEntityNotFound = (error) => error?.name === "EntityNotFound";
+
+const mapTenant = (response) => {
+  const tenant = response?.DistributionTenant;
+  if (!tenant?.Id) {
+    return null;
+  }
+
+  return {
+    etag: response?.ETag || "",
+    id: tenant.Id,
+    name: tenant.Name || "",
+    enabled: tenant.Enabled === true,
+    status: tenant.Status || "",
+    distributionId: tenant.DistributionId || "",
+    connectionGroupId: tenant.ConnectionGroupId || "",
+    certificateArn: tenant.Customizations?.Certificate?.Arn || null,
+    domains: (Array.isArray(tenant.Domains) ? tenant.Domains : []).map((domainEntry) => ({
+      domain: domainEntry?.Domain || "",
+      status: domainEntry?.Status || "",
+    })),
+  };
+};
+
+const mapManagedCertificate = (response) => {
+  const details = response?.ManagedCertificateDetails;
+  if (!details) {
+    return null;
+  }
+
+  return {
+    arn: details.CertificateArn || null,
+    status: details.CertificateStatus || "",
+    validationTokenHost: details.ValidationTokenHost || "",
+  };
+};
+
+const nullWhenNotFound = async (request) => {
+  try {
+    return await request();
+  } catch (error) {
+    if (isEntityNotFound(error)) {
+      return null;
+    }
+    throw error;
+  }
+};
+
+export class CloudFrontTenantRepository {
+  constructor({ client = new CloudFrontClient({ region: CLOUDFRONT_REGION }) } = {}) {
+    this.client = client;
+  }
+
+  async createTenant({ name, domain, distributionId, connectionGroupId }) {
+    const response = await this.client.send(
+      new CreateDistributionTenantCommand({
+        Name: name,
+        DistributionId: distributionId,
+        ConnectionGroupId: connectionGroupId,
+        Enabled: true,
+        Domains: [{ Domain: domain }],
+        ManagedCertificateRequest: {
+          ValidationTokenHost: MANAGED_CERTIFICATE_VALIDATION_TOKEN_HOST,
+          PrimaryDomainName: domain,
+        },
+      })
+    );
+    return mapTenant(response);
+  }
+
+  getTenant(tenantId) {
+    return nullWhenNotFound(async () =>
+      mapTenant(await this.client.send(new GetDistributionTenantCommand({ Identifier: tenantId })))
+    );
+  }
+
+  getTenantByDomain(domain) {
+    return nullWhenNotFound(async () =>
+      mapTenant(await this.client.send(new GetDistributionTenantByDomainCommand({ Domain: domain })))
+    );
+  }
+
+  getManagedCertificate(tenantId) {
+    return nullWhenNotFound(async () =>
+      mapManagedCertificate(await this.client.send(new GetManagedCertificateDetailsCommand({ Identifier: tenantId })))
+    );
+  }
+
+  async applyCertificate({ tenantId, etag, certificateArn }) {
+    const response = await this.client.send(
+      new UpdateDistributionTenantCommand({
+        Id: tenantId,
+        IfMatch: etag,
+        Customizations: { Certificate: { Arn: certificateArn } },
+      })
+    );
+    return mapTenant(response);
+  }
+
+  async verifyDns({ tenantId, domain }) {
+    const response = await this.client.send(
+      new VerifyDnsConfigurationCommand({ Identifier: tenantId, Domain: domain })
+    );
+    const entry = response?.DnsConfigurationList?.[0];
+    return {
+      status: entry?.Status || DNS_STATUS_UNKNOWN,
+      reason: entry?.Reason || "",
+    };
+  }
+}

--- a/backend/functions/PropertyHandler/util/exception/WebsiteCustomDomainError.js
+++ b/backend/functions/PropertyHandler/util/exception/WebsiteCustomDomainError.js
@@ -1,0 +1,28 @@
+export const WEBSITE_CUSTOM_DOMAIN_ERROR_CODES = Object.freeze({
+  INVALID_DOMAIN: "invalid_domain",
+  DOMAIN_TAKEN: "domain_taken",
+  DOMAIN_NOT_FOUND: "domain_not_found",
+  TENANT_CREATE_FAILED: "tenant_create_failed",
+  SYNC_FAILED: "sync_failed",
+});
+
+const STATUS_CODE_BY_ERROR_CODE = Object.freeze({
+  [WEBSITE_CUSTOM_DOMAIN_ERROR_CODES.INVALID_DOMAIN]: 400,
+  [WEBSITE_CUSTOM_DOMAIN_ERROR_CODES.DOMAIN_TAKEN]: 409,
+  [WEBSITE_CUSTOM_DOMAIN_ERROR_CODES.DOMAIN_NOT_FOUND]: 404,
+  [WEBSITE_CUSTOM_DOMAIN_ERROR_CODES.TENANT_CREATE_FAILED]: 502,
+  [WEBSITE_CUSTOM_DOMAIN_ERROR_CODES.SYNC_FAILED]: 502,
+});
+
+export class WebsiteCustomDomainError extends Error {
+  constructor(code, message, { cause } = {}) {
+    const statusCode = STATUS_CODE_BY_ERROR_CODE[code];
+    if (!statusCode) {
+      throw new TypeError(`Unknown website custom domain error code: ${code}`);
+    }
+    super(message, cause ? { cause } : undefined);
+    this.name = "WebsiteCustomDomainError";
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.0.0",
 			"license": "ISC",
 			"dependencies": {
+				"@aws-sdk/client-cloudfront": "^3.1129.0",
 				"@aws-sdk/client-cognito-identity-provider": "^3.812.0",
 				"@aws-sdk/client-dynamodb": "^3.812.0",
 				"@aws-sdk/client-lambda": "^3.812.0",
@@ -302,6 +303,25 @@
 				"@smithy/util-retry": "^4.2.12",
 				"@smithy/util-stream": "^4.5.19",
 				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudfront": {
+			"version": "3.1129.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.1129.0.tgz",
+			"integrity": "sha512-kWS+CU2M7UAs0otRKXpuR9gyaGimZAhM/yJAjpYdNk6gu92gES9f0UtHb6aUSOvdRJc7e5mMQmo1krjPTYNORw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.978.0",
+				"@aws-sdk/credential-provider-node": "^3.972.83",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
+				"@smithy/fetch-http-handler": "^5.7.2",
+				"@smithy/node-http-handler": "^4.11.3",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -686,27 +706,31 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.973.20",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.20.tgz",
-			"integrity": "sha512-i3GuX+lowD892F3IuJf8o6AbyDupMTdyTxQrCJGcn71ni5hTZ82L4nQhcdumxZ7XPJRJJVHS/CR3uYOIIs0PVA==",
+			"version": "3.978.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.978.0.tgz",
+			"integrity": "sha512-2yX9LUmxPklVjSGTb8dfnWRJSiFQ3TeH2nn7G1mdKHTfnabzF0+gfrS8rYfLWmZrQ8A3mEcxMJjRc51dL5KWaA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.6",
-				"@aws-sdk/xml-builder": "^3.972.11",
-				"@smithy/core": "^3.23.11",
-				"@smithy/node-config-provider": "^4.3.12",
-				"@smithy/property-provider": "^4.2.12",
-				"@smithy/protocol-http": "^5.3.12",
-				"@smithy/signature-v4": "^5.3.12",
-				"@smithy/smithy-client": "^4.12.5",
-				"@smithy/types": "^4.13.1",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-middleware": "^4.2.12",
-				"@smithy/util-utf8": "^4.2.2",
+				"@aws-sdk/types": "^3.974.5",
+				"@aws-sdk/xml-builder": "^3.972.40",
+				"@aws/lambda-invoke-store": "^0.3.0",
+				"@smithy/core": "^3.33.3",
+				"@smithy/signature-v4": "^5.6.12",
+				"@smithy/types": "^4.17.2",
+				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/core/node_modules/@aws/lambda-invoke-store": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+			"integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/crc64-nvme": {
@@ -723,15 +747,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.18",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.18.tgz",
-			"integrity": "sha512-X0B8AlQY507i5DwjLByeU2Af4ARsl9Vr84koDcXCbAkplmU+1xBFWxEPrWRAoh56waBne/yJqEloSwvRf4x6XA==",
+			"version": "3.972.71",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.71.tgz",
+			"integrity": "sha512-JN+JHruYZw3GUZB8YGAlDk4wTDPOEAEEdEzj5nS0xodWR4smzHsN7PnK2j6IeOsDIj2aqua5DSbhXl9Gtf90FQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.20",
-				"@aws-sdk/types": "^3.973.6",
-				"@smithy/property-provider": "^4.2.12",
-				"@smithy/types": "^4.13.1",
+				"@aws-sdk/core": "^3.978.0",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -739,20 +763,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.20",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.20.tgz",
-			"integrity": "sha512-ey9Lelj001+oOfrbKmS6R2CJAiXX7QKY4Vj9VJv6L2eE6/VjD8DocHIoYqztTm70xDLR4E1jYPTKfIui+eRNDA==",
+			"version": "3.972.73",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.73.tgz",
+			"integrity": "sha512-uyYYnJOnlis8uQzaYGPd7N1JoioCoNpXgnkXYixsWJXHXgXyYi8WXJSDfofxJeWfQIGWLe2Nwyq60Uc7MZdVOg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.20",
-				"@aws-sdk/types": "^3.973.6",
-				"@smithy/fetch-http-handler": "^5.3.15",
-				"@smithy/node-http-handler": "^4.4.16",
-				"@smithy/property-provider": "^4.2.12",
-				"@smithy/protocol-http": "^5.3.12",
-				"@smithy/smithy-client": "^4.12.5",
-				"@smithy/types": "^4.13.1",
-				"@smithy/util-stream": "^4.5.19",
+				"@aws-sdk/core": "^3.978.0",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
+				"@smithy/fetch-http-handler": "^5.7.2",
+				"@smithy/node-http-handler": "^4.11.3",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -760,24 +781,23 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.972.20",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.20.tgz",
-			"integrity": "sha512-5flXSnKHMloObNF+9N0cupKegnH1Z37cdVlpETVgx8/rAhCe+VNlkcZH3HDg2SDn9bI765S+rhNPXGDJJPfbtA==",
+			"version": "3.973.16",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.16.tgz",
+			"integrity": "sha512-i++ly+0Uxa+u3ebSSyr0S/3CFhFJDxCXT3+Zj+mW2bXenEx5bKGCdTIKFu39SgXBNhWDjex/8cXUx9MUTMCrTw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.20",
-				"@aws-sdk/credential-provider-env": "^3.972.18",
-				"@aws-sdk/credential-provider-http": "^3.972.20",
-				"@aws-sdk/credential-provider-login": "^3.972.20",
-				"@aws-sdk/credential-provider-process": "^3.972.18",
-				"@aws-sdk/credential-provider-sso": "^3.972.20",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.20",
-				"@aws-sdk/nested-clients": "^3.996.10",
-				"@aws-sdk/types": "^3.973.6",
-				"@smithy/credential-provider-imds": "^4.2.12",
-				"@smithy/property-provider": "^4.2.12",
-				"@smithy/shared-ini-file-loader": "^4.4.7",
-				"@smithy/types": "^4.13.1",
+				"@aws-sdk/core": "^3.978.0",
+				"@aws-sdk/credential-provider-env": "^3.972.71",
+				"@aws-sdk/credential-provider-http": "^3.972.73",
+				"@aws-sdk/credential-provider-login": "^3.972.78",
+				"@aws-sdk/credential-provider-process": "^3.972.71",
+				"@aws-sdk/credential-provider-sso": "^3.973.15",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.77",
+				"@aws-sdk/nested-clients": "^3.997.45",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
+				"@smithy/credential-provider-imds": "^4.4.16",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -785,18 +805,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.20",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.20.tgz",
-			"integrity": "sha512-gEWo54nfqp2jABMu6HNsjVC4hDLpg9HC8IKSJnp0kqWtxIJYHTmiLSsIfI4ScQjxEwpB+jOOH8dOLax1+hy/Hw==",
+			"version": "3.972.78",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.78.tgz",
+			"integrity": "sha512-eUtswnXu0+Ii9ieRK+0L7aPFV3Z/dnW2VntJzjBP9xs8s+8p5nBNuymIXtXwZ+5r5+XJP3e32nMkuZ/r0HozEA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.20",
-				"@aws-sdk/nested-clients": "^3.996.10",
-				"@aws-sdk/types": "^3.973.6",
-				"@smithy/property-provider": "^4.2.12",
-				"@smithy/protocol-http": "^5.3.12",
-				"@smithy/shared-ini-file-loader": "^4.4.7",
-				"@smithy/types": "^4.13.1",
+				"@aws-sdk/core": "^3.978.0",
+				"@aws-sdk/nested-clients": "^3.997.45",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -804,22 +822,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.21",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.21.tgz",
-			"integrity": "sha512-hah8if3/B/Q+LBYN5FukyQ1Mym6PLPDsBOBsIgNEYD6wLyZg0UmUF/OKIVC3nX9XH8TfTPuITK+7N/jenVACWA==",
+			"version": "3.972.83",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.83.tgz",
+			"integrity": "sha512-jdso7ejzfRnatxMUZK4S/U6KbaDPCvfIV4XL+IQAPFDBt5rj5Fq595euqlK8Le4lNCMFR9oUpt+1l0aMgaayOQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.18",
-				"@aws-sdk/credential-provider-http": "^3.972.20",
-				"@aws-sdk/credential-provider-ini": "^3.972.20",
-				"@aws-sdk/credential-provider-process": "^3.972.18",
-				"@aws-sdk/credential-provider-sso": "^3.972.20",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.20",
-				"@aws-sdk/types": "^3.973.6",
-				"@smithy/credential-provider-imds": "^4.2.12",
-				"@smithy/property-provider": "^4.2.12",
-				"@smithy/shared-ini-file-loader": "^4.4.7",
-				"@smithy/types": "^4.13.1",
+				"@aws-sdk/credential-provider-env": "^3.972.71",
+				"@aws-sdk/credential-provider-http": "^3.972.73",
+				"@aws-sdk/credential-provider-ini": "^3.973.16",
+				"@aws-sdk/credential-provider-process": "^3.972.71",
+				"@aws-sdk/credential-provider-sso": "^3.973.15",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.77",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
+				"@smithy/credential-provider-imds": "^4.4.16",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -827,16 +844,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.18",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.18.tgz",
-			"integrity": "sha512-Tpl7SRaPoOLT32jbTWchPsn52hYYgJ0kpiFgnwk8pxTANQdUymVSZkzFvv1+oOgZm1CrbQUP9MBeoMZ9IzLZjA==",
+			"version": "3.972.71",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.71.tgz",
+			"integrity": "sha512-lYmXJa4gvq4xN1lrT5NiP5vIYYKcGWAdj8y+8o6dlcateB5eF3Dn8DtmjjHKfMBrTPAMr2pebIiX/UOj8c1/UA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.20",
-				"@aws-sdk/types": "^3.973.6",
-				"@smithy/property-provider": "^4.2.12",
-				"@smithy/shared-ini-file-loader": "^4.4.7",
-				"@smithy/types": "^4.13.1",
+				"@aws-sdk/core": "^3.978.0",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -844,18 +860,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.972.20",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.20.tgz",
-			"integrity": "sha512-p+R+PYR5Z7Gjqf/6pvbCnzEHcqPCpLzR7Yf127HjJ6EAb4hUcD+qsNRnuww1sB/RmSeCLxyay8FMyqREw4p1RA==",
+			"version": "3.973.15",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.15.tgz",
+			"integrity": "sha512-6Jhcf4v0pSFdjk1EW2kvzuEBKD+UZ2uNcHUIglKKLndD20YhvkL2kdmDOV5/j4mYuWWwe/a1FQ1aomU86/Cg5Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.20",
-				"@aws-sdk/nested-clients": "^3.996.10",
-				"@aws-sdk/token-providers": "3.1009.0",
-				"@aws-sdk/types": "^3.973.6",
-				"@smithy/property-provider": "^4.2.12",
-				"@smithy/shared-ini-file-loader": "^4.4.7",
-				"@smithy/types": "^4.13.1",
+				"@aws-sdk/core": "^3.978.0",
+				"@aws-sdk/nested-clients": "^3.997.45",
+				"@aws-sdk/token-providers": "3.1129.0",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -863,17 +878,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.20",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.20.tgz",
-			"integrity": "sha512-rWCmh8o7QY4CsUj63qopzMzkDq/yPpkrpb+CnjBEFSOg/02T/we7sSTVg4QsDiVS9uwZ8VyONhq98qt+pIh3KA==",
+			"version": "3.972.77",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.77.tgz",
+			"integrity": "sha512-uylIQSUWpfLuH2LovxEEfwzJGM/SabLOfLMg6YXu/E8jJEKUdpdILCVCQCdFvHyu/7dLJOHPMfrSwduxO56NkQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.20",
-				"@aws-sdk/nested-clients": "^3.996.10",
-				"@aws-sdk/types": "^3.973.6",
-				"@smithy/property-provider": "^4.2.12",
-				"@smithy/shared-ini-file-loader": "^4.4.7",
-				"@smithy/types": "^4.13.1",
+				"@aws-sdk/core": "^3.978.0",
+				"@aws-sdk/nested-clients": "^3.997.45",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1142,48 +1156,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.996.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.10.tgz",
-			"integrity": "sha512-SlDol5Z+C7Ivnc2rKGqiqfSUmUZzY1qHfVs9myt/nxVwswgfpjdKahyTzLTx802Zfq0NFRs7AejwKzzzl5Co2w==",
+			"version": "3.997.45",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.45.tgz",
+			"integrity": "sha512-mooq9Q+jLa18VoM7HouczmslZU60iiB0aKc/Ztnq/luIL1ud0z4DnYprLR/ZO1gp331S9tJctM1HZr7u6YKBXQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-crypto/sha256-browser": "5.2.0",
-				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.973.20",
-				"@aws-sdk/middleware-host-header": "^3.972.8",
-				"@aws-sdk/middleware-logger": "^3.972.8",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.8",
-				"@aws-sdk/middleware-user-agent": "^3.972.21",
-				"@aws-sdk/region-config-resolver": "^3.972.8",
-				"@aws-sdk/types": "^3.973.6",
-				"@aws-sdk/util-endpoints": "^3.996.5",
-				"@aws-sdk/util-user-agent-browser": "^3.972.8",
-				"@aws-sdk/util-user-agent-node": "^3.973.7",
-				"@smithy/config-resolver": "^4.4.11",
-				"@smithy/core": "^3.23.11",
-				"@smithy/fetch-http-handler": "^5.3.15",
-				"@smithy/hash-node": "^4.2.12",
-				"@smithy/invalid-dependency": "^4.2.12",
-				"@smithy/middleware-content-length": "^4.2.12",
-				"@smithy/middleware-endpoint": "^4.4.25",
-				"@smithy/middleware-retry": "^4.4.42",
-				"@smithy/middleware-serde": "^4.2.14",
-				"@smithy/middleware-stack": "^4.2.12",
-				"@smithy/node-config-provider": "^4.3.12",
-				"@smithy/node-http-handler": "^4.4.16",
-				"@smithy/protocol-http": "^5.3.12",
-				"@smithy/smithy-client": "^4.12.5",
-				"@smithy/types": "^4.13.1",
-				"@smithy/url-parser": "^4.2.12",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-body-length-browser": "^4.2.2",
-				"@smithy/util-body-length-node": "^4.2.3",
-				"@smithy/util-defaults-mode-browser": "^4.3.41",
-				"@smithy/util-defaults-mode-node": "^4.2.44",
-				"@smithy/util-endpoints": "^3.3.3",
-				"@smithy/util-middleware": "^4.2.12",
-				"@smithy/util-retry": "^4.2.12",
-				"@smithy/util-utf8": "^4.2.2",
+				"@aws-sdk/core": "^3.978.0",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.46",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
+				"@smithy/fetch-http-handler": "^5.7.2",
+				"@smithy/node-http-handler": "^4.11.3",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1243,16 +1227,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/signature-v4-multi-region": {
-			"version": "3.996.8",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.8.tgz",
-			"integrity": "sha512-n1qYFD+tbqZuyskVaxUE+t10AUz9g3qzDw3Tp6QZDKmqsjfDmZBd4GIk2EKJJNtcCBtE5YiUjDYA+3djFAFBBg==",
+			"version": "3.996.46",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+			"integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/middleware-sdk-s3": "^3.972.20",
-				"@aws-sdk/types": "^3.973.6",
-				"@smithy/protocol-http": "^5.3.12",
-				"@smithy/signature-v4": "^5.3.12",
-				"@smithy/types": "^4.13.1",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/signature-v4": "^5.6.12",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1260,17 +1242,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.1009.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1009.0.tgz",
-			"integrity": "sha512-KCPLuTqN9u0Rr38Arln78fRG9KXpzsPWmof+PZzfAHMMQq2QED6YjQrkrfiH7PDefLWEposY1o4/eGwrmKA4JA==",
+			"version": "3.1129.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1129.0.tgz",
+			"integrity": "sha512-Sbl3rpzQdsG4ZK2zh0JWUYyZPKKorJlVOddA2T0DVbKJFrsW8J6wgnslxxUH04+WaBMr4A1HzJZvZX0xUvkniA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.20",
-				"@aws-sdk/nested-clients": "^3.996.10",
-				"@aws-sdk/types": "^3.973.6",
-				"@smithy/property-provider": "^4.2.12",
-				"@smithy/shared-ini-file-loader": "^4.4.7",
-				"@smithy/types": "^4.13.1",
+				"@aws-sdk/core": "^3.978.0",
+				"@aws-sdk/nested-clients": "^3.997.45",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1278,12 +1259,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.973.6",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
-			"integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+			"version": "3.974.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+			"integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.13.1",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1398,13 +1379,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.11",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.11.tgz",
-			"integrity": "sha512-iitV/gZKQMvY9d7ovmyFnFuTHbBAtrmLnvaSb/3X8vOKyevwtpmEtyc8AdhVWZe0pI/1GsHxlEvQeOePFzy7KQ==",
+			"version": "3.972.40",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+			"integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.13.1",
-				"fast-xml-parser": "5.4.1",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4069,20 +4049,12 @@
 			}
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.23.11",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.11.tgz",
-			"integrity": "sha512-952rGf7hBRnhUIaeLp6q4MptKW8sPFe5VvkoZ5qIzFAtx6c/QZ/54FS3yootsyUSf9gJX/NBqEBNdNR7jMIlpQ==",
+			"version": "3.33.3",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+			"integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.12",
-				"@smithy/types": "^4.13.1",
-				"@smithy/url-parser": "^4.2.12",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-body-length-browser": "^4.2.2",
-				"@smithy/util-middleware": "^4.2.12",
-				"@smithy/util-stream": "^4.5.19",
-				"@smithy/util-utf8": "^4.2.2",
-				"@smithy/uuid": "^1.1.2",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4090,15 +4062,13 @@
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "4.2.12",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
-			"integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
+			"version": "4.5.2",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+			"integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.12",
-				"@smithy/property-provider": "^4.2.12",
-				"@smithy/types": "^4.13.1",
-				"@smithy/url-parser": "^4.2.12",
+				"@smithy/core": "^3.33.2",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4176,15 +4146,13 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.3.15",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
-			"integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+			"version": "5.8.0",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.8.0.tgz",
+			"integrity": "sha512-ycSJu3tFAQ4v04CBB0agqFMVsSQ1iG3yw+SpgxRqKfaURpQD4CZ8Wn0zPMmSnOuTpTh65Vz+EA0rMrw089wvkA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.12",
-				"@smithy/querystring-builder": "^4.2.12",
-				"@smithy/types": "^4.13.1",
-				"@smithy/util-base64": "^4.3.2",
+				"@smithy/core": "^3.33.3",
+				"@smithy/types": "^4.18.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4371,15 +4339,13 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "4.4.16",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.16.tgz",
-			"integrity": "sha512-ULC8UCS/HivdCB3jhi+kLFYe4B5gxH2gi9vHBfEIiRrT2jfKiZNiETJSlzRtE6B26XbBHjPtc8iZKSNqMol9bw==",
+			"version": "4.12.1",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+			"integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/abort-controller": "^4.2.12",
-				"@smithy/protocol-http": "^5.3.12",
-				"@smithy/querystring-builder": "^4.2.12",
-				"@smithy/types": "^4.13.1",
+				"@smithy/core": "^3.33.3",
+				"@smithy/types": "^4.18.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4465,18 +4431,13 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "5.3.12",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
-			"integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+			"integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/is-array-buffer": "^4.2.2",
-				"@smithy/protocol-http": "^5.3.12",
-				"@smithy/types": "^4.13.1",
-				"@smithy/util-hex-encoding": "^4.2.2",
-				"@smithy/util-middleware": "^4.2.12",
-				"@smithy/util-uri-escape": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
+				"@smithy/core": "^3.33.3",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4502,9 +4463,9 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "4.13.1",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-			"integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.18.0.tgz",
+			"integrity": "sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -5934,40 +5895,6 @@
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/fast-xml-builder": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.3.tgz",
-			"integrity": "sha512-1o60KoFw2+LWKQu3IdcfcFlGTW4dpqEWmjhYec6H82AYZU2TVBXep6tMl8Z1Y+wM+ZrzCwe3BZ9Vyd9N2rIvmg==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"path-expression-matcher": "^1.1.3"
-			}
-		},
-		"node_modules/fast-xml-parser": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-			"integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"fast-xml-builder": "^1.0.0",
-				"strnum": "^2.1.2"
-			},
-			"bin": {
-				"fxparser": "src/cli/cli.js"
-			}
 		},
 		"node_modules/fb-watchman": {
 			"version": "2.0.2",
@@ -7619,21 +7546,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/path-expression-matcher": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
-			"integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
 		"node_modules/path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -8543,18 +8455,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/strnum": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
-			"integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT"
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,6 +28,7 @@
 		"zip-lib": "^1.1.2"
 	},
 	"dependencies": {
+		"@aws-sdk/client-cloudfront": "^3.1129.0",
 		"@aws-sdk/client-cognito-identity-provider": "^3.812.0",
 		"@aws-sdk/client-dynamodb": "^3.812.0",
 		"@aws-sdk/client-lambda": "^3.812.0",

--- a/backend/test/PropertyHandler/cloudFrontTenantRepository.test.js
+++ b/backend/test/PropertyHandler/cloudFrontTenantRepository.test.js
@@ -1,0 +1,130 @@
+import { describe, it, expect, jest } from "@jest/globals";
+import { CloudFrontTenantRepository } from "../../functions/PropertyHandler/data/repository/cloudFrontTenantRepository.js";
+
+const TENANT_RESPONSE = {
+  ETag: "E1TAG",
+  DistributionTenant: {
+    Id: "dt_1",
+    Name: "dbw-site-1",
+    Enabled: true,
+    Status: "Deployed",
+    DistributionId: "E18DIST",
+    ConnectionGroupId: "cg_1",
+    Domains: [{ Domain: "www.example.com", Status: "inactive" }],
+  },
+};
+
+const buildClient = (responses = {}) => ({
+  send: jest.fn(async (command) => {
+    const handler = responses[command.constructor.name];
+    if (!handler) {
+      throw new Error(`Unexpected command ${command.constructor.name}`);
+    }
+    return typeof handler === "function" ? handler(command.input) : handler;
+  }),
+});
+
+const sentInput = (client, index = 0) => client.send.mock.calls[index][0].input;
+
+const buildNotFoundError = () => Object.assign(new Error("not found"), { name: "EntityNotFound" });
+
+describe("CloudFrontTenantRepository", () => {
+  it("creates an enabled tenant with a cloudfront-hosted managed certificate request", async () => {
+    const client = buildClient({ CreateDistributionTenantCommand: TENANT_RESPONSE });
+    const repository = new CloudFrontTenantRepository({ client });
+
+    const tenant = await repository.createTenant({
+      name: "dbw-site-1",
+      domain: "www.example.com",
+      distributionId: "E18DIST",
+      connectionGroupId: "cg_1",
+    });
+
+    expect(sentInput(client)).toEqual({
+      Name: "dbw-site-1",
+      DistributionId: "E18DIST",
+      ConnectionGroupId: "cg_1",
+      Enabled: true,
+      Domains: [{ Domain: "www.example.com" }],
+      ManagedCertificateRequest: { ValidationTokenHost: "cloudfront", PrimaryDomainName: "www.example.com" },
+    });
+    expect(tenant).toEqual({
+      etag: "E1TAG",
+      id: "dt_1",
+      name: "dbw-site-1",
+      enabled: true,
+      status: "Deployed",
+      distributionId: "E18DIST",
+      connectionGroupId: "cg_1",
+      certificateArn: null,
+      domains: [{ domain: "www.example.com", status: "inactive" }],
+    });
+  });
+
+  it("applies a certificate by sending only the certificate customization with the etag", async () => {
+    const client = buildClient({
+      UpdateDistributionTenantCommand: {
+        DistributionTenant: {
+          ...TENANT_RESPONSE.DistributionTenant,
+          Customizations: { Certificate: { Arn: "arn:cert" } },
+        },
+      },
+    });
+    const repository = new CloudFrontTenantRepository({ client });
+
+    const tenant = await repository.applyCertificate({ tenantId: "dt_1", etag: "E1TAG", certificateArn: "arn:cert" });
+
+    expect(sentInput(client)).toEqual({
+      Id: "dt_1",
+      IfMatch: "E1TAG",
+      Customizations: { Certificate: { Arn: "arn:cert" } },
+    });
+    expect(tenant.certificateArn).toBe("arn:cert");
+  });
+
+  it("returns null for a missing tenant or certificate and rethrows other errors", async () => {
+    const client = buildClient({
+      GetDistributionTenantCommand: () => {
+        throw buildNotFoundError();
+      },
+      GetManagedCertificateDetailsCommand: () => {
+        throw buildNotFoundError();
+      },
+      GetDistributionTenantByDomainCommand: () => {
+        throw Object.assign(new Error("slow down"), { name: "Throttling" });
+      },
+    });
+    const repository = new CloudFrontTenantRepository({ client });
+
+    await expect(repository.getTenant("dt_missing")).resolves.toBeNull();
+    await expect(repository.getManagedCertificate("dt_missing")).resolves.toBeNull();
+    await expect(repository.getTenantByDomain("www.example.com")).rejects.toMatchObject({ name: "Throttling" });
+  });
+
+  it("maps managed certificate details and dns verification results", async () => {
+    const client = buildClient({
+      GetManagedCertificateDetailsCommand: {
+        ManagedCertificateDetails: {
+          CertificateArn: "arn:cert",
+          CertificateStatus: "issued",
+          ValidationTokenHost: "cloudfront",
+        },
+      },
+      VerifyDnsConfigurationCommand: (input) => ({
+        DnsConfigurationList: [{ Domain: input.Domain, Status: "valid-configuration" }],
+      }),
+    });
+    const repository = new CloudFrontTenantRepository({ client });
+
+    await expect(repository.getManagedCertificate("dt_1")).resolves.toEqual({
+      arn: "arn:cert",
+      status: "issued",
+      validationTokenHost: "cloudfront",
+    });
+    await expect(repository.verifyDns({ tenantId: "dt_1", domain: "www.example.com" })).resolves.toEqual({
+      status: "valid-configuration",
+      reason: "",
+    });
+    expect(sentInput(client, 1)).toEqual({ Identifier: "dt_1", Domain: "www.example.com" });
+  });
+});


### PR DESCRIPTION
## Close or Relate the Issue
- Closes #
- Related Issue: #3106

## Proposed Changes
Description:

First backend part for custom domains. Three small things that the domain service in the next PR needs.

The CloudFront SDK, plus the lockfile changes that come with it. Four packages got removed because the newer SDK doesn't need them, and twenty others got a version bump. All backend tests still pass.

A repository that turns six CloudFront API calls into simple objects. The important bit: when it asks for a certificate, it always sets ValidationTokenHost to cloudfront. I tested this by hand today and the default setting, self-hosted, never works for a domain that has no other server. The tenant just gets stuck.

An error class built the same way as WebsiteQuoteError, so the controller can turn error codes into HTTP statuses later.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Optimization
- [ ] Documentation update

## Change Size
- [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
- [x] Big change (+-max 1000)
- [ ] Small change (less than 300)

## Refactoring
Nothing refactored. The lockfile diff is large but it's npm reconciling dependencies, not code.

## Evidence
Verified a real GetDistributionTenant call works with the new SDK against developers.domits.com.

## Responsiveness
Not applicable.

## Npm Packages
- [x] NPM Packages installed
- [ ] NPM Packages removed
- [x] NPM Packages updated
- [x] Checked for vulnerabilities using "npm audit"

Added @aws-sdk/client-cloudfront. Lockfile bumped 20 transitive @aws-sdk and @smithy packages and dropped 4 that nothing needs anymore.

## Checklist
- [ ] Pull request has at least 2 reviewers assigned
- [x] PR title is descriptive and includes issue number
- [x] Conventions
  - [x] No config files have been added (Amplify config, cache files)
  - [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  - [x] No global styling (see [#1691](https://github.com/domits1/Domits/issues/1691))
  - [x] No `console.log` left in code
  - [x] No commented-out code remains
- [x] Testing
  - [x] Code tested locally
  - [x] Jest tests are included, 4 for the repository
  - [x] Jest tests are passing, 103 suites

## Keep or delete my branch
- [ ] Delete my branch after merge
- [x] Keep my branch

Keeping the branch because the next PR stacks on it.