### PR TITLE
fix: validate host-team invite role against allow-list, excluding Hos…

### DIFF
--- a/backend/functions/host-team/business/service/service.js
+++ b/backend/functions/host-team/business/service/service.js
@@ -3,20 +3,31 @@ import { BadRequestException } from "../../util/exception/badRequestException.js
 import { ForbiddenException } from "../../util/exception/forbiddenException.js";
 import { NotFoundException } from "../../util/exception/notFoundException.js";
 import { sendTeamInviteEmail } from "../emailService.js";
+import { ALLOWED_TEAM_MEMBER_ROLES, DEFAULT_TEAM_MEMBER_ROLE } from "../../util/roles.js";
 import { CognitoIdentityProviderClient, AdminUpdateUserAttributesCommand, AdminGetUserCommand } from "@aws-sdk/client-cognito-identity-provider";
 import Database from "database";
 
 const cognitoClient = new CognitoIdentityProviderClient({ region: "eu-north-1" });
 const USER_POOL_ID = "eu-north-1_mPxNhvSFX";
 
+export const normalizeRole = (role) => {
+    if (!role) return DEFAULT_TEAM_MEMBER_ROLE;
+    const normalized = String(role).trim();
+    if (!ALLOWED_TEAM_MEMBER_ROLES.includes(normalized)) {
+        throw new BadRequestException(`role must be one of: ${ALLOWED_TEAM_MEMBER_ROLES.join(", ")}.`);
+    }
+    return normalized;
+};
+
 export class Service {
-    constructor() {
-        this.repository = new Repository();
+    constructor({ repository = new Repository() } = {}) {
+        this.repository = repository;
     }
 
     async inviteMember(hostId, hostEmail, email, role) {
         if (!email) throw new BadRequestException("Email is required.");
 
+        const normalizedRole = normalizeRole(role);
         const dataSource = await Database.getInstance();
 
         const existing = await this.repository.findByHostAndEmail(dataSource, hostId, email);
@@ -27,7 +38,7 @@ export class Service {
         const record = {
             host_id: hostId,
             member_email: email,
-            role: role || "Property Operations Manager",
+            role: normalizedRole,
             status: "pending",
             invited_at: Date.now(),
         };

--- a/backend/functions/host-team/util/roles.js
+++ b/backend/functions/host-team/util/roles.js
@@ -1,0 +1,16 @@
+export const DEFAULT_TEAM_MEMBER_ROLE = "Property Operations Manager";
+
+// "Host" and "Admin" must never be settable through the team-invite endpoint:
+// acceptInvite() writes this value straight into the invitee's Cognito
+// custom:group attribute, so allowing either here would let a host grant
+// account-owner-level group membership to someone else's account.
+export const ALLOWED_TEAM_MEMBER_ROLES = Object.freeze([
+  "General Manager",
+  "Reservation Manager",
+  "Guest Experience Manager",
+  "Financial Manager",
+  "Distribution Manager",
+  "Revenue Manager",
+  "Sales Manager",
+  "Property Operations Manager",
+]);

--- a/backend/test/host-team/service.test.js
+++ b/backend/test/host-team/service.test.js
@@ -1,0 +1,71 @@
+jest.mock("database", () => ({
+  __esModule: true,
+  default: { getInstance: jest.fn().mockResolvedValue({}) },
+}));
+
+jest.mock("../../functions/host-team/business/emailService.js", () => ({
+  __esModule: true,
+  sendTeamInviteEmail: jest.fn().mockResolvedValue(undefined),
+}));
+
+const { Service, normalizeRole } = require("../../functions/host-team/business/service/service.js");
+const { ALLOWED_TEAM_MEMBER_ROLES, DEFAULT_TEAM_MEMBER_ROLE } = require("../../functions/host-team/util/roles.js");
+
+const createRepository = () => ({
+  findByHostAndEmail: jest.fn(async () => null),
+  create: jest.fn(async (dataSource, record) => ({ id: "member-1", invite_token: "token-1", ...record })),
+});
+
+const createService = () => {
+  const repository = createRepository();
+  return { repository, service: new Service({ repository }) };
+};
+
+describe("normalizeRole", () => {
+  test("defaults to Property Operations Manager when role is falsy", () => {
+    expect(normalizeRole(undefined)).toBe(DEFAULT_TEAM_MEMBER_ROLE);
+    expect(normalizeRole("")).toBe(DEFAULT_TEAM_MEMBER_ROLE);
+  });
+
+  test("accepts every role in the allow-list", () => {
+    for (const role of ALLOWED_TEAM_MEMBER_ROLES) {
+      expect(normalizeRole(role)).toBe(role);
+    }
+  });
+
+  test.each(["Host", "Admin", "Traveler", "Superhost"])("rejects %s", (role) => {
+    expect(() => normalizeRole(role)).toThrow(/role must be one of/);
+  });
+});
+
+describe("Service.inviteMember", () => {
+  test("accepts every role in the allow-list", async () => {
+    for (const role of ALLOWED_TEAM_MEMBER_ROLES) {
+      const { repository, service } = createService();
+      const created = await service.inviteMember("host-1", "host@example.com", "member@example.com", role);
+      expect(created.role).toBe(role);
+      expect(repository.create).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ role }));
+    }
+  });
+
+  test("defaults to Property Operations Manager when role is omitted", async () => {
+    const { repository, service } = createService();
+    const created = await service.inviteMember("host-1", "host@example.com", "member@example.com", undefined);
+    expect(created.role).toBe(DEFAULT_TEAM_MEMBER_ROLE);
+    expect(repository.create).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ role: DEFAULT_TEAM_MEMBER_ROLE })
+    );
+  });
+
+  test.each(["Host", "Admin", "Traveler", "Superhost"])(
+    "rejects invite with role %s and never persists it",
+    async (role) => {
+      const { repository, service } = createService();
+      await expect(
+        service.inviteMember("host-1", "host@example.com", "member@example.com", role)
+      ).rejects.toMatchObject({ statusCode: 400 });
+      expect(repository.create).not.toHaveBeenCalled();
+    }
+  );
+});


