### PR TITLE
feat(inbox): add message delivery status indicators (#2291)

### DIFF
--- a/frontend/web/src/components/messages/ChatMessage.js
+++ b/frontend/web/src/components/messages/ChatMessage.js
@@ -11,8 +11,15 @@ import {
   mdiRobotOutline,
 } from "@mdi/js";
 
+const DELIVERY_STATUS_INDICATORS = {
+  pending: "…",
+  sent: "✓",
+  delivered: "✓✓",
+  failed: "!",
+};
+
 const ChatMessage = ({ message, userId, contactName, contactImage }) => {
-  const { userId: senderId, text, createdAt, isSent, fileUrls, isAutomated, messageType } = message;
+  const { userId: senderId, text, createdAt, isSent, fileUrls, isAutomated, messageType, deliveryStatus } = message;
 
   const formatTime = (v) => {
     const d = new Date(v);
@@ -114,7 +121,9 @@ const ChatMessage = ({ message, userId, contactName, contactImage }) => {
 
         <div className="message-footer">
           <span>{formatTime(createdAt)}</span>
-          {isOutgoing ? <span className="message-status">✓✓</span> : null}
+          {isOutgoing && DELIVERY_STATUS_INDICATORS[deliveryStatus] ? (
+            <span className="message-status">{DELIVERY_STATUS_INDICATORS[deliveryStatus]}</span>
+          ) : null}
         </div>
       </div>
 

--- a/frontend/web/src/components/messages/ChatMessage.test.js
+++ b/frontend/web/src/components/messages/ChatMessage.test.js
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import ChatMessage from "./ChatMessage";
+
+jest.mock("./domits-logo.jpg", () => "domits-logo.jpg");
+
+const baseMessage = {
+  userId: "host-1",
+  text: "Hello",
+  createdAt: "2026-01-01T10:00:00.000Z",
+};
+
+describe("ChatMessage delivery status indicator", () => {
+  test.each([
+    ["pending", "…"],
+    ["sent", "✓"],
+    ["delivered", "✓✓"],
+    ["failed", "!"],
+  ])("renders %s deliveryStatus correctly", (deliveryStatus, expectedText) => {
+    render(<ChatMessage message={{ ...baseMessage, deliveryStatus }} userId="host-1" />);
+    expect(screen.getByText(expectedText, { selector: ".message-status", exact: true })).toBeInTheDocument();
+  });
+
+  test.each([undefined, "unknown"])(
+    "renders no status indicator for missing or unsupported deliveryStatus: %s",
+    (deliveryStatus) => {
+      render(<ChatMessage message={{ ...baseMessage, deliveryStatus }} userId="host-1" />);
+      expect(screen.queryByText(() => true, { selector: ".message-status" })).not.toBeInTheDocument();
+    }
+  );
+
+  test("does not render a status indicator for incoming messages", () => {
+    render(
+      <ChatMessage message={{ ...baseMessage, userId: "guest-1", deliveryStatus: "delivered" }} userId="host-1" />
+    );
+    expect(screen.queryByText(() => true, { selector: ".message-status" })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/web/src/components/messages/ChatScreen.jsx
+++ b/frontend/web/src/components/messages/ChatScreen.jsx
@@ -206,6 +206,7 @@ const ChatScreen = ({
         threadId: saved?.threadId || optimistic.threadId,
         bookingId: saved?.bookingId || optimistic.bookingId,
         platform: saved?.platform || resolvedPlatform,
+        deliveryStatus: saved?.deliveryStatus,
       };
 
       setLocalMessages((prev) => prev.map((m) => (m.id === optimisticId ? finalMsg : m)));

--- a/frontend/web/src/components/messages/ChatScreen.test.js
+++ b/frontend/web/src/components/messages/ChatScreen.test.js
@@ -99,4 +99,30 @@ describe("ChatScreen reservation messaging", () => {
       );
     });
   });
+
+  test("preserves the deliveryStatus returned by the send response", async () => {
+    mockSendMessage.mockResolvedValue({
+      success: true,
+      saved: { id: "message-1", threadId: "thread-1", deliveryStatus: "sent" },
+    });
+
+    render(
+      <ChatScreen
+        userId="guest-1"
+        contactId="host-1"
+        contactName="Reservation Host"
+        propertyId="property-1"
+        bookingId="booking-1"
+        dashboardType="guest"
+        capabilities={getMessageCapabilities("guest")}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Type a message"), { target: { value: "Hello host" } });
+    fireEvent.click(screen.getByTitle("Send"));
+
+    await waitFor(() => {
+      expect(screen.getByText("✓", { selector: ".message-status", exact: true })).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Close or Relate the Issue
- Closes #

- Related Issue: #2291

## Proposed Changes

Description:

Adds message delivery status indicators to the Unified Inbox.

- Shows `…` for pending messages.
- Shows `✓` for sent messages.
- Shows `✓✓` for delivered messages.
- Shows `!` for failed messages.
- Incoming messages do not show outgoing delivery indicators.
- Missing or unknown delivery statuses do not show a fake status.
- Preserves `deliveryStatus` from the send response so the correct status is shown immediately.
- Adds Jest coverage for the new delivery-status behavior.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Optimization
- [ ] Documentation update

## Change Size
- [ ] Huge change (1000+ lines, mostly refactored/moved code. Clarify in [Refactoring](#Refactoring))
- [ ] Big change (+-max 1000)
- [x] Small change (less than 300)

## Refactoring

N/A

## Evidence
- [ ] Screenshots or screen recording added for UI changes
- [ ] Before/after images added when relevant
- [ ] Images clearly show the implemented change
- [ ] Image quality is readable (no cropped or blurry evidence)

## Responsiveness
- [ ] UI checked on mobile
- [ ] UI checked on tablet
- [ ] UI checked on desktop
- [ ] No broken layout, overflow, or hidden content on tested screen sizes

## Npm Packages
- [ ] NPM Packages installed
- [ ] NPM Packages removed
- [ ] NPM Packages updated
- [ ] Checked for vulnerabilities using "npm audit"

## Checklist
- [ ] Pull request has at least 2 reviewers assigned
- [x] PR title is descriptive and includes issue number
- [x] Conventions
  - [x] No config files have been added (Amplify config, cache files)
  - [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  - [x] No global styling (see [#1691](https://github.com/domits1/Domits/issues/1691))
  - [x] No `console.log` left in code
  - [x] No commented-out code remains
- [x] Testing
  - [x] Code tested locally
  - [x] Jest tests are included
  - [x] Jest tests are passing

## Keep or delete my branch
- [x] Delete my branch after merge
- [ ] Keep my branch