### PR TITLE
feat(integrations): add channex credentials connect and reconnect form

### DIFF
--- a/frontend/web/src/features/hostdashboard/hostintegrations/ChannexDiagnosticsPanel.jsx
+++ b/frontend/web/src/features/hostdashboard/hostintegrations/ChannexDiagnosticsPanel.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import ChannexBookingRevisionLog from "./ChannexBookingRevisionLog";
 import {
   cancelBooking,
+  connectChannex,
   getChannexAriPayloadPreview,
   getChannexAriPreview,
   getChannexAriTargets,
@@ -360,6 +361,11 @@ const createSetupSelection = () => ({
   externalPropertyId: "",
   externalRoomTypeId: "",
   externalRatePlanId: "",
+});
+
+const createConnectForm = () => ({
+  apiKey: "",
+  displayName: "",
 });
 
 const findById = (items, key, value) =>
@@ -1210,6 +1216,40 @@ SectionCard.propTypes = {
   children: PropTypes.node,
 };
 
+const getConnectButtonLabel = ({ loading, isConnected }) => {
+  if (loading) return "Connecting...";
+  return isConnected ? "Reconnect" : "Connect";
+};
+
+// A 200 response does not mean the key works: the backend stores the credential first and
+// reports Channex's own verdict in `connected`, so a rejected key still returns 200.
+const ConnectOutcome = ({ result }) => (
+  <>
+    {result.connected ? (
+      <p className="host-integrations-success-banner">Channex credentials verified and connected.</p>
+    ) : (
+      <ErrorCallout error="Channex rejected these credentials. The key was stored, but the integration is not usable yet." />
+    )}
+    <DetailGrid
+      items={[
+        { label: "Connected", value: result.connected ? "Yes" : "No" },
+        { label: "Validation state", value: result.validationState },
+        { label: "Provider status", value: result.providerStatus },
+        { label: "Integration account", value: result.integration?.id },
+      ]}
+    />
+  </>
+);
+
+ConnectOutcome.propTypes = {
+  result: PropTypes.shape({
+    connected: PropTypes.bool,
+    validationState: PropTypes.string,
+    providerStatus: PropTypes.string,
+    integration: PropTypes.object,
+  }).isRequired,
+};
+
 const ACTION_CONFIG = [
   {
     key: "availability",
@@ -1263,6 +1303,9 @@ function ChannexDiagnosticsPanel({ userId }) {
   const [setupRatePlansState, setSetupRatePlansState] = useState(createRequestState);
   const [setupMappingState, setSetupMappingState] = useState(createRequestState);
   const [setupSelection, setSetupSelection] = useState(createSetupSelection);
+  const [connectForm, setConnectForm] = useState(createConnectForm);
+  const [connectState, setConnectState] = useState(createRequestState);
+  const [apiKeyVisible, setApiKeyVisible] = useState(false);
   const [actionStates, setActionStates] = useState({});
   const [modifyBookingForm, setModifyBookingForm] = useState(MODIFY_BOOKING_DEMO_DEFAULTS);
   const [modifyBookingState, setModifyBookingState] = useState(createRequestState);
@@ -1414,6 +1457,40 @@ function ChannexDiagnosticsPanel({ userId }) {
       externalRatePlanId,
     }));
     setSetupMappingState(createRequestState());
+  };
+
+  const submitChannexConnect = async () => {
+    const apiKey = connectForm.apiKey.trim();
+    if (!apiKey) {
+      setConnectState({
+        loading: false,
+        error: "Enter a Channex API key before connecting.",
+        errorDetails: null,
+        data: null,
+      });
+      return null;
+    }
+
+    const data = await runRequest({
+      setState: setConnectState,
+      request: () =>
+        connectChannex({
+          userId,
+          apiKey,
+          displayName: connectForm.displayName.trim(),
+        }),
+    });
+
+    if (data) {
+      // Keep the entered key when Channex rejected it, so a typo can be corrected without re-pasting.
+      if (data.connected) {
+        setConnectForm(createConnectForm());
+        setApiKeyVisible(false);
+      }
+      await refreshStatus();
+    }
+
+    return data;
   };
 
   const saveSetupMapping = async () => {
@@ -1583,6 +1660,8 @@ function ChannexDiagnosticsPanel({ userId }) {
   };
 
   const status = statusState.data || {};
+  const connectResult = connectState.data;
+  const isConnected = String(status.status || "").toUpperCase() === "CONNECTED";
   const targets = targetsState.data || {};
   const latestEvidence = latestEvidenceState.data?.item || null;
   const ariPreview = ariPreviewState.data || {};
@@ -1644,6 +1723,51 @@ function ChannexDiagnosticsPanel({ userId }) {
 
   const renderSetup = () => (
     <div className="channex-diagnostics-grid">
+      <SectionCard
+        title="Channex credentials"
+        description="Connect this Domits host account to Channex with a user API key generated in the Channex profile settings."
+        state={connectState}>
+        <form
+          className="host-integrations-field-grid"
+          onSubmit={(event) => {
+            event.preventDefault();
+            submitChannexConnect();
+          }}>
+          <label className="host-integrations-field">
+            <span>Channex API key</span>
+            <input
+              type={apiKeyVisible ? "text" : "password"}
+              value={connectForm.apiKey}
+              autoComplete="off"
+              placeholder="Channex user API key"
+              onChange={(event) => setConnectForm((current) => ({ ...current, apiKey: event.target.value }))}
+            />
+          </label>
+          <label className="host-integrations-field">
+            <span>Display name (optional)</span>
+            <input
+              value={connectForm.displayName}
+              placeholder="Channex"
+              onChange={(event) => setConnectForm((current) => ({ ...current, displayName: event.target.value }))}
+            />
+          </label>
+
+          <div className="channex-diagnostics-actions">
+            <button
+              type="button"
+              className="host-integrations-secondary-btn"
+              onClick={() => setApiKeyVisible((current) => !current)}>
+              {apiKeyVisible ? "Hide API key" : "Show API key"}
+            </button>
+            <button type="submit" className="host-integrations-primary-btn" disabled={!userId || connectState.loading}>
+              {getConnectButtonLabel({ loading: connectState.loading, isConnected })}
+            </button>
+          </div>
+        </form>
+
+        {connectResult ? <ConnectOutcome result={connectResult} /> : null}
+      </SectionCard>
+
       <SectionCard
         title="Setup & Connection"
         description="Admin-only single-unit mapping setup for one Domits property, one Channex property, one room type, and one rate plan."

--- a/frontend/web/src/features/hostdashboard/hostintegrations/ChannexDiagnosticsPanel.jsx
+++ b/frontend/web/src/features/hostdashboard/hostintegrations/ChannexDiagnosticsPanel.jsx
@@ -1189,8 +1189,8 @@ ErrorCallout.propTypes = {
   }),
 };
 
-const SectionCard = ({ title, description, actions, state, children }) => (
-  <section className="channex-diagnostics-card">
+const SectionCard = ({ title, description, actions, state, children, className }) => (
+  <section className={["channex-diagnostics-card", className].filter(Boolean).join(" ")}>
     <div className="channex-diagnostics-card-header">
       <div>
         <h3>{title}</h3>
@@ -1214,6 +1214,7 @@ SectionCard.propTypes = {
     errorDetails: PropTypes.object,
   }),
   children: PropTypes.node,
+  className: PropTypes.string,
 };
 
 const getConnectButtonLabel = ({ loading, isConnected }) => {
@@ -1726,7 +1727,8 @@ function ChannexDiagnosticsPanel({ userId }) {
       <SectionCard
         title="Channex credentials"
         description="Connect this Domits host account to Channex with a user API key generated in the Channex profile settings."
-        state={connectState}>
+        state={connectState}
+        className="channex-diagnostics-card--credentials channex-diagnostics-card--align-top">
         <form
           className="host-integrations-field-grid"
           onSubmit={(event) => {
@@ -1902,6 +1904,7 @@ function ChannexDiagnosticsPanel({ userId }) {
         title="Current mapping readiness"
         description="Readiness after setup save, or the latest readiness loaded for the selected Domits property."
         state={targetsState}
+        className="channex-diagnostics-card--align-top"
       >
         {targetsState.data ? (
           <>

--- a/frontend/web/src/features/hostdashboard/hostintegrations/ChannexDiagnosticsPanel.test.js
+++ b/frontend/web/src/features/hostdashboard/hostintegrations/ChannexDiagnosticsPanel.test.js
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import ChannexDiagnosticsPanel from "./ChannexDiagnosticsPanel";
 import {
   cancelBooking,
+  connectChannex,
   getChannexAriPreview,
   getLatestChannexSyncEvidence,
   getChannexStatus,
@@ -20,6 +21,7 @@ import {
 
 jest.mock("./channexApi", () => ({
   cancelBooking: jest.fn(),
+  connectChannex: jest.fn(),
   getChannexAriPayloadPreview: jest.fn(),
   getChannexAriPreview: jest.fn(),
   getChannexAriTargets: jest.fn(),
@@ -512,5 +514,108 @@ describe("ChannexDiagnosticsPanel certification actions", () => {
       includeRawPayload: false,
       limit: "50",
     });
+  });
+});
+
+describe("ChannexDiagnosticsPanel connect form", () => {
+  const openSetupTab = async () => {
+    await renderDiagnosticsPanel();
+    fireEvent.click(screen.getByRole("button", { name: "Setup & Connection" }));
+  };
+
+  const submitConnectForm = ({ apiKey, displayName } = {}) => {
+    if (apiKey !== undefined) {
+      fireEvent.change(screen.getByLabelText("Channex API key"), { target: { value: apiKey } });
+    }
+    if (displayName !== undefined) {
+      fireEvent.change(screen.getByLabelText("Display name (optional)"), { target: { value: displayName } });
+    }
+    fireEvent.click(screen.getByRole("button", { name: /^(Connect|Reconnect)$/ }));
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getChannexStatus.mockResolvedValue({ status: "NOT_CONNECTED" });
+    getLatestChannexSyncEvidence.mockResolvedValue({ item: null });
+    listChannexBookingRevisions.mockResolvedValue({ revisions: [], count: 0 });
+  });
+
+  test("sends the entered credentials and refreshes status on a verified connection", async () => {
+    connectChannex.mockResolvedValue({
+      connected: true,
+      validationState: "CONNECTED",
+      providerStatus: "ACTIVE",
+      integration: { id: "integration-account-1" },
+    });
+
+    await openSetupTab();
+    submitConnectForm({ apiKey: " key-1 ", displayName: "Staging" });
+
+    await waitFor(() => expect(connectChannex).toHaveBeenCalledTimes(1));
+    expect(connectChannex).toHaveBeenCalledWith({
+      userId: "user-1",
+      apiKey: "key-1",
+      displayName: "Staging",
+    });
+    expect(await screen.findByText("Channex credentials verified and connected.")).toBeTruthy();
+    await waitFor(() => expect(getChannexStatus).toHaveBeenCalledTimes(2));
+    expect(screen.getByLabelText("Channex API key")).toHaveValue("");
+  });
+
+  test("does not call the API when the key is blank", async () => {
+    await openSetupTab();
+    submitConnectForm({ apiKey: "   " });
+
+    expect(await screen.findByText("Enter a Channex API key before connecting.")).toBeTruthy();
+    expect(connectChannex).not.toHaveBeenCalled();
+  });
+
+  test("reports a rejected key as a failure even though the request returned 200", async () => {
+    connectChannex.mockResolvedValue({
+      connected: false,
+      validationState: "VALIDATION_FAILED",
+      providerStatus: "UNAUTHORIZED",
+      integration: { id: "integration-account-1" },
+    });
+
+    await openSetupTab();
+    submitConnectForm({ apiKey: "bad-key" });
+
+    await waitFor(() => expect(connectChannex).toHaveBeenCalledTimes(1));
+    expect(
+      await screen.findByText(
+        "Channex rejected these credentials. The key was stored, but the integration is not usable yet."
+      )
+    ).toBeTruthy();
+    expect(screen.queryByText("Channex credentials verified and connected.")).toBeNull();
+    expect(screen.getByText("UNAUTHORIZED")).toBeTruthy();
+    expect(screen.getByLabelText("Channex API key")).toHaveValue("bad-key");
+  });
+
+  test("surfaces a failed request through the shared error callout", async () => {
+    const error = new Error("POST /integrations/channex/connect failed with status 503: secret store down");
+    error.status = 503;
+    connectChannex.mockRejectedValueOnce(error);
+
+    await openSetupTab();
+    submitConnectForm({ apiKey: "key-1" });
+
+    expect(await screen.findByText(/POST \/integrations\/channex\/connect failed with status 503/)).toBeTruthy();
+  });
+
+  test("labels the action Reconnect once the integration is already connected", async () => {
+    getChannexStatus.mockResolvedValue({ status: "CONNECTED" });
+
+    await openSetupTab();
+
+    expect(screen.getByRole("button", { name: "Reconnect" })).toBeTruthy();
+  });
+
+  test("keeps the api key masked until the reveal toggle is used", async () => {
+    await openSetupTab();
+
+    expect(screen.getByLabelText("Channex API key")).toHaveProperty("type", "password");
+    fireEvent.click(screen.getByRole("button", { name: "Show API key" }));
+    expect(screen.getByLabelText("Channex API key")).toHaveProperty("type", "text");
   });
 });

--- a/frontend/web/src/features/hostdashboard/hostintegrations/HostIntegrations.scss
+++ b/frontend/web/src/features/hostdashboard/hostintegrations/HostIntegrations.scss
@@ -493,6 +493,23 @@
   min-width: 0;
 }
 
+// Grid's default align-items: stretch matches a card's height to its row, which can be taller
+// than the card's own content — either because a row-mate is taller, or because
+// .channex-diagnostics-grid itself is taller than its natural content (page layout). Since each
+// card is itself display: grid, that extra height spreads into a gap between its header and its
+// content instead of sitting harmlessly below the card. Any card whose content can be much
+// shorter than its neighbours — an empty state, in particular — needs this to size to its own
+// content instead.
+.channex-diagnostics-card--align-top {
+  align-self: start;
+}
+
+// A standalone step (connect), not a side-by-side comparison with the mapping card next to it,
+// so it spans the full row instead of sharing one with a taller sibling.
+.channex-diagnostics-card--credentials {
+  grid-column: 1 / -1;
+}
+
 .channex-diagnostics-card-header {
   display: flex;
   align-items: flex-start;

--- a/frontend/web/src/features/hostdashboard/hostintegrations/channexApi.js
+++ b/frontend/web/src/features/hostdashboard/hostintegrations/channexApi.js
@@ -130,6 +130,16 @@ export const getChannexAdminAccess = ({ userId }) =>
     query: { userId },
   });
 
+export const connectChannex = ({ userId, apiKey, displayName }) =>
+  requestChannex("/integrations/channex/connect", {
+    method: "POST",
+    body: {
+      userId,
+      credentials: { apiKey },
+      ...(displayName ? { displayName } : {}),
+    },
+  });
+
 export const getChannexAriTargets = ({ userId, domitsPropertyId }) =>
   requestChannex("/integrations/channex/ari-targets", {
     query: { userId, domitsPropertyId },

--- a/frontend/web/src/features/hostdashboard/hostintegrations/channexApi.test.js
+++ b/frontend/web/src/features/hostdashboard/hostintegrations/channexApi.test.js
@@ -1,0 +1,66 @@
+import { connectChannex } from "./channexApi";
+
+const CONNECT_URL = "https://54s3llwby8.execute-api.eu-north-1.amazonaws.com/default/integrations/channex/connect";
+
+const mockResponse = ({ ok = true, status = 200, body = {} } = {}) => ({
+  ok,
+  status,
+  text: async () => JSON.stringify(body),
+});
+
+describe("connectChannex", () => {
+  beforeEach(() => {
+    globalThis.fetch = jest.fn();
+  });
+
+  test("posts the api key as a credentials object and returns the parsed body", async () => {
+    globalThis.fetch.mockResolvedValueOnce(mockResponse({ body: { connected: true, validationState: "CONNECTED" } }));
+
+    const result = await connectChannex({ userId: "user-1", apiKey: "key-1", displayName: "Staging" });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(CONNECT_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        userId: "user-1",
+        credentials: { apiKey: "key-1" },
+        displayName: "Staging",
+      }),
+    });
+    expect(result).toEqual({ connected: true, validationState: "CONNECTED" });
+  });
+
+  test("omits displayName when it is not provided, so the backend default applies", async () => {
+    globalThis.fetch.mockResolvedValueOnce(mockResponse({ body: { connected: true } }));
+
+    await connectChannex({ userId: "user-1", apiKey: "key-1" });
+
+    expect(JSON.parse(globalThis.fetch.mock.calls[0][1].body)).toEqual({
+      userId: "user-1",
+      credentials: { apiKey: "key-1" },
+    });
+  });
+
+  test("throws with the backend error message when the request fails", async () => {
+    globalThis.fetch.mockResolvedValueOnce(
+      mockResponse({ ok: false, status: 400, body: { error: "Channex credentials must include apiKey." } })
+    );
+
+    await expect(connectChannex({ userId: "user-1", apiKey: "" })).rejects.toMatchObject({
+      status: 400,
+      endpoint: "/integrations/channex/connect",
+      method: "POST",
+      message: expect.stringContaining("Channex credentials must include apiKey."),
+    });
+  });
+
+  test("wraps a network failure instead of leaking the raw fetch error", async () => {
+    globalThis.fetch.mockRejectedValueOnce(new Error("Failed to fetch"));
+
+    await expect(connectChannex({ userId: "user-1", apiKey: "key-1" })).rejects.toMatchObject({
+      endpoint: "/integrations/channex/connect",
+      method: "POST",
+      message: "POST /integrations/channex/connect failed: Failed to fetch",
+    });
+  });
+});


### PR DESCRIPTION
## Close or Relate the Issue
- Closes #

[//]: # (in the issue a reference will be added to this pr)
- Related Issue: #2266 #440 

## Proposed Changes
[//]: # (Add a detailed description of the changes here)
Description:
Adds a production connect and reconnect credential management interface to the Channex Certification diagnostics panel, replacing the need for manual API key injection via DevTools.

- **API Client Implementation:** Added `connectChannex({ userId, apiKey, displayName })` in `frontend/web/src/features/hostdashboard/hostintegrations/channexApi.js` targeting `POST /integrations/channex/connect`. Omits blank display names so backend defaults apply cleanly.
- **Diagnostics Panel UI:** Added a "Channex credentials" card to the top of the Setup & Connection tab in `ChannexDiagnosticsPanel.jsx` with:
  - Masked API key input with a Show/Hide toggle.
  - Optional Display Name field.
  - Dynamic action button labeled **Connect** or **Reconnect** based on current status.
  - Integrated loading and error states using the existing `runRequest`, `SectionCard`, and `ErrorCallout` patterns.
- **Provider Rejection Handling:** Addressed the edge case where the backend returns `HTTP 200` with `{ connected: false, validationState: "VALIDATION_FAILED" }` on rejected keys. The form reset is guarded by `data?.connected === true` so invalid keys remain visible for typo correction, while `refreshStatus()` triggers to display the updated validation state.
- **Layout fix (bundled):** Manual browser verification surfaced a pre-existing CSS Grid stretch bug — a card shorter than its row-mate (or than the overall grid's page-driven height) stretched internally, opening a visible gap between its header and its content. Fixed with a small, reusable `channex-diagnostics-card--align-top` utility, applied to both the new credentials card and the pre-existing "Current mapping readiness" card. This is a genuine pre-existing bug fix, not new behavior — called out separately so it isn't mistaken for scope creep.
- **Test Coverage:** 10 new tests across `channexApi.test.js` (new file) and `ChannexDiagnosticsPanel.test.js`, covering payload structures, network error wrapping, validation rejection, form reset behaviors, mask toggling, and button labeling. The layout fix itself is CSS-only and was verified visually in a running dev server rather than via Jest, since jsdom does not compute layout.


## Change Type
- [x] Bug fix
- [x] New feature
- [ ] Optimization
- [ ] Documentation update

## Change Size
[//]: # (Indicate the size of this change.)
[//]: # (Clarify under Refactoring which parts are moved/unchanged code, so the reviewer doesn’t review old logic.)
- [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
- [x] Big change (+-max 1000)
- [ ] Small change (less than 300)

## Refactoring
Refactors following files, but didn't change the code. This is to avoid reviewing old logic.
- src/features/example.xx

## Evidence
- [x ] Screenshots or screen recording added for UI changes
- [ ] Before/after images added when relevant
- [x ] Images clearly show the implemented change
- [x] Image quality is readable (no cropped or blurry evidence)

## Responsiveness
- [ ] UI checked on mobile
- [ ] UI checked on tablet
- [x ] UI checked on desktop
- [x ] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages
- [ ] NPM Packages installed
- [ ] NPM Packages removed
- [ ] NPM Packages updated
- [ ] Checked for vulnerabilities using "npm audit"

## Checklist
[//]: # (All boxes must be checked before merging.)
- [x] Pull request has at least 2 reviewers assigned
- [x] PR title is descriptive and includes issue number
- [x ] Conventions
  - [x ] No config files have been added (Amplify config, cache files)
  - [x ] No hardcoded sensitive data (e.g., API-keys/passwords)
  - [x ] No global styling (see [#1691](https://github.com/domits1/Domits/issues/1691))
  - [x ] No `console.log` left in code
  - [x ] No commented-out code remains
- [x ] Testing
  - [x ] Code tested locally
  - [x ] Jest tests are included
  - [x ] Jest tests are passing

## Keep or delete my branch
- [x] Delete my branch after merge
- [ ] Keep my branch  
)## Close or Relate the Issue
[//]: # (Only if this should close the issue)
- Closes #

[//]: # (in the issue a reference will be added to this pr)
- Related Issue: #2266 #440 

## Proposed Changes
[//]: # (Add a detailed description of the changes here)
Description:
Adds a production connect and reconnect credential management interface to the Channex Certification diagnostics panel, replacing the need for manual API key injection via DevTools.

- **API Client Implementation:** Added `connectChannex({ userId, apiKey, displayName })` in `frontend/web/src/features/hostdashboard/hostintegrations/channexApi.js` targeting `POST /integrations/channex/connect`. Omit blank display names so backend defaults apply cleanly.
- **Diagnostics Panel UI:** Added a "Channex credentials" card to the top of the Setup & Connection tab in `ChannexDiagnosticsPanel.jsx` with:
  - Masked API key input with a Show/Hide toggle.
  - Optional Display Name field.
  - Dynamic action button labeled **Connect** or **Reconnect** based on current status.
  - Integrated loading and error states using the existing `runRequest`, `SectionCard`, and `ErrorCallout` patterns.
- **Provider Rejection Handling:** Addressed the edge case where the backend returns `HTTP 200` with `{ connected: false, validationState: "VALIDATION_FAILED" }` on rejected keys. The form reset is guarded by `data?.connected === true` so invalid keys remain visible for typo correction, while `refreshStatus()` triggers to display the updated validation state.
- **Test Coverage:** Added 10 new tests across `channexApi.test.js` (new file) and `ChannexDiagnosticsPanel.test.js`, covering payload structures, network error wrapping, validation rejection, form reset behaviors, mask toggling, and button labeling.
- **Diff Hygiene:** Retained a clean, additive diff (+305 insertions, 0 deletions) without bundling unformatted legacy lines from the parent component.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Optimization
- [ ] Documentation update

## Change Size
[//]: # (Indicate the size of this change.)
[//]: # (Clarify under Refactoring which parts are moved/unchanged code, so the reviewer doesn’t review old logic.)
- [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
- [x] Big change (+-max 1000)
- [ ] Small change (less than 300)

## Refactoring
Refactors following files, but didn't change the code. This is to avoid reviewing old logic.
- src/features/example.xx

## Evidence
- [ ] Screenshots or screen recording added for UI changes
- [ ] Before/after images added when relevant
- [ ] Images clearly show the implemented change
- [ ] Image quality is readable (no cropped or blurry evidence)

## Responsiveness
- [ ] UI checked on mobile
- [ ] UI checked on tablet
- [x ] UI checked on desktop
- [x ] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages
- [ ] NPM Packages installed
- [ ] NPM Packages removed
- [ ] NPM Packages updated
- [x ] Checked for vulnerabilities using "npm audit"

## Checklist
[//]: # (All boxes must be checked before merging.)
- [x] Pull request has at least 2 reviewers assigned
- [x] PR title is descriptive and includes issue number
- [x ] Conventions
  - [x ] No config files have been added (Amplify config, cache files)
  - [x ] No hardcoded sensitive data (e.g., API-keys/passwords)
  - [x ] No global styling (see [#1691](https://github.com/domits1/Domits/issues/1691))
  - [x ] No `console.log` left in code
  - [x ] No commented-out code remains
- [x ] Testing
  - [x ] Code tested locally
  - [x ] Jest tests are included
  - [x ] Jest tests are passing

## Keep or delete my branch
- [x] Delete my branch after merge
- [ ] Keep my branch  