### PR DESCRIPTION
## Close or Relate the Issue
- Related Issue: #2390

## Proposed Changes
Description:
Added server-side validation to `host-team`'s `inviteMember` so the `role` field must match a known allow-list before being persisted. Previously any string was accepted with no validation, and that value flows directly into the invitee's Cognito `custom:group` attribute when they accept the invite. This meant a direct API call with `role: "Host"` (bypassing the UI, which only ever sends `"Property Operations Manager"`) could grant a stranger Host-group privileges through another user's invite.

Changes:
- New `backend/functions/host-team/util/roles.js` — frozen `ALLOWED_TEAM_MEMBER_ROLES` allow-list (8 roles) and `DEFAULT_TEAM_MEMBER_ROLE`. `Host`, `Admin`, and `Traveler` are intentionally excluded.
- `backend/functions/host-team/business/service/service.js` — added `normalizeRole()`, following the same pattern as `communication-preferences`'s `normalizePersona`: defaults to `Property Operations Manager` when falsy, throws `BadRequestException` when the value isn't in the allow-list. Wired into `inviteMember`. Changed the constructor to `constructor({ repository = new Repository() } = {})` for dependency injection (needed for the new tests; the only existing caller, `controller.js`, is unaffected since the param is optional).
- New `backend/test/host-team/service.test.js` — 13 tests covering `normalizeRole` (defaults, all valid roles accepted, `Host`/`Admin`/`Traveler`/unknown strings rejected) and `Service.inviteMember` end-to-end for the same cases, asserting `repository.create` is never called on rejection.

This is a backend-only fix and intentionally scoped separately from the frontend invite-dropdown work (also under #2390), which is pending a product decision on whether "Host" should ever be invitable and will be a separate PR.

## Change Type
- [x] Bug fix

## Change Size
- [x] Small change (less than 300)

## Refactoring
N/A — no files changed without logic changes.

## Evidence
- [ ] Screenshots or screen recording added for UI changes
- [ ] Before/after images added when relevant
- [ ] Images clearly show the implemented change
- [ ] Image quality is readable (no cropped or blurry evidence)

N/A — backend-only change, no UI affected.

## Responsiveness
- [ ] UI checked on mobile
- [ ] UI checked on tablet
- [ ] UI checked on desktop
- [ ] No broken layout, overflow, or hidden content on tested screen sizes

N/A — backend-only change.

## Npm Packages
- [ ] NPM Packages installed
- [ ] NPM Packages removed
- [ ] NPM Packages updated
- [ ] Checked for vulnerabilities using "npm audit"

N/A — no package changes.

## Checklist
- [ ] Pull request has at least 2 reviewers assigned
- [x] PR title is descriptive and includes issue number
- [x] Conventions
  - [x] No config files have been added (Amplify config, cache files)
  - [x] No hardcoded sensitive data (e.g., API-keys/passwords)
  - [x] No global styling (see [#1691](https://github.com/domits1/Domits/issues/1691))
  - [x] No `console.log` left in code
  - [x] No commented-out code remains
- [x] Testing
  - [x] Code tested locally
  - [x] Jest tests are included
  - [x] Jest tests are passing

## Keep or delete my branch
- [x] Delete my branch after merge
- [ ] Keep my branch